### PR TITLE
feat(explorer): build accessible public catalogue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: assurance-evidence
-          path: artifacts/
+          path: |
+            artifacts/
+            apps/public-explorer/test-results/
           if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 .ruff_cache/
 artifacts/
 coverage/
+apps/public-explorer/public/catalogue/
+apps/public-explorer/test-results/
+apps/public-explorer/playwright-report/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,12 +10,14 @@ reproducible GitHub Pages deployment.
 
 ## Active workstream
 
-`DISC-101 — Generate the canonical OKF bundle`
+`DISC-102 — Build the accessible public Explorer`
 
-- lock the approved research and HMLR metadata inputs by SHA-256;
-- generate deterministic OKF Markdown, JSON and JSON-LD projections;
-- fail closed on unknown rights, unsafe content and unresolved references;
-- prove source, schema, checksum and byte-for-byte build integrity.
+- build a static search, facet and governed data-card journey from the canonical OKF
+  bundle;
+- provide complete graph, timeline and schematic-map non-visual alternatives;
+- preserve direct URL state and browser history without requiring WebMCP;
+- prove keyboard, touch, zoom, forced-colour, reduced-motion and hostile-record
+  behaviour in real-browser assurance.
 
 ## Completed
 
@@ -32,13 +34,17 @@ reproducible GitHub Pages deployment.
 - `CTRL-002` merged through protected `main` with passing assurance;
 - `main` protected by a no-bypass, squash-only pull request ruleset;
 - `v0.1.0` delivery issues 3 to 7 created and assigned;
+- `DISC-101` merged at `4ff9cc79946b1977a2022428336687a3dedb04b3` with
+  passing main assurance and CodeQL;
+- canonical OKF generation now produces 18 source-locked public metadata records in
+  equivalent Markdown, JSON and JSON-LD projections;
 - full local `pnpm run check` passed on 19 August 2026.
 
 ## Next
 
-1. Merge `DISC-101` after local and remote assurance pass.
-2. Start `DISC-102`, the hardened accessible static Explorer.
-3. Add the reviewed public source families through `DISC-103` and `DISC-104`.
+1. Merge `DISC-102` after component, browser, security and accessibility assurance.
+2. Add the reviewed public source families through `DISC-103`.
+3. Publish the immutable static product through `DISC-104` after the final gate.
 
 ## Current blockers
 
@@ -49,10 +55,15 @@ reproducible GitHub Pages deployment.
 
 ## Latest evidence
 
-- local assurance: passing for the `DISC-101` candidate, including 18 generated OKF
-  records, 22 repository tests and 2 execution-boundary tests, 19 August 2026;
-- remote assurance: passing on protected `main`; the active branch is awaiting its
-  pull request;
+- canonical OKF content: merged and passing on protected `main` at `4ff9cc7`;
+- remote assurance and CodeQL: passing on `main`, 19 August 2026;
+- active Explorer branch: the complete `pnpm run check` gate passes, including
+  16 build-policy tests, 36 unit and component tests, 18 browser journeys and
+  production integrity checks;
+- bounded security diff review: all changed runtime, interface and build-assurance
+  files covered; the confirmed Low CSP/origin assurance gap, exact HTML-attribute
+  parsing, fresh preview-server enforcement, and defensive symlink and lock-strict
+  hardening are remediated with passing regressions;
 - public repository: verified with personal `noreply` commit identity;
 - deployed product: none;
 - latest supported release: none.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ governance, candidate contracts, synthetic fixtures, architecture sources and an
 assurance harness. The first functional release will add the accessible public
 discovery product described in the [roadmap](docs/implementation/ROADMAP.md).
 
-There is not yet a deployed Explorer or MCP service. Live status is in
+The Explorer is implemented as a local static build but is not yet deployed; there
+is no MCP service. Live status is in
 [`PROGRESS.md`](PROGRESS.md); current authority and boundaries are in
 [`CONTEXT.md`](CONTEXT.md); notable changes are in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -59,15 +60,17 @@ pnpm run check
 ```
 
 The check builds and type-checks the TypeScript boundary, runs TypeScript and Python
-unit tests, reproducibly builds and validates the public OKF candidate, validates
-other schemas and fixtures, checks local links, performs a baseline secret scan,
-renders diagrams and creates a CycloneDX SBOM in `artifacts/`.
+unit tests, reproducibly builds and validates the public OKF candidate and Explorer,
+runs its real-browser accessibility and security journeys, validates other schemas
+and fixtures, checks local links, performs a baseline secret scan, renders diagrams
+and creates a CycloneDX SBOM in `artifacts/`.
 The foundation baseline and its explicit limits are preserved in the
 [`Stage 0 verification record`](docs/operations/STAGE_0_VERIFICATION.md); each OKF
 build emits its own ignored manifest, checksums and deterministic receipt.
 
 ## Repository map
 
+- `apps/public-explorer/` — static accessible catalogue Explorer
 - `apps/mcp-gateway/` — TypeScript gateway, currently a fail-closed scaffold
 - `services/geo-execution/` — deterministic Python execution boundary
 - `schemas/` — candidate contracts promoted from the research pack

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,8 @@ GIS AI GO is a public open-source project and has no supported production releas
 yet.
 The current gateway and execution service remain fail-closed scaffolds. Do not
 connect unreviewed code to provider credentials, protected data or public listeners.
+The public Explorer is a static metadata-only build; it is not a provider client or
+property-information service.
 
 ## Reporting
 
@@ -22,6 +24,13 @@ defects may use the public bug template.
 - application dependencies, the WebAssembly diagram renderer and GitHub Actions are
   lockfile or commit pinned;
 - schema, link, secret and boundary checks run in the assurance command;
+- the Explorer verifies its source inventory and checksums before build, ships no
+  production JavaScript dependency, renders catalogue values as text, allowlists
+  navigation, rejects symlinked or unallowlisted build inputs and outputs, requires
+  its exact restrictive Content Security Policy and makes no cross-origin runtime
+  request;
+- browser assurance covers hostile URL state, exact-origin requests, console errors,
+  keyboard operation and machine-readable download integrity;
 - GitHub secret scanning, push protection, Dependabot security updates and CodeQL
   default setup are enabled for the public repository;
 - no security claim is made for later identity, policy or hosting designs.

--- a/apps/public-explorer/README.md
+++ b/apps/public-explorer/README.md
@@ -1,6 +1,41 @@
-# Public Explorer boundary
+# Public Explorer
 
-No Explorer is implemented in Stage 0. The research viewer is evidence only and must
-not be deployed directly. Before promotion, its URL handling needs an HTTPS/relative
-scheme allowlist, a strict Content Security Policy, reproducible generation and WCAG
-2.2 AA acceptance.
+The Explorer is a static, progressively enhanced view of the generated public OKF
+bundle. It makes no provider request and needs no account, credential, MCP host or
+WebMCP implementation.
+
+Build from the repository root so the checksum-verified catalogue is generated and
+copied into the static application:
+
+```bash
+pnpm run build:explorer
+```
+
+Generated catalogue files and browser reports are ignored. The eventual GitHub Pages
+workflow publishes only `dist/`, never the repository root or immutable research
+viewer. Deployment remains outside DISC-102.
+
+Before Vite runs, the build rejects symlinked or special-file public and distribution
+trees and requires the exact checksum-derived public inventory. The finished
+distribution must contain only referenced assets and the byte-identical catalogue,
+and its Content Security Policy must match the reviewed directive set exactly.
+
+## Runtime and URL boundary
+
+The application has no production runtime dependency and makes only same-origin
+requests for its static assets and verified catalogue. It does not use cookies,
+browser storage, analytics, map tiles, provider APIs or WebMCP.
+
+Search and selected facets use the query string. The selected view uses `view`, and
+the source-native record identifier uses `#record=…`. Supported facets are `type`,
+`authority`, `access`, `rights`, `freshness` and `tag`; unknown or oversized state is
+discarded with a visible warning. The graph contains only explicit `sourceRefs`, and
+the coverage schematic contains no real geometry or legal boundary.
+
+Run the focused checks with:
+
+```bash
+pnpm --filter @gis-ai-go/public-explorer run typecheck
+pnpm --filter @gis-ai-go/public-explorer run test:unit
+pnpm run test:browser
+```

--- a/apps/public-explorer/index.html
+++ b/apps/public-explorer/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html class="no-js" lang="en-GB">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="no-referrer">
+    <meta name="color-scheme" content="light">
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; media-src 'none'; object-src 'none'; frame-src 'none'; worker-src 'none'; manifest-src 'self'; base-uri 'none'; form-action 'none'"
+    >
+    <title>GIS AI GO public Explorer</title>
+    <meta
+      name="description"
+      content="Accessible discovery of governed public geospatial catalogue metadata."
+    >
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml">
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <header class="site-header">
+      <div class="page-width">
+        <p class="product-name">GIS AI GO</p>
+        <p class="product-description">
+          Governed geospatial knowledge and action for people, systems and AI agents
+        </p>
+        <p class="boundary-label">Public metadata candidate — no property records or geometry</p>
+      </div>
+    </header>
+    <main id="main-content" class="page-width" tabindex="-1">
+      <div id="explorer-root" aria-busy="true">
+        <p role="status">Loading the public catalogue…</p>
+      </div>
+      <noscript>
+        <section aria-labelledby="javascript-free-heading">
+          <h1 id="javascript-free-heading">INSPIRE polygon: indicative or legal boundary?</h1>
+          <p>
+            <strong>Indicative.</strong> The dataset describes polygons showing the
+            indicative position and extent of registered freehold property.
+            <span>Polygons are indicative and do not establish the exact legal extent of a title.</span>
+          </p>
+          <p>
+            This Explorer contains metadata only. It contains no property record,
+            address or geometry, is not legal advice and must not be used to decide
+            ownership, title extent or a boundary dispute.
+          </p>
+          <p>
+            Interactive search and views need JavaScript. The governed catalogue remains
+            available as <a href="./catalogue/okf-bundle.json">Download JSON</a> and
+            <a href="./catalogue/okf-bundle.jsonld">Download JSON-LD</a>, with its
+            <a href="./catalogue/CHECKSUMS.sha256">Download checksums</a> ledger.
+          </p>
+        </section>
+      </noscript>
+    </main>
+    <footer class="site-footer">
+      <div class="page-width">
+        <p>
+          GIS AI GO is authoritative only for this normalised publication. External
+          publishers remain authoritative for their sources.
+        </p>
+      </div>
+    </footer>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/public-explorer/package.json
+++ b/apps/public-explorer/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@gis-ai-go/public-explorer",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Accessible static public catalogue Explorer for GIS AI GO",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "prepare:data": "node scripts/prepare-data.mjs",
+    "check:build-boundary": "node scripts/check-build-boundary.mjs",
+    "build": "pnpm run prepare:data && pnpm run check:build-boundary && vite build && pnpm run check:dist",
+    "check:dist": "node scripts/check-dist.mjs",
+    "preview": "vite preview",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "test:build": "node --test test/build/*.test.mjs",
+    "test:unit": "pnpm run test:build && vitest run",
+    "test:browser": "playwright test"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.13.0",
+    "@playwright/test": "1.62.1",
+    "jsdom": "30.0.1",
+    "vite": "8.2.1",
+    "vitest": "4.1.11"
+  }
+}

--- a/apps/public-explorer/playwright.config.ts
+++ b/apps/public-explorer/playwright.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
     colorScheme: "light",
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
-    video: "retain-on-failure",
+    // Runner Chrome does not need Playwright's separately downloaded FFmpeg binary.
+    video: "off",
   },
   webServer: {
     // Exercise Vite's relative-base output at the origin root.

--- a/apps/public-explorer/playwright.config.ts
+++ b/apps/public-explorer/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+
+const port = Number(process.env.EXPLORER_PREVIEW_PORT ?? "4173");
+const origin = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./test/browser",
+  outputDir: "./test-results",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  ...(process.env.CI ? { workers: 1 } : {}),
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: `${origin}/`,
+    channel: "chrome",
+    locale: "en-GB",
+    timezoneId: "Europe/London",
+    colorScheme: "light",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    // Exercise Vite's relative-base output at the origin root.
+    command: `pnpm exec vite preview --host 127.0.0.1 --port ${port} --strictPort`,
+    reuseExistingServer: false,
+    timeout: 60_000,
+    url: `${origin}/`,
+  },
+});

--- a/apps/public-explorer/public/favicon.svg
+++ b/apps/public-explorer/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#073b4c"/>
+  <path d="M15 18h34v8H25v7h18v8H25v13H15z" fill="#f5c242"/>
+  <circle cx="47" cy="45" r="8" fill="#27a69a"/>
+</svg>

--- a/apps/public-explorer/scripts/build-boundary.mjs
+++ b/apps/public-explorer/scripts/build-boundary.mjs
@@ -1,0 +1,172 @@
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+
+export const EXPLORER_GENERATED_MARKER = "gis-ai-go-public-explorer-data.v1\n";
+
+const CHECKSUM_ROW = /^([0-9a-f]{64})  (.+)$/u;
+
+function isMissing(error) {
+  return error && typeof error === "object" && "code" in error && error.code === "ENOENT";
+}
+
+async function optionalMetadata(path) {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (isMissing(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function safeRelativePath(value) {
+  const segments = value.split("/");
+  if (
+    !value ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    value.includes("\0") ||
+    segments.includes("") ||
+    segments.includes(".") ||
+    segments.includes("..")
+  ) {
+    throw new Error(`Unsafe catalogue checksum path: ${value}`);
+  }
+  return value;
+}
+
+/**
+ * Inventory a directory without following symbolic links.
+ *
+ * Only directories and regular files are valid build inputs. This check applies
+ * to the root itself as well as every descendant so Vite cannot dereference a
+ * link while copying its public directory.
+ */
+export async function inventoryRegularTree(
+  root,
+  label,
+  { allowMissing = false } = {},
+) {
+  const rootMetadata = await optionalMetadata(root);
+  if (rootMetadata === null) {
+    if (allowMissing) {
+      return { directories: [], files: [] };
+    }
+    throw new Error(`${label} root is missing: ${root}`);
+  }
+  if (rootMetadata.isSymbolicLink()) {
+    throw new Error(`${label} root must not be a symbolic link: ${root}`);
+  }
+  if (!rootMetadata.isDirectory()) {
+    throw new Error(`${label} root must be a directory: ${root}`);
+  }
+
+  const directories = [];
+  const files = [];
+  async function visit(directory, relative = "") {
+    const names = (await readdir(directory)).sort((left, right) => left.localeCompare(right));
+    for (const name of names) {
+      const child = relative ? `${relative}/${name}` : name;
+      const target = resolve(directory, name);
+      const metadata = await lstat(target);
+      if (metadata.isSymbolicLink()) {
+        throw new Error(`${label} must not contain a symbolic link: ${child}`);
+      }
+      if (metadata.isDirectory()) {
+        directories.push(child);
+        await visit(target, child);
+      } else if (metadata.isFile()) {
+        files.push(child);
+      } else {
+        throw new Error(`${label} must contain regular files and directories only: ${child}`);
+      }
+    }
+  }
+  await visit(root);
+  return { directories, files };
+}
+
+export async function assertSafeBuildRoots({ publicRoot, distRoot }) {
+  const publicTree = await inventoryRegularTree(publicRoot, "Explorer public directory", {
+    allowMissing: true,
+  });
+  const distTree = await inventoryRegularTree(distRoot, "Explorer distribution directory", {
+    allowMissing: true,
+  });
+  return { publicTree, distTree };
+}
+
+export function parseCatalogueChecksumPaths(text) {
+  if (!text.endsWith("\n")) {
+    throw new Error("Catalogue checksums must end with a newline");
+  }
+  const rows = text.slice(0, -1).split("\n");
+  if (rows.length === 0 || rows.some((row) => row.length === 0)) {
+    throw new Error("Catalogue checksums must contain non-empty rows");
+  }
+  const paths = rows.map((row) => {
+    const match = CHECKSUM_ROW.exec(row);
+    if (!match) {
+      throw new Error(`Invalid catalogue checksum row: ${row}`);
+    }
+    return safeRelativePath(match[2]);
+  });
+  if (
+    paths.length !== new Set(paths).size ||
+    paths.join("\n") !== [...paths].sort().join("\n")
+  ) {
+    throw new Error("Catalogue checksum paths must be unique and sorted");
+  }
+  return paths;
+}
+
+/** Require the complete, generated public input and nothing else. */
+export async function assertPreparedPublicInventory({ publicRoot, distRoot }) {
+  const { publicTree } = await assertSafeBuildRoots({ publicRoot, distRoot });
+  const publicMetadata = await optionalMetadata(publicRoot);
+  if (publicMetadata === null) {
+    throw new Error(`Explorer public directory root is missing: ${publicRoot}`);
+  }
+
+  const catalogueRoot = resolve(publicRoot, "catalogue");
+  const markerPath = resolve(catalogueRoot, ".explorer-generated");
+  const checksumPath = resolve(catalogueRoot, "CHECKSUMS.sha256");
+  const marker = await readFile(markerPath, "utf8");
+  if (marker !== EXPLORER_GENERATED_MARKER) {
+    throw new Error("Explorer catalogue marker is invalid");
+  }
+  const checksumPaths = parseCatalogueChecksumPaths(await readFile(checksumPath, "utf8"));
+  const expectedFiles = [
+    "favicon.svg",
+    "catalogue/.explorer-generated",
+    "catalogue/CHECKSUMS.sha256",
+    ...checksumPaths.map((path) => {
+      const target = resolve(catalogueRoot, path);
+      if (!target.startsWith(`${catalogueRoot}${sep}`)) {
+        throw new Error(`Catalogue checksum path escapes its root: ${path}`);
+      }
+      return `catalogue/${path}`;
+    }),
+  ].sort();
+  const expectedDirectories = [...new Set(
+    expectedFiles.flatMap((path) => {
+      const segments = path.split("/");
+      return segments.slice(0, -1).map((_, index) => segments.slice(0, index + 1).join("/"));
+    }),
+  )].sort();
+  const actualFiles = [...publicTree.files].sort();
+  const actualDirectories = [...publicTree.directories].sort();
+  if (
+    actualFiles.join("\n") !== expectedFiles.join("\n") ||
+    actualDirectories.join("\n") !== expectedDirectories.join("\n")
+  ) {
+    throw new Error(
+      `Explorer public inventory differs from the generated allowlist; ` +
+        `expected files=${expectedFiles.join(",")}; actual files=${actualFiles.join(",")}; ` +
+        `expected directories=${expectedDirectories.join(",")}; ` +
+        `actual directories=${actualDirectories.join(",")}`,
+    );
+  }
+  return actualFiles;
+}

--- a/apps/public-explorer/scripts/check-build-boundary.mjs
+++ b/apps/public-explorer/scripts/check-build-boundary.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertPreparedPublicInventory } from "./build-boundary.mjs";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const files = await assertPreparedPublicInventory({
+  publicRoot: resolve(appRoot, "public"),
+  distRoot: resolve(appRoot, "dist"),
+});
+
+console.log(`Checked ${files.length} allowlisted regular files before the Vite build.`);

--- a/apps/public-explorer/scripts/check-dist.mjs
+++ b/apps/public-explorer/scripts/check-dist.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { dirname, extname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  inspectHtmlDocument,
+  requireExactInventory,
+} from "./dist-policy.mjs";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(appRoot, "../..");
+const distRoot = resolve(appRoot, "dist");
+const catalogueRoot = resolve(distRoot, "catalogue");
+const sourceCatalogueRoot = resolve(repositoryRoot, "artifacts/okf");
+const CHECKSUM_ROW = /^([0-9a-f]{64})  (.+)$/;
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function safeRelativePath(value) {
+  const segments = value.split("/");
+  if (
+    !value ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    value.includes("\0") ||
+    segments.includes("") ||
+    segments.includes(".") ||
+    segments.includes("..")
+  ) {
+    throw new Error(`Unsafe distribution path: ${value}`);
+  }
+  return value;
+}
+
+function containedPath(root, relative) {
+  const target = resolve(root, safeRelativePath(relative));
+  if (!target.startsWith(`${root}${sep}`)) {
+    throw new Error(`Distribution path escapes its root: ${relative}`);
+  }
+  return target;
+}
+
+async function inventory(root, relative = "") {
+  const directory = relative ? containedPath(root, relative) : root;
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const child = relative ? `${relative}/${entry.name}` : entry.name;
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Distribution must not contain a symbolic link: ${child}`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await inventory(root, child)));
+    } else if (entry.isFile()) {
+      files.push(child);
+    } else {
+      throw new Error(`Distribution must contain regular files only: ${child}`);
+    }
+  }
+  return files;
+}
+
+function parseChecksums(text) {
+  if (!text.endsWith("\n")) {
+    throw new Error("Catalogue checksums must end with a newline");
+  }
+  const rows = text.slice(0, -1).split("\n");
+  if (rows.length === 0 || rows.some((row) => row.length === 0)) {
+    throw new Error("Catalogue checksums must contain non-empty rows");
+  }
+  const parsed = rows.map((row) => {
+    const match = CHECKSUM_ROW.exec(row);
+    if (!match) throw new Error(`Invalid catalogue checksum row: ${row}`);
+    return { digest: match[1], path: safeRelativePath(match[2]) };
+  });
+  const paths = parsed.map((row) => row.path);
+  if (
+    paths.length !== new Set(paths).size ||
+    paths.join("\n") !== [...paths].sort().join("\n")
+  ) {
+    throw new Error("Catalogue checksum paths must be unique and sorted");
+  }
+  return parsed;
+}
+
+async function requireRegularFile(path, label) {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`${label} must be a regular file`);
+  }
+}
+
+async function verifyHtml(distFiles) {
+  const indexPath = resolve(distRoot, "index.html");
+  await requireRegularFile(indexPath, "Explorer index");
+  const html = await readFile(indexPath, "utf8");
+  const referenced = [];
+  for (const value of inspectHtmlDocument(html)) {
+    const path = decodeURIComponent(value.split(/[?#]/u, 1)[0]).replace(/^\.\//u, "");
+    if (path) referenced.push(safeRelativePath(path));
+  }
+  for (const path of referenced) {
+    if (!distFiles.includes(path)) {
+      throw new Error(`Built HTML references a missing local file: ${path}`);
+    }
+  }
+  return [...new Set(referenced)].sort();
+}
+
+async function verifyCatalogue() {
+  const sourceChecksumPath = resolve(sourceCatalogueRoot, "CHECKSUMS.sha256");
+  const distChecksumPath = resolve(catalogueRoot, "CHECKSUMS.sha256");
+  await requireRegularFile(sourceChecksumPath, "Canonical OKF checksums");
+  await requireRegularFile(distChecksumPath, "Distributed OKF checksums");
+  const sourceChecksumBytes = await readFile(sourceChecksumPath);
+  const distChecksumBytes = await readFile(distChecksumPath);
+  if (!sourceChecksumBytes.equals(distChecksumBytes)) {
+    throw new Error("Distributed catalogue checksums differ from the canonical OKF build");
+  }
+  const checksums = parseChecksums(distChecksumBytes.toString("utf8"));
+  for (const row of checksums) {
+    const sourcePath = containedPath(sourceCatalogueRoot, row.path);
+    const distPath = containedPath(catalogueRoot, row.path);
+    await requireRegularFile(sourcePath, `Canonical catalogue file ${row.path}`);
+    await requireRegularFile(distPath, `Distributed catalogue file ${row.path}`);
+    const sourceBytes = await readFile(sourcePath);
+    const distBytes = await readFile(distPath);
+    if (sha256(sourceBytes) !== row.digest || sha256(distBytes) !== row.digest) {
+      throw new Error(`Catalogue checksum mismatch for ${row.path}`);
+    }
+    if (!sourceBytes.equals(distBytes)) {
+      throw new Error(`Distributed catalogue file differs byte-for-byte: ${row.path}`);
+    }
+  }
+  const catalogueFiles = (await inventory(catalogueRoot)).sort();
+  const expected = [
+    ".explorer-generated",
+    "CHECKSUMS.sha256",
+    ...checksums.map((row) => row.path),
+  ].sort();
+  if (catalogueFiles.join("\n") !== expected.join("\n")) {
+    throw new Error(
+      `Distributed catalogue inventory differs from checksums; ` +
+        `expected=${expected.join(",")}; actual=${catalogueFiles.join(",")}`,
+    );
+  }
+  const bundle = JSON.parse(
+    await readFile(resolve(catalogueRoot, "okf-bundle.json"), "utf8"),
+  );
+  const jsonld = JSON.parse(
+    await readFile(resolve(catalogueRoot, "okf-bundle.jsonld"), "utf8"),
+  );
+  if (
+    bundle.recordCount !== bundle.records?.length ||
+    bundle.recordCount !== jsonld["@graph"]?.length
+  ) {
+    throw new Error("Distributed JSON and JSON-LD record counts differ");
+  }
+  const identifiers = new Set(bundle.records.map((record) => record.id));
+  const jsonldIdentifiers = new Set(
+    jsonld["@graph"].map((record) => record.identifier),
+  );
+  if (
+    identifiers.size !== jsonldIdentifiers.size ||
+    [...identifiers].some((identifier) => !jsonldIdentifiers.has(identifier))
+  ) {
+    throw new Error("Distributed JSON and JSON-LD identifiers differ");
+  }
+  return expected.map((path) => `catalogue/${path}`);
+}
+
+await requireRegularFile(resolve(distRoot, "favicon.svg"), "Explorer favicon");
+const distFiles = (await inventory(distRoot)).sort();
+for (const path of distFiles) {
+  if (extname(path) === ".map") {
+    throw new Error(`Production distribution must not contain a source map: ${path}`);
+  }
+  if (path.includes("docs/research/") || path.includes("research-pack")) {
+    throw new Error(`Distribution contains historical research material: ${path}`);
+  }
+}
+const referencedFiles = await verifyHtml(distFiles);
+const catalogueFiles = await verifyCatalogue();
+requireExactInventory(distFiles, [
+  "favicon.svg",
+  "index.html",
+  ...referencedFiles,
+  ...catalogueFiles,
+]);
+console.log(
+  `Checked ${distFiles.length} static Explorer files, relative Vite assets, CSP and ` +
+    "byte-exact catalogue checksums.",
+);

--- a/apps/public-explorer/scripts/dist-policy.mjs
+++ b/apps/public-explorer/scripts/dist-policy.mjs
@@ -1,0 +1,119 @@
+import { JSDOM } from "jsdom";
+
+const EXPECTED_CSP_DIRECTIVES = Object.freeze([
+  ["default-src", "'none'"],
+  ["script-src", "'self'"],
+  ["style-src", "'self'"],
+  ["img-src", "'self'"],
+  ["font-src", "'self'"],
+  ["connect-src", "'self'"],
+  ["media-src", "'none'"],
+  ["object-src", "'none'"],
+  ["frame-src", "'none'"],
+  ["worker-src", "'none'"],
+  ["manifest-src", "'self'"],
+  ["base-uri", "'none'"],
+  ["form-action", "'none'"],
+]);
+
+function parseCsp(value) {
+  const directives = new Map();
+  for (const part of value
+    .split(";")
+    .map((item) => item.trim())
+    .filter(Boolean)) {
+    const [rawDirective, ...tokens] = part.split(/\s+/u);
+    const directive = rawDirective.toLowerCase();
+    if (directives.has(directive)) {
+      throw new Error(`Content Security Policy contains duplicate directive: ${directive}`);
+    }
+    directives.set(directive, tokens.join(" "));
+  }
+  return directives;
+}
+
+export function requireExactCsp(value) {
+  const actual = parseCsp(value);
+  const expected = new Map(EXPECTED_CSP_DIRECTIVES);
+  const missing = [...expected.keys()].filter((directive) => !actual.has(directive));
+  const extra = [...actual.keys()].filter((directive) => !expected.has(directive));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new Error(
+      `Content Security Policy directive set differs from the required policy; ` +
+        `missing=${missing.join(",") || "none"}; extra=${extra.join(",") || "none"}`,
+    );
+  }
+  for (const [directive, requiredValue] of expected) {
+    const actualValue = actual.get(directive);
+    if (actualValue !== requiredValue) {
+      throw new Error(
+        `Content Security Policy ${directive} must be exactly: ${requiredValue}; ` +
+          `found: ${actualValue || "<empty>"}`,
+      );
+    }
+  }
+}
+
+export function inspectHtmlDocument(html) {
+  const { document, Node } = new JSDOM(html).window;
+  if (document.documentElement.getAttribute("lang") !== "en-GB") {
+    throw new Error("Explorer index must declare lang=en-GB");
+  }
+  if (!document.head.querySelector('meta[name="viewport"]')) {
+    throw new Error("Explorer index must declare a viewport");
+  }
+
+  const cspElements = [...document.head.querySelectorAll("meta")].filter(
+    (element) =>
+      element.getAttribute("http-equiv")?.toLowerCase() === "content-security-policy",
+  );
+  if (cspElements.length !== 1 || !cspElements[0].getAttribute("content")) {
+    throw new Error("Explorer index must contain exactly one Content Security Policy meta element");
+  }
+  const [cspElement] = cspElements;
+  requireExactCsp(cspElement.getAttribute("content"));
+
+  const firstScript = document.querySelector("script");
+  if (
+    firstScript &&
+    !(cspElement.compareDocumentPosition(firstScript) & Node.DOCUMENT_POSITION_FOLLOWING)
+  ) {
+    throw new Error("Content Security Policy must precede executable scripts");
+  }
+  const inlineScripts = [...document.querySelectorAll("script")].filter(
+    (element) => !element.hasAttribute("src") && element.textContent.trim(),
+  );
+  if (inlineScripts.length > 0) {
+    throw new Error("Explorer index must not contain inline executable scripts");
+  }
+
+  const references = [];
+  for (const element of document.querySelectorAll("[src], [href]")) {
+    for (const name of ["src", "href"]) {
+      const value = element.getAttribute(name);
+      if (!value || value.startsWith("#")) continue;
+      if (/^(?:[a-z][a-z0-9+.-]*:|\/\/|\/)/iu.test(value)) {
+        throw new Error(`Built HTML contains a non-relative asset URL: ${value}`);
+      }
+      references.push(value);
+    }
+  }
+  return references;
+}
+
+export function requireExactInventory(actualFiles, expectedFiles) {
+  const actual = [...new Set(actualFiles)].sort();
+  const expected = [...new Set(expectedFiles)].sort();
+  const missing = expected.filter((path) => !actual.includes(path));
+  const extra = actual.filter((path) => !expected.includes(path));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new Error(
+      `Distribution inventory differs from the required publication; ` +
+        `missing=${missing.join(",") || "none"}; extra=${extra.join(",") || "none"}`,
+    );
+  }
+}
+
+export const REQUIRED_CSP = EXPECTED_CSP_DIRECTIVES
+  .map(([directive, value]) => `${directive} ${value}`)
+  .join("; ");

--- a/apps/public-explorer/scripts/prepare-data.mjs
+++ b/apps/public-explorer/scripts/prepare-data.mjs
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  EXPLORER_GENERATED_MARKER,
+  assertSafeBuildRoots,
+} from "./build-boundary.mjs";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(appRoot, "../..");
+const sourceRoot = resolve(repositoryRoot, "artifacts/okf");
+const publicRoot = resolve(appRoot, "public");
+const destinationRoot = resolve(appRoot, "public/catalogue");
+const distRoot = resolve(appRoot, "dist");
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function safeRelativePath(value) {
+  if (
+    !value ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    value.split("/").includes("..")
+  ) {
+    throw new Error(`Unsafe catalogue path: ${value}`);
+  }
+  return value;
+}
+
+async function inventory(root, relative = "") {
+  const directory = resolve(root, relative);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const child = relative ? `${relative}/${entry.name}` : entry.name;
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Catalogue input must not contain a symbolic link: ${child}`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await inventory(root, child)));
+    } else if (entry.isFile()) {
+      files.push(child);
+    } else {
+      throw new Error(`Catalogue input must contain regular files only: ${child}`);
+    }
+  }
+  return files;
+}
+
+async function verifySource() {
+  const checksumText = await readFile(resolve(sourceRoot, "CHECKSUMS.sha256"), "utf8");
+  const rows = checksumText.trimEnd().split("\n");
+  const locked = [];
+  for (const row of rows) {
+    const match = /^([0-9a-f]{64})  (.+)$/.exec(row);
+    if (!match) {
+      throw new Error(`Invalid checksum row: ${row}`);
+    }
+    const [, expected, rawPath] = match;
+    const relative = safeRelativePath(rawPath);
+    const target = resolve(sourceRoot, relative);
+    if (!target.startsWith(`${sourceRoot}${sep}`)) {
+      throw new Error(`Catalogue path escapes the generated root: ${relative}`);
+    }
+    const metadata = await stat(target);
+    if (!metadata.isFile()) {
+      throw new Error(`Catalogue checksum target is not a file: ${relative}`);
+    }
+    const actual = digest(await readFile(target));
+    if (actual !== expected) {
+      throw new Error(
+        `Catalogue checksum mismatch for ${relative}: expected ${expected}, found ${actual}`,
+      );
+    }
+    locked.push(relative);
+  }
+
+  if (locked.length !== new Set(locked).size || locked.join("\n") !== [...locked].sort().join("\n")) {
+    throw new Error("Catalogue checksum paths must be unique and sorted");
+  }
+
+  const actual = (await inventory(sourceRoot))
+    .filter((path) => path !== ".okf-generated")
+    .sort();
+  const expected = [...locked, "CHECKSUMS.sha256"].sort();
+  if (actual.join("\n") !== expected.join("\n")) {
+    throw new Error(
+      `Catalogue inventory differs from checksums; expected=${expected.join(",")}; ` +
+        `actual=${actual.join(",")}`,
+    );
+  }
+  return locked;
+}
+
+async function prepareDestination() {
+  try {
+    const marker = await readFile(resolve(destinationRoot, ".explorer-generated"), "utf8");
+    if (marker !== EXPLORER_GENERATED_MARKER) {
+      throw new Error("Refusing to replace an unmarked Explorer catalogue directory");
+    }
+    await rm(destinationRoot, { recursive: true });
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      // A missing generated destination is the normal first-build state.
+    } else if (error instanceof Error) {
+      throw error;
+    }
+  }
+  await mkdir(destinationRoot, { recursive: true });
+  await writeFile(
+    resolve(destinationRoot, ".explorer-generated"),
+    EXPLORER_GENERATED_MARKER,
+    "utf8",
+  );
+}
+
+await assertSafeBuildRoots({ publicRoot, distRoot });
+const locked = await verifySource();
+await prepareDestination();
+for (const relative of [...locked, "CHECKSUMS.sha256"]) {
+  const target = resolve(destinationRoot, relative);
+  await mkdir(dirname(target), { recursive: true });
+  await cp(resolve(sourceRoot, relative), target, { errorOnExist: true });
+}
+
+console.log(`Prepared ${locked.length + 1} checksum-verified catalogue files.`);

--- a/apps/public-explorer/src/catalogue.ts
+++ b/apps/public-explorer/src/catalogue.ts
@@ -1,0 +1,910 @@
+import { isSafeNavigableHref } from "./links.js";
+import {
+  ACCESS_STATES,
+  AUTHORITY_CLASSES,
+  FRESHNESS_STATUSES,
+  RECORD_STATUSES,
+  RECORD_TYPES,
+  RIGHTS_STATES,
+  TIMELINE_EVENT_KINDS,
+  type AccessState,
+  type AuthorityClass,
+  type CatalogueBundle,
+  type CatalogueRecord,
+  type ExplorerState,
+  type FacetOption,
+  type FacetOptions,
+  type FreshnessStatus,
+  type GraphModel,
+  type JsonValue,
+  type RecordStatus,
+  type RecordType,
+  type RightsState,
+  type TimelineEvent,
+  type TimelineEventKind,
+  type TimelineModel,
+} from "./types.js";
+
+export const DEFAULT_RECORD_ID = "hmlr:dataset:inspire-index-polygons";
+export const DEFAULT_BOUNDARY_CAVEAT =
+  "Polygons are indicative and do not establish the exact legal extent of a title.";
+
+export const MAX_CATALOGUE_JSON_BYTES = 8 * 1024 * 1024;
+export const MAX_CATALOGUE_RECORDS = 10_000;
+const MAX_STRING_LENGTH = 65_536;
+const MAX_DISPLAY_STRING_LENGTH = 16_384;
+const MAX_ARRAY_ITEMS = 10_000;
+const MAX_OBJECT_KEYS = 256;
+const MAX_JSON_DEPTH = 16;
+const MAX_JSON_NODES = 250_000;
+const PUBLICATION_BASE = "https://chris-page-gov.github.io/gis-ai-go/";
+
+const DATE = /^\d{4}-\d{2}-\d{2}$/u;
+const DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u;
+const SHA_40 = /^[0-9a-f]{40}$/u;
+const SEMVER = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u;
+const HTML_LIKE = /<\s*(?:!--|!doctype\b|\/?[a-z][^>]*)>/iu;
+const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u;
+const BIDI_CONTROL = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+type ObjectValue = Record<string, unknown>;
+
+function fail(path: string, message: string): never {
+  throw new Error(`Invalid catalogue at ${path}: ${message}`);
+}
+
+function isObject(value: unknown): value is ObjectValue {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function objectAt(value: unknown, path: string): ObjectValue {
+  if (!isObject(value)) {
+    fail(path, "expected an object");
+  }
+  return value;
+}
+
+function exactKeys(value: ObjectValue, expected: readonly string[], path: string): void {
+  const actual = Object.keys(value).sort();
+  const required = [...expected].sort();
+  if (actual.length !== required.length || actual.some((key, index) => key !== required[index])) {
+    fail(path, `expected keys ${required.join(", ")}; found ${actual.join(", ")}`);
+  }
+}
+
+function stringAt(
+  value: unknown,
+  path: string,
+  options: { readonly plain?: boolean; readonly max?: number } = {},
+): string {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(path, "expected a non-empty string");
+  }
+  if (value.length > (options.max ?? MAX_STRING_LENGTH)) {
+    fail(path, "string exceeds the permitted length");
+  }
+  if (CONTROL_CHARACTER.test(value) || BIDI_CONTROL.test(value)) {
+    fail(path, "string contains an unsafe control character");
+  }
+  if (options.plain && HTML_LIKE.test(value)) {
+    fail(path, "HTML-like content is not permitted");
+  }
+  return value;
+}
+
+function literalAt<T extends string | boolean>(value: unknown, expected: T, path: string): T {
+  if (value !== expected) {
+    fail(path, `expected ${JSON.stringify(expected)}`);
+  }
+  return expected;
+}
+
+function enumAt<const T extends readonly string[]>(
+  value: unknown,
+  values: T,
+  path: string,
+): T[number] {
+  if (typeof value !== "string" || !(values as readonly string[]).includes(value)) {
+    fail(path, `expected one of ${values.join(", ")}`);
+  }
+  return value as T[number];
+}
+
+function validCalendarDate(value: string): boolean {
+  const datePart = value.slice(0, 10);
+  if (!DATE.test(datePart)) {
+    return false;
+  }
+  const [year, month, day] = datePart.split("-").map(Number);
+  const candidate = new Date(Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1));
+  return (
+    candidate.getUTCFullYear() === year &&
+    candidate.getUTCMonth() + 1 === month &&
+    candidate.getUTCDate() === day
+  );
+}
+
+function dateTimeAt(value: unknown, path: string): string {
+  const text = stringAt(value, path, { max: 64 });
+  if (!DATE_TIME.test(text) || !validCalendarDate(text) || !Number.isFinite(Date.parse(text))) {
+    fail(path, "expected an RFC 3339 date-time");
+  }
+  return text;
+}
+
+function dateLikeAt(value: unknown, path: string): string {
+  const text = stringAt(value, path, { max: 64 });
+  if (DATE.test(text)) {
+    if (!validCalendarDate(text)) {
+      fail(path, "expected a valid calendar date");
+    }
+    return text;
+  }
+  return dateTimeAt(text, path);
+}
+
+function uniqueStringsAt(
+  value: unknown,
+  path: string,
+  options: { readonly plain?: boolean; readonly min?: number } = {},
+): readonly string[] {
+  if (!Array.isArray(value) || value.length < (options.min ?? 0) || value.length > MAX_ARRAY_ITEMS) {
+    fail(path, "expected a bounded string array");
+  }
+  const strings = value.map((item, index) => {
+    const stringOptions =
+      options.plain === undefined
+        ? { max: MAX_DISPLAY_STRING_LENGTH }
+        : { plain: options.plain, max: MAX_DISPLAY_STRING_LENGTH };
+    return stringAt(item, `${path}[${index}]`, stringOptions);
+  });
+  if (new Set(strings).size !== strings.length) {
+    fail(path, "values must be unique");
+  }
+  return strings;
+}
+
+function assertSafeJson(value: unknown): void {
+  let nodes = 0;
+  const ancestors = new WeakSet<object>();
+
+  function visit(item: unknown, path: string, depth: number): void {
+    nodes += 1;
+    if (nodes > MAX_JSON_NODES) {
+      fail(path, "JSON value exceeds the node limit");
+    }
+    if (depth > MAX_JSON_DEPTH) {
+      fail(path, "JSON value exceeds the depth limit");
+    }
+    if (item === null || typeof item === "boolean") {
+      return;
+    }
+    if (typeof item === "string") {
+      stringAt(item, path, { max: MAX_STRING_LENGTH, plain: true });
+      return;
+    }
+    if (typeof item === "number") {
+      if (!Number.isFinite(item)) {
+        fail(path, "number must be finite");
+      }
+      return;
+    }
+    if (typeof item !== "object") {
+      fail(path, "value is not JSON-compatible");
+    }
+    const prototype = Object.getPrototypeOf(item);
+    if (prototype !== Object.prototype && prototype !== null && !Array.isArray(item)) {
+      fail(path, "object must be a plain JSON object");
+    }
+    if (ancestors.has(item)) {
+      fail(path, "cyclic values are not permitted");
+    }
+    ancestors.add(item);
+    if (Array.isArray(item)) {
+      if (item.length > MAX_ARRAY_ITEMS) {
+        fail(path, "array exceeds the item limit");
+      }
+      item.forEach((child, index) => visit(child, `${path}[${index}]`, depth + 1));
+    } else {
+      const keys = Object.keys(item);
+      if (keys.length > MAX_OBJECT_KEYS) {
+        fail(path, "object exceeds the key limit");
+      }
+      for (const key of keys) {
+        if (DANGEROUS_KEYS.has(key)) {
+          fail(`${path}.${key}`, "dangerous object key is not permitted");
+        }
+        stringAt(key, `${path}.<key>`, { max: 256 });
+        visit((item as ObjectValue)[key], `${path}.${key}`, depth + 1);
+      }
+    }
+    ancestors.delete(item);
+  }
+
+  visit(value, "$", 0);
+}
+
+function httpsUrlAt(value: unknown, path: string): string {
+  const text = stringAt(value, path, { max: 2_048 });
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    fail(path, "expected an absolute HTTPS URL");
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    fail(path, "expected an HTTPS URL without credentials");
+  }
+  return text;
+}
+
+function validateDetailLinks(details: ObjectValue, path: string): void {
+  const visit = (value: unknown, key: string, itemPath: string): void => {
+    if (typeof value === "string" && new Set(["url", "profile", "compatibilityProfile"]).has(key)) {
+      if (!isSafeNavigableHref(value, PUBLICATION_BASE)) {
+        fail(itemPath, "navigable URL is not HTTPS or a safe publication-relative path");
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((child, index) => visit(child, key, `${itemPath}[${index}]`));
+    } else if (isObject(value)) {
+      Object.entries(value).forEach(([childKey, child]) =>
+        visit(child, childKey, `${itemPath}.${childKey}`),
+      );
+    }
+  };
+  Object.entries(details).forEach(([key, value]) => visit(value, key, `${path}.${key}`));
+}
+
+function parseRecord(value: unknown, index: number): CatalogueRecord {
+  const path = `$.records[${index}]`;
+  const record = objectAt(value, path);
+  exactKeys(
+    record,
+    [
+      "schema",
+      "id",
+      "type",
+      "title",
+      "description",
+      "authority",
+      "publication",
+      "access",
+      "rights",
+      "freshness",
+      "status",
+      "sourceRefs",
+      "limitations",
+      "tags",
+      "details",
+    ],
+    path,
+  );
+
+  literalAt(record.schema, "gis-ai-go-okf-concept.v1", `${path}.schema`);
+  const id = stringAt(record.id, `${path}.id`, { max: 512 });
+  const type = enumAt(record.type, RECORD_TYPES, `${path}.type`);
+  const title = stringAt(record.title, `${path}.title`, {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+  const description = stringAt(record.description, `${path}.description`, {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+
+  const authority = objectAt(record.authority, `${path}.authority`);
+  exactKeys(authority, ["class", "statement", "source"], `${path}.authority`);
+  const authorityClass = enumAt(authority.class, AUTHORITY_CLASSES, `${path}.authority.class`);
+  const authorityStatement = stringAt(authority.statement, `${path}.authority.statement`, {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+  const authoritySource = stringAt(authority.source, `${path}.authority.source`, {
+    plain: true,
+    max: 2_048,
+  });
+  if (/^[a-z][a-z0-9+.-]*:/iu.test(authoritySource) && !authoritySource.startsWith("https://")) {
+    fail(`${path}.authority.source`, "absolute authority links must use HTTPS");
+  }
+  if (authoritySource.startsWith("https://") && !isSafeNavigableHref(authoritySource, PUBLICATION_BASE)) {
+    fail(`${path}.authority.source`, "authority URL is unsafe");
+  }
+
+  const publication = objectAt(record.publication, `${path}.publication`);
+  exactKeys(
+    publication,
+    ["classification", "containsPersonalData", "containsProtectedData"],
+    `${path}.publication`,
+  );
+  literalAt(publication.classification, "public", `${path}.publication.classification`);
+  literalAt(publication.containsPersonalData, false, `${path}.publication.containsPersonalData`);
+  literalAt(
+    publication.containsProtectedData,
+    false,
+    `${path}.publication.containsProtectedData`,
+  );
+
+  const access = objectAt(record.access, `${path}.access`);
+  exactKeys(access, ["tier", "state", "authentication"], `${path}.access`);
+  literalAt(access.tier, "open", `${path}.access.tier`);
+  const accessState = enumAt(access.state, ACCESS_STATES, `${path}.access.state`);
+  const authentication = stringAt(access.authentication, `${path}.access.authentication`, {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+
+  const rights = objectAt(record.rights, `${path}.rights`);
+  exactKeys(
+    rights,
+    ["state", "recordLicence", "describedResourceLicence", "attribution"],
+    `${path}.rights`,
+  );
+  const rightsState = enumAt(rights.state, RIGHTS_STATES, `${path}.rights.state`);
+  const recordLicence = stringAt(rights.recordLicence, `${path}.rights.recordLicence`, {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+  const describedResourceLicence = stringAt(
+    rights.describedResourceLicence,
+    `${path}.rights.describedResourceLicence`,
+    { plain: true, max: MAX_DISPLAY_STRING_LENGTH },
+  );
+  const attribution = stringAt(rights.attribution, `${path}.rights.attribution`, {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+
+  const freshness = objectAt(record.freshness, `${path}.freshness`);
+  exactKeys(
+    freshness,
+    ["observedAt", "reviewedAt", "staleAfter", "status"],
+    `${path}.freshness`,
+  );
+  const observedAt = dateTimeAt(freshness.observedAt, `${path}.freshness.observedAt`);
+  const reviewedAt = dateTimeAt(freshness.reviewedAt, `${path}.freshness.reviewedAt`);
+  const staleAfter = dateTimeAt(freshness.staleAfter, `${path}.freshness.staleAfter`);
+  const freshnessStatus = enumAt(
+    freshness.status,
+    FRESHNESS_STATUSES,
+    `${path}.freshness.status`,
+  );
+
+  const status = enumAt(record.status, RECORD_STATUSES, `${path}.status`);
+  const sourceRefs = uniqueStringsAt(record.sourceRefs, `${path}.sourceRefs`, { min: 1 });
+  const limitations = uniqueStringsAt(record.limitations, `${path}.limitations`, {
+    plain: true,
+    min: 1,
+  });
+  const tags = uniqueStringsAt(record.tags, `${path}.tags`);
+  const details = objectAt(record.details, `${path}.details`);
+  validateDetailLinks(details, `${path}.details`);
+  for (const key of ["publisherLastUpdated", "published", "releasedAt", "releaseDate"] as const) {
+    const detail = details[key];
+    if (detail !== undefined && detail !== null) {
+      dateLikeAt(detail, `${path}.details.${key}`);
+    }
+  }
+
+  return {
+    schema: "gis-ai-go-okf-concept.v1",
+    id,
+    type,
+    title,
+    description,
+    authority: {
+      class: authorityClass,
+      statement: authorityStatement,
+      source: authoritySource,
+    },
+    publication: {
+      classification: "public",
+      containsPersonalData: false,
+      containsProtectedData: false,
+    },
+    access: { tier: "open", state: accessState, authentication },
+    rights: {
+      state: rightsState,
+      recordLicence,
+      describedResourceLicence,
+      attribution,
+    },
+    freshness: {
+      observedAt,
+      reviewedAt,
+      staleAfter,
+      status: freshnessStatus,
+    },
+    status,
+    sourceRefs,
+    limitations,
+    tags,
+    details: details as Readonly<Record<string, JsonValue>>,
+  };
+}
+
+/** Parse and validate JSON text before it reaches the Explorer model. */
+export function parseCatalogueJson(text: string): CatalogueBundle {
+  if (new TextEncoder().encode(text).byteLength > MAX_CATALOGUE_JSON_BYTES) {
+    throw new Error(`Catalogue JSON exceeds ${MAX_CATALOGUE_JSON_BYTES} bytes`);
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new Error("Catalogue is not valid JSON", { cause: error });
+  }
+  return parseCatalogue(value);
+}
+
+/** Validate an unknown value against the bounded GIS AI GO public bundle contract. */
+export function parseCatalogue(value: unknown): CatalogueBundle {
+  assertSafeJson(value);
+  const bundle = objectAt(value, "$");
+  exactKeys(
+    bundle,
+    [
+      "schema",
+      "id",
+      "title",
+      "description",
+      "okfVersion",
+      "profile",
+      "profileStatus",
+      "version",
+      "revision",
+      "status",
+      "authority",
+      "scope",
+      "rights",
+      "observedAt",
+      "reviewedAt",
+      "staleAfter",
+      "recordCount",
+      "records",
+    ],
+    "$",
+  );
+
+  literalAt(bundle.schema, "gis-ai-go-okf-bundle.v1", "$.schema");
+  const id = httpsUrlAt(bundle.id, "$.id");
+  const title = stringAt(bundle.title, "$.title", { plain: true, max: MAX_DISPLAY_STRING_LENGTH });
+  const description = stringAt(bundle.description, "$.description", {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+  literalAt(bundle.okfVersion, "0.2", "$.okfVersion");
+  const profile = httpsUrlAt(bundle.profile, "$.profile");
+  literalAt(
+    bundle.profileStatus,
+    "candidate-pending-consumer-acceptance",
+    "$.profileStatus",
+  );
+  const version = stringAt(bundle.version, "$.version", { max: 64 });
+  if (!SEMVER.test(version)) {
+    fail("$.version", "expected a semantic version");
+  }
+  const revision = stringAt(bundle.revision, "$.revision", { max: 40 });
+  if (!SHA_40.test(revision)) {
+    fail("$.revision", "expected a lowercase 40-character Git SHA");
+  }
+  literalAt(bundle.status, "candidate", "$.status");
+
+  const authority = objectAt(bundle.authority, "$.authority");
+  exactKeys(
+    authority,
+    ["bundleAuthority", "officialSourceAuthority", "legalAdvice", "notEndorsedBySource"],
+    "$.authority",
+  );
+  const bundleAuthority = stringAt(authority.bundleAuthority, "$.authority.bundleAuthority", {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+  const officialSourceAuthority = stringAt(
+    authority.officialSourceAuthority,
+    "$.authority.officialSourceAuthority",
+    { plain: true, max: MAX_DISPLAY_STRING_LENGTH },
+  );
+  literalAt(authority.legalAdvice, false, "$.authority.legalAdvice");
+  literalAt(authority.notEndorsedBySource, true, "$.authority.notEndorsedBySource");
+
+  const scope = objectAt(bundle.scope, "$.scope");
+  exactKeys(scope, ["kind", "metadataOnly", "containsProtectedData", "excludes"], "$.scope");
+  literalAt(scope.kind, "bounded-public-metadata-discovery", "$.scope.kind");
+  literalAt(scope.metadataOnly, true, "$.scope.metadataOnly");
+  literalAt(scope.containsProtectedData, false, "$.scope.containsProtectedData");
+  const excludes = uniqueStringsAt(scope.excludes, "$.scope.excludes", { plain: true, min: 1 });
+
+  const rights = objectAt(bundle.rights, "$.rights");
+  exactKeys(rights, ["statement", "thirdPartyNotices"], "$.rights");
+  const rightsStatement = stringAt(rights.statement, "$.rights.statement", {
+    plain: true,
+    max: MAX_DISPLAY_STRING_LENGTH,
+  });
+  literalAt(rights.thirdPartyNotices, "THIRD_PARTY.md", "$.rights.thirdPartyNotices");
+
+  const observedAt = dateTimeAt(bundle.observedAt, "$.observedAt");
+  const reviewedAt = dateTimeAt(bundle.reviewedAt, "$.reviewedAt");
+  const staleAfter = dateTimeAt(bundle.staleAfter, "$.staleAfter");
+  if (
+    typeof bundle.recordCount !== "number" ||
+    !Number.isInteger(bundle.recordCount) ||
+    bundle.recordCount < 1
+  ) {
+    fail("$.recordCount", "expected a positive integer");
+  }
+  const recordCount = bundle.recordCount;
+  if (!Array.isArray(bundle.records) || bundle.records.length > MAX_CATALOGUE_RECORDS) {
+    fail("$.records", `expected no more than ${MAX_CATALOGUE_RECORDS} records`);
+  }
+  if (recordCount !== bundle.records.length) {
+    fail("$.recordCount", "does not match the records array length");
+  }
+
+  const records = bundle.records.map(parseRecord);
+  const byId = new Map(records.map((record) => [record.id, record]));
+  if (byId.size !== records.length) {
+    fail("$.records", "record IDs must be unique");
+  }
+  for (const record of records) {
+    for (const sourceRef of record.sourceRefs) {
+      if (!byId.has(sourceRef)) {
+        fail(`$.records.${record.id}.sourceRefs`, `unresolved source reference ${sourceRef}`);
+      }
+    }
+  }
+  const defaultRecord = byId.get(DEFAULT_RECORD_ID);
+  if (!defaultRecord) {
+    fail("$.records", `missing canonical default record ${DEFAULT_RECORD_ID}`);
+  }
+  if (!defaultRecord.limitations.includes(DEFAULT_BOUNDARY_CAVEAT)) {
+    fail(
+      `$.records.${DEFAULT_RECORD_ID}.limitations`,
+      "missing the required indicative-versus-legal-boundary caveat",
+    );
+  }
+
+  return {
+    schema: "gis-ai-go-okf-bundle.v1",
+    id,
+    title,
+    description,
+    okfVersion: "0.2",
+    profile,
+    profileStatus: "candidate-pending-consumer-acceptance",
+    version,
+    revision,
+    status: "candidate",
+    authority: {
+      bundleAuthority,
+      officialSourceAuthority,
+      legalAdvice: false,
+      notEndorsedBySource: true,
+    },
+    scope: {
+      kind: "bounded-public-metadata-discovery",
+      metadataOnly: true,
+      containsProtectedData: false,
+      excludes,
+    },
+    rights: {
+      statement: rightsStatement,
+      thirdPartyNotices: "THIRD_PARTY.md",
+    },
+    observedAt,
+    reviewedAt,
+    staleAfter,
+    recordCount: records.length,
+    records,
+  };
+}
+
+function normaliseSearchText(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-GB")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function approvedDetailText(value: JsonValue | undefined): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (value === null) {
+    return [];
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(approvedDetailText);
+  }
+  return [];
+}
+
+function searchableText(record: CatalogueRecord): string {
+  return normaliseSearchText(
+    [
+      record.id,
+      record.type,
+      record.title,
+      record.description,
+      record.authority.statement,
+      ...record.limitations,
+      ...record.tags,
+      ...approvedDetailText(record.details.publisher),
+      ...approvedDetailText(record.details.jurisdiction),
+      ...approvedDetailText(record.details.formats),
+      ...approvedDetailText(record.details.cadence),
+    ].join(" "),
+  );
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Apply bounded full-text search and the controlled Explorer facets. */
+export function searchRecords(
+  records: readonly CatalogueRecord[],
+  state: ExplorerState,
+): readonly CatalogueRecord[] {
+  const tokens = normaliseSearchText(state.query).split(" ").filter(Boolean).slice(0, 10);
+  const matches = records.filter((record) => {
+    const haystack = searchableText(record);
+    return (
+      tokens.every((token) => haystack.includes(token)) &&
+      (state.types.length === 0 || state.types.includes(record.type)) &&
+      (state.authority.length === 0 || state.authority.includes(record.authority.class)) &&
+      (state.access.length === 0 || state.access.includes(record.access.state)) &&
+      (state.rights.length === 0 || state.rights.includes(record.rights.state)) &&
+      (state.freshness.length === 0 || state.freshness.includes(record.freshness.status)) &&
+      (state.tags.length === 0 || state.tags.some((tag) => record.tags.includes(tag)))
+    );
+  });
+
+  return [...matches].sort((left, right) => {
+    if (tokens.length > 0) {
+      const leftTitle = normaliseSearchText(left.title);
+      const rightTitle = normaliseSearchText(right.title);
+      const leftScore = tokens.reduce(
+        (score, token) => score + (leftTitle === token ? 8 : leftTitle.startsWith(token) ? 4 : leftTitle.includes(token) ? 2 : 0),
+        0,
+      );
+      const rightScore = tokens.reduce(
+        (score, token) => score + (rightTitle === token ? 8 : rightTitle.startsWith(token) ? 4 : rightTitle.includes(token) ? 2 : 0),
+        0,
+      );
+      if (leftScore !== rightScore) {
+        return rightScore - leftScore;
+      }
+    }
+    return compareText(left.title, right.title) || compareText(left.id, right.id);
+  });
+}
+
+function countedOptions<T extends string>(values: readonly T[]): readonly FacetOption<T>[] {
+  const counts = new Map<T, number>();
+  values.forEach((value) => counts.set(value, (counts.get(value) ?? 0) + 1));
+  return [...counts.entries()]
+    .sort(([left], [right]) => compareText(left, right))
+    .map(([value, count]) => ({ value, count }));
+}
+
+function stateWithoutFacet(
+  state: ExplorerState,
+  facet: "types" | "authority" | "access" | "rights" | "freshness" | "tags",
+): ExplorerState {
+  return { ...state, [facet]: [] };
+}
+
+function countedKnownOptions<T extends string>(
+  known: readonly T[],
+  matching: readonly T[],
+): readonly FacetOption<T>[] {
+  const counts = new Map<T, number>();
+  matching.forEach((value) => counts.set(value, (counts.get(value) ?? 0) + 1));
+  return uniqueFacetValues(known)
+    .sort(compareText)
+    .map((value) => ({ value, count: counts.get(value) ?? 0 }));
+}
+
+function uniqueFacetValues<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+export function deriveFacetOptions(
+  records: readonly CatalogueRecord[],
+  state?: ExplorerState,
+): FacetOptions {
+  if (state === undefined) {
+    return {
+      types: countedOptions(records.map((record) => record.type)),
+      authority: countedOptions(records.map((record) => record.authority.class)),
+      access: countedOptions(records.map((record) => record.access.state)),
+      rights: countedOptions(records.map((record) => record.rights.state)),
+      freshness: countedOptions(records.map((record) => record.freshness.status)),
+      tags: countedOptions(records.flatMap((record) => record.tags)),
+    };
+  }
+  const matching = (facet: Parameters<typeof stateWithoutFacet>[1]): readonly CatalogueRecord[] =>
+    searchRecords(records, stateWithoutFacet(state, facet));
+  return {
+    types: countedKnownOptions(
+      records.map((record) => record.type),
+      matching("types").map((record) => record.type),
+    ),
+    authority: countedKnownOptions(
+      records.map((record) => record.authority.class),
+      matching("authority").map((record) => record.authority.class),
+    ),
+    access: countedKnownOptions(
+      records.map((record) => record.access.state),
+      matching("access").map((record) => record.access.state),
+    ),
+    rights: countedKnownOptions(
+      records.map((record) => record.rights.state),
+      matching("rights").map((record) => record.rights.state),
+    ),
+    freshness: countedKnownOptions(
+      records.map((record) => record.freshness.status),
+      matching("freshness").map((record) => record.freshness.status),
+    ),
+    tags: countedKnownOptions(
+      records.flatMap((record) => record.tags),
+      matching("tags").flatMap((record) => record.tags),
+    ),
+  };
+}
+
+const FACET_LABELS: Readonly<Record<string, string>> = {
+  bundle: "Bundle",
+  dataset: "Dataset",
+  provider: "Provider",
+  source: "Source",
+  workflow: "Workflow",
+  derived: "Derived",
+  "project-authoritative": "Project authoritative",
+  "source-authoritative": "Source authoritative",
+  "planned-non-executing": "Planned, non-executing",
+  public: "Public",
+  "public-metadata": "Public metadata",
+  "metadata-citation": "Metadata citation",
+  "open-with-conditions": "Open with conditions",
+  "project-mit": "Project MIT",
+  current: "Current",
+  "review-required": "Review required",
+};
+
+export function facetLabel(value: string): string {
+  return FACET_LABELS[value] ?? value;
+}
+
+/**
+ * Derive source-reference nodes, edges and a complete adjacency alternative.
+ * When IDs are supplied they represent filtered records; their immediate referenced
+ * evidence nodes are added so the graph retains its one-hop evidence context.
+ */
+export function deriveGraph(
+  records: readonly CatalogueRecord[],
+  includeRecordIds?: readonly string[],
+): GraphModel {
+  const byId = new Map(records.map((record) => [record.id, record]));
+  if (byId.size !== records.length) {
+    throw new Error("Cannot derive a graph from duplicate record IDs");
+  }
+  const explicit = new Set(includeRecordIds ?? records.map((record) => record.id));
+  for (const id of explicit) {
+    if (!byId.has(id)) {
+      throw new Error(`Cannot derive a graph for unknown record ${id}`);
+    }
+  }
+
+  const included = new Set(explicit);
+  for (const id of explicit) {
+    const record = byId.get(id);
+    if (!record) {
+      throw new Error(`Graph record disappeared: ${id}`);
+    }
+    for (const sourceId of record.sourceRefs) {
+      if (!byId.has(sourceId)) {
+        throw new Error(`Unresolved graph source ${sourceId} from ${record.id}`);
+      }
+      if (!included.has(sourceId)) {
+        included.add(sourceId);
+      }
+    }
+  }
+
+  const includedRecords = records
+    .filter((record) => included.has(record.id))
+    .sort((left, right) => compareText(left.type, right.type) || compareText(left.id, right.id));
+  return {
+    nodes: includedRecords.map((record) => ({
+      id: record.id,
+      type: record.type,
+      title: record.title,
+      status: record.status,
+      explicitlyIncluded: explicit.has(record.id),
+    })),
+    edges: includedRecords.flatMap((record) =>
+      explicit.has(record.id) ? record.sourceRefs.filter((sourceId) => sourceId !== record.id).map((sourceId) => ({
+        from: record.id,
+        to: sourceId,
+        relation: "source" as const,
+        selfReference: false,
+      })) : [],
+    ),
+    adjacency: includedRecords.map((record) => ({
+      recordId: record.id,
+      recordTitle: record.title,
+      sourceIds: explicit.has(record.id)
+        ? record.sourceRefs.filter((sourceId) => sourceId !== record.id).sort(compareText)
+        : [],
+    })),
+  };
+}
+
+function optionalDetailDate(record: CatalogueRecord, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = record.details[key];
+    if (typeof value === "string") {
+      return dateLikeAt(value, `record ${record.id}.details.${key}`);
+    }
+  }
+  return null;
+}
+
+export function deriveTimeline(records: readonly CatalogueRecord[]): TimelineModel {
+  const events: TimelineEvent[] = [];
+  const missing = new Map<TimelineEventKind, number>(
+    TIMELINE_EVENT_KINDS.map((kind) => [kind, 0]),
+  );
+  const add = (record: CatalogueRecord, kind: TimelineEventKind, date: string | null): void => {
+    if (date === null) {
+      missing.set(kind, (missing.get(kind) ?? 0) + 1);
+      return;
+    }
+    events.push({
+      id: `${record.id}|${kind}|${date}`,
+      recordId: record.id,
+      recordTitle: record.title,
+      kind,
+      date,
+    });
+  };
+
+  for (const record of records) {
+    add(record, "observation", record.freshness.observedAt);
+    add(record, "modification", optionalDetailDate(record, ["publisherLastUpdated"]));
+    add(record, "publication", optionalDetailDate(record, ["published"]));
+    add(record, "release", optionalDetailDate(record, ["releasedAt", "releaseDate"]));
+  }
+
+  const kindOrder = new Map(TIMELINE_EVENT_KINDS.map((kind, index) => [kind, index]));
+  events.sort(
+    (left, right) =>
+      Date.parse(right.date) - Date.parse(left.date) ||
+      (kindOrder.get(left.kind) ?? 0) - (kindOrder.get(right.kind) ?? 0) ||
+      compareText(left.recordId, right.recordId),
+  );
+  return {
+    events,
+    missing: TIMELINE_EVENT_KINDS.map((kind) => ({
+      kind,
+      recordCount: missing.get(kind) ?? 0,
+    })).filter((item) => item.recordCount > 0),
+  };
+}
+
+// These aliases make the controlled facet types discoverable to UI consumers.
+export type CatalogueRecordType = RecordType;
+export type CatalogueAuthorityClass = AuthorityClass;
+export type CatalogueAccessState = AccessState;
+export type CatalogueRightsState = RightsState;
+export type CatalogueFreshnessStatus = FreshnessStatus;
+export type CatalogueRecordStatus = RecordStatus;

--- a/apps/public-explorer/src/dom.ts
+++ b/apps/public-explorer/src/dom.ts
@@ -1,0 +1,158 @@
+export type DomChild = Node | string | null | undefined | false;
+
+export interface ElementOptions {
+  readonly className?: string;
+  readonly id?: string;
+  readonly text?: string;
+}
+
+export function appendChildren(parent: Node, children: readonly DomChild[]): void {
+  for (const child of children) {
+    if (child === null || child === undefined || child === false) {
+      continue;
+    }
+    parent.appendChild(child instanceof Node ? child : document.createTextNode(child));
+  }
+}
+
+export function element<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  options: ElementOptions = {},
+  children: readonly DomChild[] = [],
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tagName);
+  if (options.className !== undefined) {
+    node.className = options.className;
+  }
+  if (options.id !== undefined) {
+    node.id = options.id;
+  }
+  if (options.text !== undefined) {
+    node.textContent = options.text;
+  }
+  appendChildren(node, children);
+  return node;
+}
+
+export function svgElement<K extends keyof SVGElementTagNameMap>(
+  tagName: K,
+  attributes: Readonly<Record<string, string>> = {},
+): SVGElementTagNameMap[K] {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", tagName);
+  for (const [name, value] of Object.entries(attributes)) {
+    node.setAttribute(name, value);
+  }
+  return node;
+}
+
+export function link(label: string, href: string, className?: string): HTMLAnchorElement {
+  const node = element("a", className === undefined ? { text: label } : { className, text: label });
+  node.href = href;
+  return node;
+}
+
+export function button(label: string, className?: string): HTMLButtonElement {
+  const node = element(
+    "button",
+    className === undefined ? { text: label } : { className, text: label },
+  );
+  node.type = "button";
+  return node;
+}
+
+export interface DefinitionRow {
+  readonly term: string;
+  readonly description: DomChild | readonly DomChild[];
+}
+
+export function definitionList(
+  rows: readonly DefinitionRow[],
+  className = "metadata-list",
+): HTMLDListElement {
+  const list = element("dl", { className });
+  for (const row of rows) {
+    list.append(element("dt", { text: row.term }));
+    const description = element("dd");
+    appendChildren(
+      description,
+      Array.isArray(row.description) ? row.description : [row.description as DomChild],
+    );
+    list.append(description);
+  }
+  return list;
+}
+
+export function bulletList(
+  values: readonly string[],
+  className?: string,
+): HTMLUListElement {
+  const list = element("ul", className === undefined ? {} : { className });
+  for (const value of values) {
+    list.append(element("li", { text: value }));
+  }
+  return list;
+}
+
+const dateOnlyFormatter = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  hour: "2-digit",
+  hour12: false,
+  minute: "2-digit",
+  month: "long",
+  timeZone: "Europe/London",
+  timeZoneName: "short",
+  year: "numeric",
+});
+
+export function formatDate(value: string): string {
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? new Date(`${value}T00:00:00Z`)
+    : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? dateOnlyFormatter.format(parsed)
+    : dateTimeFormatter.format(parsed);
+}
+
+export function time(value: string): HTMLTimeElement {
+  const node = element("time", { text: formatDate(value) });
+  node.dateTime = value;
+  return node;
+}
+
+export function recordHeadingId(recordId: string): string {
+  return `record-heading-${encodeURIComponent(recordId)}`;
+}
+
+export function viewHeadingId(view: string): string {
+  return `view-heading-${encodeURIComponent(view)}`;
+}
+
+export function humaniseToken(value: string): string {
+  return value
+    .split(/[-_]/u)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function setCurrentPage(linkNode: HTMLAnchorElement, current: boolean): void {
+  if (current) {
+    linkNode.setAttribute("aria-current", "page");
+  } else {
+    linkNode.removeAttribute("aria-current");
+  }
+}
+
+export function setStatus(node: HTMLElement, message: string): void {
+  node.textContent = message;
+}

--- a/apps/public-explorer/src/links.ts
+++ b/apps/public-explorer/src/links.ts
@@ -1,0 +1,103 @@
+declare const safeNavigableHrefBrand: unique symbol;
+
+/** A URL value that has passed the Explorer's navigation policy. */
+export type SafeNavigableHref = string & {
+  readonly [safeNavigableHrefBrand]: true;
+};
+
+const FORBIDDEN_CODE_POINT =
+  /[\u0000-\u001f\u007f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+const SCHEME = /^[a-z][a-z0-9+.-]*:/iu;
+const ENCODED_SEPARATOR = /%(?:2f|5c)/iu;
+
+function repeatedlyDecode(value: string): string | null {
+  let current = value;
+  for (let index = 0; index < 4; index += 1) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(current);
+    } catch {
+      return null;
+    }
+    if (decoded === current) {
+      return decoded;
+    }
+    current = decoded;
+  }
+  return null;
+}
+
+function hasTraversal(value: string): boolean {
+  const path = value.split(/[?#]/u, 1)[0] ?? "";
+  const decoded = repeatedlyDecode(path);
+  if (decoded === null) {
+    return true;
+  }
+  return decoded.replaceAll("\\", "/").split("/").some((part) => part === "..");
+}
+
+/**
+ * Return a branded href when it can be used for navigation.
+ *
+ * Absolute destinations must use HTTPS. Relative destinations must remain on the
+ * base origin and must not contain credentials, protocol-relative syntax or path
+ * traversal. HTTP is tolerated only when it results from resolving a relative URL
+ * against a local development base; an explicitly supplied HTTP URL is rejected.
+ */
+export function safeNavigableHref(
+  value: string,
+  base: string | URL,
+): SafeNavigableHref | null {
+  if (
+    value.length === 0 ||
+    value.length > 2_048 ||
+    value !== value.trim() ||
+    FORBIDDEN_CODE_POINT.test(value) ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    ENCODED_SEPARATOR.test(value) ||
+    hasTraversal(value)
+  ) {
+    return null;
+  }
+
+  let baseUrl: URL;
+  let resolved: URL;
+  try {
+    baseUrl = base instanceof URL ? new URL(base.href) : new URL(base);
+    resolved = new URL(value, baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (!new Set(["http:", "https:"]).has(baseUrl.protocol)) {
+    return null;
+  }
+  if (resolved.username || resolved.password) {
+    return null;
+  }
+
+  const absolute = SCHEME.test(value);
+  if (absolute) {
+    if (resolved.protocol !== "https:") {
+      return null;
+    }
+  } else {
+    const deploymentBase = new URL("./", baseUrl);
+    if (
+      resolved.origin !== deploymentBase.origin ||
+      !resolved.pathname.startsWith(deploymentBase.pathname)
+    ) {
+      return null;
+    }
+  }
+
+  if (resolved.protocol !== "https:" && resolved.origin !== baseUrl.origin) {
+    return null;
+  }
+  return value as SafeNavigableHref;
+}
+
+export function isSafeNavigableHref(value: string, base: string | URL): boolean {
+  return safeNavigableHref(value, base) !== null;
+}

--- a/apps/public-explorer/src/main.ts
+++ b/apps/public-explorer/src/main.ts
@@ -1,0 +1,625 @@
+import "./styles.css";
+
+import {
+  DEFAULT_BOUNDARY_CAVEAT,
+  DEFAULT_RECORD_ID,
+  deriveFacetOptions,
+  deriveGraph,
+  deriveTimeline,
+  facetLabel,
+  parseCatalogueJson,
+  searchRecords,
+} from "./catalogue";
+import {
+  button,
+  definitionList,
+  element,
+  humaniseToken,
+  link,
+  recordHeadingId,
+  setCurrentPage,
+} from "./dom";
+import { safeNavigableHref } from "./links";
+import {
+  canonicaliseState,
+  createDefaultExplorerState,
+  parseExplorerUrl,
+  serialiseExplorerUrl,
+} from "./state";
+import type {
+  CatalogueBundle,
+  CatalogueRecord,
+  ExplorerState,
+  FacetOption,
+  FacetOptions,
+} from "./types";
+import { renderCardsView, type CardNavigation } from "./views/cards";
+import { renderGraphView } from "./views/graph";
+import { renderMapView } from "./views/map";
+import { renderTimelineView } from "./views/timeline";
+
+document.documentElement.classList.remove("no-js");
+
+function requireExplorerRoot(): HTMLElement {
+  const candidate = document.querySelector<HTMLElement>("#explorer-root");
+  if (candidate === null) {
+    throw new Error("Explorer root is missing");
+  }
+  return candidate;
+}
+
+const root = requireExplorerRoot();
+
+type FacetStateKey = "types" | "authority" | "access" | "rights" | "freshness" | "tags";
+
+interface HistorySnapshot {
+  readonly focusId?: string;
+  readonly scrollY?: number;
+}
+
+let bundle: CatalogueBundle;
+let state: ExplorerState;
+let stateWarning = false;
+let malformedRecordIntent = false;
+let lastHandledLocation = "";
+
+function isUnmodifiedPrimaryClick(event: MouseEvent): boolean {
+  return (
+    !event.defaultPrevented &&
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+function isBareEntry(url: URL): boolean {
+  return url.search.length === 0 && (url.hash.length === 0 || url.hash === "#");
+}
+
+function hasRecordHash(url: URL): boolean {
+  if (url.hash.length < 2) {
+    return false;
+  }
+  try {
+    return new URLSearchParams(url.hash.slice(1)).has("record");
+  } catch {
+    return true;
+  }
+}
+
+function stateUrl(nextState: ExplorerState): URL {
+  return serialiseExplorerUrl(nextState, new URL(window.location.href), bundle);
+}
+
+function updateCurrentHistoryScroll(): void {
+  const current = (history.state ?? {}) as HistorySnapshot;
+  history.replaceState(
+    { ...current, scrollY: window.scrollY },
+    "",
+    window.location.href,
+  );
+}
+
+function focusAfterRender(focusId: string | undefined, scrollY?: number): void {
+  if (focusId === undefined && scrollY === undefined) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    if (focusId !== undefined) {
+      document.getElementById(focusId)?.focus({ preventScroll: scrollY !== undefined });
+    }
+    if (scrollY !== undefined) {
+      window.scrollTo({ left: 0, top: scrollY });
+    }
+  });
+}
+
+function commitState(
+  candidate: ExplorerState,
+  focusId?: string,
+  mode: "push" | "replace" = "push",
+): void {
+  const nextState = canonicaliseState(candidate, bundle);
+  if (mode === "push") {
+    updateCurrentHistoryScroll();
+  }
+  const snapshot: HistorySnapshot = focusId === undefined ? {} : { focusId };
+  history[mode === "push" ? "pushState" : "replaceState"](
+    snapshot,
+    "",
+    stateUrl(nextState),
+  );
+  state = nextState;
+  stateWarning = false;
+  malformedRecordIntent = false;
+  render(focusId);
+  lastHandledLocation = window.location.href;
+}
+
+function internalLink(
+  label: string,
+  candidate: ExplorerState,
+  focusId: string,
+  className?: string,
+): HTMLAnchorElement {
+  const href = stateUrl(canonicaliseState(candidate, bundle)).href;
+  const node = link(label, href, className);
+  node.addEventListener("click", (event) => {
+    if (!isUnmodifiedPrimaryClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    commitState(candidate, focusId);
+  });
+  return node;
+}
+
+function navigation(): CardNavigation {
+  return {
+    hrefForRecord(recordId: string | null): string {
+      return stateUrl(
+        canonicaliseState(
+          { ...state, view: "cards", selectedRecordId: recordId },
+          bundle,
+        ),
+      ).href;
+    },
+    selectRecord(recordId: string | null): void {
+      commitState(
+        { ...state, view: "cards", selectedRecordId: recordId },
+        recordId === null ? "view-heading-cards" : recordHeadingId(recordId),
+      );
+    },
+  };
+}
+
+function renderQuestion(): HTMLElement {
+  const section = element("section");
+  section.setAttribute("aria-labelledby", "question-heading");
+  section.append(
+    element("h1", {
+      id: "question-heading",
+      text: "INSPIRE polygon: indicative or legal boundary?",
+    }),
+    element("div", { className: "answer-panel" }, [
+      element("p", {}, [
+        element("strong", { text: "Indicative." }),
+        " The dataset describes polygons showing the indicative position and extent of registered freehold property. ",
+        element("span", { text: DEFAULT_BOUNDARY_CAVEAT }),
+      ]),
+      element("p", {
+        text: "This Explorer contains metadata only. It contains no property record, address or geometry and must not be used to decide ownership, title extent or a boundary dispute.",
+      }),
+    ]),
+    element("p", {
+      text: "Coverage is England and Wales and the described data is a freehold subset. A title may have several polygons, and absence of an INSPIRE ID does not prove that land is unregistered.",
+    }),
+    element("p", {
+      text: "HM Land Registry remains authoritative for its source metadata. GIS AI GO is authoritative only for this normalised catalogue projection; it is not endorsed by the publisher and is not legal advice.",
+    }),
+    element("p", {}, [
+      internalLink(
+        "View the governed INSPIRE catalogue record",
+        { ...state, view: "cards", selectedRecordId: DEFAULT_RECORD_ID },
+        recordHeadingId(DEFAULT_RECORD_ID),
+      ),
+    ]),
+  );
+  return section;
+}
+
+function facetGroup(
+  legend: string,
+  key: FacetStateKey,
+  options: readonly FacetOption[],
+): HTMLFieldSetElement {
+  const fieldset = element("fieldset", { className: "facet-group" });
+  fieldset.append(element("legend", { text: legend }));
+  const selected = new Set(state[key] as readonly string[]);
+  for (const option of options) {
+    const encoded = encodeURIComponent(option.value);
+    const id = `facet-${key}-${encoded}`;
+    const wrapper = element("div", { className: "checkbox-item" });
+    const checkbox = element("input");
+    checkbox.type = "checkbox";
+    checkbox.id = id;
+    checkbox.name = key;
+    checkbox.value = option.value;
+    checkbox.checked = selected.has(option.value);
+    const labelNode = element("label", {
+      text: `${key === "tags" ? option.value : facetLabel(option.value)} (${option.count})`,
+    });
+    labelNode.htmlFor = id;
+    checkbox.addEventListener("change", () => {
+      const values = new Set(state[key] as readonly string[]);
+      if (checkbox.checked) {
+        values.add(option.value);
+      } else {
+        values.delete(option.value);
+      }
+      const next = {
+        ...state,
+        query:
+          document.querySelector<HTMLInputElement>("#catalogue-search")?.value ??
+          state.query,
+        [key]: [...values].sort(),
+        selectedRecordId: null,
+      } as ExplorerState;
+      commitState(next, id);
+    });
+    wrapper.append(checkbox, labelNode);
+    fieldset.append(wrapper);
+  }
+  return fieldset;
+}
+
+function renderSearch(facets: FacetOptions): HTMLElement {
+  const section = element("section", { className: "search-panel" });
+  section.setAttribute("aria-labelledby", "search-heading");
+  section.append(element("h2", { id: "search-heading", text: "Search and filter" }));
+  const form = element("form");
+  form.setAttribute("role", "search");
+  form.setAttribute("aria-label", "Catalogue search");
+  const group = element("div", { className: "form-group" });
+  const input = element("input");
+  input.type = "search";
+  input.id = "catalogue-search";
+  input.name = "q";
+  input.value = state.query;
+  input.maxLength = 200;
+  input.autocomplete = "off";
+  input.setAttribute("aria-describedby", "catalogue-search-hint");
+  const labelNode = element("label", { className: "form-label", text: "Search catalogue" });
+  labelNode.htmlFor = input.id;
+  const hint = element("span", {
+    className: "hint",
+    id: "catalogue-search-hint",
+    text: "Search public catalogue metadata. Do not enter personal information or a property address. Your search is included in the URL.",
+  });
+  const submit = button("Search");
+  submit.id = "catalogue-search-submit";
+  submit.type = "submit";
+  group.append(labelNode, hint, element("div", { className: "search-row" }, [input, submit]));
+  form.append(group);
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    commitState(
+      { ...state, query: input.value, selectedRecordId: null },
+      submit.id,
+    );
+  });
+
+  const facetGrid = element("div", { className: "facet-grid" });
+  facetGrid.append(
+    facetGroup("Type", "types", facets.types),
+    facetGroup("Authority", "authority", facets.authority),
+    facetGroup("Access", "access", facets.access),
+    facetGroup("Rights", "rights", facets.rights),
+    facetGroup("Freshness", "freshness", facets.freshness),
+    facetGroup("Topic", "tags", facets.tags),
+  );
+  const clear = button("Clear search and filters", "secondary-button");
+  clear.id = "clear-search-filters";
+  clear.addEventListener("click", () => {
+    commitState(
+      {
+        ...state,
+        query: "",
+        types: [],
+        authority: [],
+        access: [],
+        rights: [],
+        freshness: [],
+        tags: [],
+        selectedRecordId: null,
+      },
+      clear.id,
+    );
+  });
+  section.append(form, facetGrid, clear);
+  return section;
+}
+
+function renderViewNavigation(): HTMLElement {
+  const nav = element("nav", { className: "view-navigation" });
+  nav.setAttribute("aria-label", "Explore catalogue");
+  const list = element("ul");
+  const views = [
+    ["Catalogue", "cards"],
+    ["Graph", "graph"],
+    ["Timeline", "timeline"],
+    ["Map", "map"],
+  ] as const;
+  for (const [label, view] of views) {
+    const item = element("li");
+    const node = internalLink(label, { ...state, view }, `view-heading-${view}`);
+    setCurrentPage(node, state.view === view);
+    item.append(node);
+    list.append(item);
+  }
+  const aboutItem = element("li");
+  const about = link("About", "#about");
+  about.addEventListener("click", (event) => {
+    if (!isUnmodifiedPrimaryClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    updateCurrentHistoryScroll();
+    const next = canonicaliseState({ ...state, selectedRecordId: null }, bundle);
+    const url = stateUrl(next);
+    url.hash = "about";
+    history.pushState({ focusId: "about-heading" } satisfies HistorySnapshot, "", url);
+    state = next;
+    stateWarning = false;
+    malformedRecordIntent = false;
+    render("about-heading");
+    lastHandledLocation = window.location.href;
+  });
+  aboutItem.append(about);
+  list.append(aboutItem);
+  nav.append(list);
+  return nav;
+}
+
+function staticDownload(label: string, relative: string): HTMLAnchorElement {
+  const safe = safeNavigableHref(relative, document.baseURI);
+  if (safe === null) {
+    throw new Error(`Unsafe static download path: ${relative}`);
+  }
+  return link(label, safe);
+}
+
+function renderAbout(): HTMLElement {
+  const section = element("section", { className: "about-section", id: "about" });
+  section.setAttribute("aria-labelledby", "about-heading");
+  section.tabIndex = -1;
+  section.append(
+    element("h2", { id: "about-heading", text: "About this Explorer" }),
+    element("p", {
+      text: "This static candidate lets people inspect and cite public catalogue metadata without an account, MCP host or WebMCP implementation. It makes no provider request and contains no protected data.",
+    }),
+    element("h3", { text: "What catalogue terms mean" }),
+    definitionList([
+      {
+        term: "Indicative",
+        description: "A general representation, not evidence of an exact legal title extent.",
+      },
+      {
+        term: "Authority",
+        description: "Who is responsible for the source statement and what GIS AI GO has normalised.",
+      },
+      {
+        term: "Freshness",
+        description: "When metadata was observed, reviewed and due for another review.",
+      },
+      {
+        term: "Rights",
+        description: "The licence for the catalogue record is kept separate from the licence and conditions for the described resource.",
+      },
+      {
+        term: "GML",
+        description: "Geography Markup Language, a structured format for geographic information.",
+      },
+      {
+        term: "EPSG:27700",
+        description: "The identifier for the British National Grid coordinate reference system used by the source GML.",
+      },
+    ]),
+    definitionList([
+      { term: "Catalogue version", description: bundle.version },
+      { term: "OKF version", description: bundle.okfVersion },
+      { term: "Revision", description: bundle.revision },
+      { term: "Records", description: String(bundle.recordCount) },
+      { term: "Publication state", description: "Candidate public metadata" },
+      { term: "Rights", description: bundle.rights.statement },
+    ]),
+  );
+
+  const downloads = element("section", { className: "downloads-section" });
+  downloads.setAttribute("aria-labelledby", "downloads-heading");
+  const list = element("ul", { className: "download-list" });
+  list.append(
+    element("li", {}, [staticDownload("Download JSON", "./catalogue/okf-bundle.json")]),
+    element("li", {}, [staticDownload("Download JSON-LD", "./catalogue/okf-bundle.jsonld")]),
+    element("li", {}, [staticDownload("Download checksums", "./catalogue/CHECKSUMS.sha256")]),
+  );
+  downloads.append(
+    element("h3", { id: "downloads-heading", text: "Download catalogue" }),
+    list,
+  );
+  section.append(downloads);
+  return section;
+}
+
+function renderNotFound(navigationModel: CardNavigation): HTMLElement {
+  const section = element("section", { className: "error-state" });
+  section.setAttribute("aria-labelledby", "record-not-found-heading");
+  const back = link("Back to catalogue", navigationModel.hrefForRecord(null));
+  back.addEventListener("click", (event) => {
+    if (!isUnmodifiedPrimaryClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    navigationModel.selectRecord(null);
+  });
+  section.append(
+    element("h2", { id: "record-not-found-heading", text: "Record not found" }),
+    element("p", {
+      text: "The catalogue does not contain the record named by this link. No substitute record has been selected.",
+    }),
+    element("p", {}, [back]),
+  );
+  return section;
+}
+
+function renderActiveView(
+  matches: readonly CatalogueRecord[],
+  selectedRecord: CatalogueRecord | null,
+): HTMLElement {
+  const navigationModel = navigation();
+  if (
+    malformedRecordIntent ||
+    (state.selectedRecordId !== null && selectedRecord === null)
+  ) {
+    return renderNotFound(navigationModel);
+  }
+  switch (state.view) {
+    case "cards":
+      return renderCardsView(matches, bundle.records, selectedRecord, navigationModel);
+    case "graph":
+      return renderGraphView(
+        deriveGraph(bundle.records, matches.map((record) => record.id)),
+        bundle.records,
+        navigationModel,
+      );
+    case "timeline":
+      return renderTimelineView(deriveTimeline(matches), matches, navigationModel);
+    case "map":
+      return renderMapView(matches, selectedRecord, navigationModel);
+  }
+}
+
+function render(focusId?: string, scrollY?: number): void {
+  const previousFocusId = document.activeElement instanceof HTMLElement
+    ? document.activeElement.id
+    : "";
+  const matches = searchRecords(bundle.records, state);
+  const selectedRecord =
+    state.selectedRecordId === null
+      ? null
+      : (bundle.records.find((record) => record.id === state.selectedRecordId) ?? null);
+  const fragment = document.createDocumentFragment();
+  fragment.append(
+    renderQuestion(),
+    renderSearch(deriveFacetOptions(bundle.records, state)),
+    renderViewNavigation(),
+  );
+
+  if (stateWarning) {
+    const warning = element("p", {
+      className: "warning-panel",
+      text: "Some settings in this link were not recognised and were ignored.",
+    });
+    warning.setAttribute("role", "status");
+    fragment.append(warning);
+  }
+
+  const summary = element("p", {
+    className: "result-summary",
+    id: "catalogue-result-summary",
+    text: `${matches.length} catalogue ${matches.length === 1 ? "record" : "records"} found`,
+  });
+  summary.setAttribute("role", "status");
+  summary.setAttribute("aria-live", "polite");
+  summary.setAttribute("aria-atomic", "true");
+  fragment.append(summary, renderActiveView(matches, selectedRecord), renderAbout());
+  root.replaceChildren(fragment);
+  root.setAttribute("aria-busy", "false");
+
+  if (
+    malformedRecordIntent ||
+    (state.selectedRecordId !== null && selectedRecord === null)
+  ) {
+    document.title = "Record not found – GIS AI GO";
+  } else if (selectedRecord !== null && state.view === "cards") {
+    document.title = `${selectedRecord.title} – GIS AI GO`;
+  } else {
+    const viewTitle =
+      state.view === "cards" ? "Catalogue" : humaniseToken(state.view);
+    document.title = `${viewTitle} – GIS AI GO`;
+  }
+  focusAfterRender(focusId ?? (previousFocusId || undefined), scrollY);
+}
+
+function comparableStateUrl(url: URL): string {
+  if (url.hash === "#about") {
+    return `${url.pathname}${url.search}`;
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function readLocation(initial = false): void {
+  const raw = new URL(window.location.href);
+  if (initial && isBareEntry(raw)) {
+    state = createDefaultExplorerState(bundle);
+    history.replaceState({}, "", stateUrl(state));
+    stateWarning = false;
+    malformedRecordIntent = false;
+    return;
+  }
+
+  state = parseExplorerUrl(raw, bundle);
+  malformedRecordIntent = hasRecordHash(raw) && state.selectedRecordId === null;
+  const canonical = stateUrl(state);
+  stateWarning = comparableStateUrl(raw) !== comparableStateUrl(canonical);
+  if (stateWarning && malformedRecordIntent) {
+    canonical.hash = new URLSearchParams({ record: "not-found" }).toString();
+    history.replaceState(history.state, "", canonical);
+  } else if (stateWarning && raw.hash !== "#about") {
+    history.replaceState(history.state, "", canonical);
+  }
+}
+
+function renderLoadFailure(error: unknown): void {
+  const detail = error instanceof Error ? error.message : "The catalogue could not be read.";
+  root.replaceChildren(
+    element("section", { className: "error-state" }, [
+      element("h1", { text: "Catalogue unavailable" }),
+      element("p", {
+        text: "The Explorer stopped because its governed catalogue did not pass validation. It has not selected substitute data or contacted a provider.",
+      }),
+      element("p", { text: detail }),
+      element("p", {}, [staticDownload("Download JSON", "./catalogue/okf-bundle.json")]),
+    ]),
+  );
+  root.setAttribute("aria-busy", "false");
+  document.title = "Catalogue unavailable – GIS AI GO";
+}
+
+async function start(): Promise<void> {
+  try {
+    const response = await fetch("./catalogue/okf-bundle.json", {
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+      redirect: "error",
+    });
+    if (!response.ok) {
+      throw new Error(`Catalogue request failed with status ${response.status}.`);
+    }
+    bundle = parseCatalogueJson(await response.text());
+    readLocation(true);
+    render();
+    lastHandledLocation = window.location.href;
+  } catch (error) {
+    renderLoadFailure(error);
+  }
+}
+
+function handleLocationChange(snapshot: HistorySnapshot = {}): void {
+  if (bundle === undefined) {
+    return;
+  }
+  if (window.location.href === lastHandledLocation) {
+    return;
+  }
+  readLocation();
+  lastHandledLocation = window.location.href;
+  const focusId =
+    snapshot.focusId ??
+    (state.selectedRecordId === null
+      ? `view-heading-${state.view}`
+      : recordHeadingId(state.selectedRecordId));
+  render(focusId, snapshot.scrollY);
+}
+
+window.addEventListener("popstate", (event) => {
+  handleLocationChange((event.state ?? {}) as HistorySnapshot);
+});
+
+window.addEventListener("hashchange", () => {
+  handleLocationChange();
+});
+
+void start();

--- a/apps/public-explorer/src/state.ts
+++ b/apps/public-explorer/src/state.ts
@@ -1,0 +1,212 @@
+import { DEFAULT_RECORD_ID } from "./catalogue.js";
+import {
+  ACCESS_STATES,
+  AUTHORITY_CLASSES,
+  EXPLORER_VIEWS,
+  FRESHNESS_STATUSES,
+  RECORD_TYPES,
+  RIGHTS_STATES,
+  type CatalogueBundle,
+  type ExplorerState,
+} from "./types.js";
+
+export const MAX_QUERY_LENGTH = 200;
+export const MAX_FACET_VALUES = 20;
+const MAX_TAG_LENGTH = 128;
+const MAX_RECORD_ID_LENGTH = 512;
+const UNSAFE_CONTROL = /[\u0000-\u001f\u007f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function normaliseQuery(value: string): string {
+  if (UNSAFE_CONTROL.test(value)) {
+    return "";
+  }
+  const bounded = [...value.normalize("NFKC").replace(/\s+/gu, " ").trim()]
+    .slice(0, MAX_QUERY_LENGTH)
+    .join("")
+    .trim();
+  return bounded.split(" ").slice(0, 10).join(" ");
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): readonly T[] {
+  return [...new Set(values)].sort(compareText);
+}
+
+function controlledValues<const T extends readonly string[]>(
+  values: readonly string[],
+  allowed: T,
+): readonly T[number][] {
+  if (values.length > MAX_FACET_VALUES) {
+    return [];
+  }
+  const allowedSet = new Set<string>(allowed);
+  return uniqueSorted(values.filter((value): value is T[number] => allowedSet.has(value)));
+}
+
+function knownTags(bundle: CatalogueBundle): ReadonlySet<string> {
+  return new Set(bundle.records.flatMap((record) => record.tags));
+}
+
+export function createDefaultExplorerState(bundle: CatalogueBundle): ExplorerState {
+  if (!bundle.records.some((record) => record.id === DEFAULT_RECORD_ID)) {
+    throw new Error(`Catalogue does not contain the default record ${DEFAULT_RECORD_ID}`);
+  }
+  return {
+    view: "cards",
+    query: "inspire",
+    types: ["dataset"],
+    authority: [],
+    access: [],
+    rights: [],
+    freshness: [],
+    tags: [],
+    selectedRecordId: DEFAULT_RECORD_ID,
+  };
+}
+
+/** Constrain a caller-created state to values present in the validated bundle. */
+export function canonicaliseState(
+  state: ExplorerState,
+  bundle: CatalogueBundle,
+): ExplorerState {
+  const tags = knownTags(bundle);
+  return {
+    view: EXPLORER_VIEWS.includes(state.view) ? state.view : "cards",
+    query: normaliseQuery(state.query),
+    types: controlledValues(state.types, RECORD_TYPES),
+    authority: controlledValues(state.authority, AUTHORITY_CLASSES),
+    access: controlledValues(state.access, ACCESS_STATES),
+    rights: controlledValues(state.rights, RIGHTS_STATES),
+    freshness: controlledValues(state.freshness, FRESHNESS_STATUSES),
+    tags:
+      state.tags.length > MAX_FACET_VALUES
+        ? []
+        : uniqueSorted(
+            state.tags.filter(
+              (tag) => tag.length <= MAX_TAG_LENGTH && !UNSAFE_CONTROL.test(tag) && tags.has(tag),
+            ),
+          ),
+    selectedRecordId:
+      state.selectedRecordId !== null &&
+      state.selectedRecordId.length <= MAX_RECORD_ID_LENGTH &&
+      !UNSAFE_CONTROL.test(state.selectedRecordId)
+        ? state.selectedRecordId
+        : null,
+  };
+}
+
+function singleParameter(search: URLSearchParams, key: string): string | null {
+  const values = search.getAll(key);
+  return values.length === 1 ? (values[0] ?? null) : null;
+}
+
+function parseControlled<const T extends readonly string[]>(
+  search: URLSearchParams,
+  key: string,
+  allowed: T,
+): readonly T[number][] {
+  return controlledValues(search.getAll(key), allowed);
+}
+
+function selectedRecordFromHash(url: URL): string | null {
+  if (url.hash.length === 0 || url.hash === "#") {
+    return null;
+  }
+  const hash = new URLSearchParams(url.hash.slice(1));
+  if ([...hash.keys()].some((key) => key !== "record")) {
+    return null;
+  }
+  const selected = singleParameter(hash, "record");
+  if (
+    selected === null ||
+    selected.length === 0 ||
+    selected.length > MAX_RECORD_ID_LENGTH ||
+    UNSAFE_CONTROL.test(selected)
+  ) {
+    return null;
+  }
+  return selected;
+}
+
+/** Parse only the documented query and hash fields; all other state is discarded. */
+export function parseExplorerUrl(
+  input: string | URL,
+  bundle: CatalogueBundle,
+): ExplorerState {
+  const url = input instanceof URL ? new URL(input.href) : new URL(input, "https://invalid.local/");
+  const query = singleParameter(url.searchParams, "q");
+  const view = singleParameter(url.searchParams, "view");
+  const tagSet = knownTags(bundle);
+  const rawTags = url.searchParams.getAll("tag");
+  const parsed: ExplorerState = {
+    view: view !== null && EXPLORER_VIEWS.includes(view as (typeof EXPLORER_VIEWS)[number])
+      ? (view as (typeof EXPLORER_VIEWS)[number])
+      : "cards",
+    query: query !== null && query.length <= MAX_QUERY_LENGTH ? normaliseQuery(query) : "",
+    types: parseControlled(url.searchParams, "type", RECORD_TYPES),
+    authority: parseControlled(url.searchParams, "authority", AUTHORITY_CLASSES),
+    access: parseControlled(url.searchParams, "access", ACCESS_STATES),
+    rights: parseControlled(url.searchParams, "rights", RIGHTS_STATES),
+    freshness: parseControlled(url.searchParams, "freshness", FRESHNESS_STATUSES),
+    tags:
+      rawTags.length > MAX_FACET_VALUES
+        ? []
+        : uniqueSorted(
+            rawTags.filter(
+              (tag) => tag.length <= MAX_TAG_LENGTH && !UNSAFE_CONTROL.test(tag) && tagSet.has(tag),
+            ),
+          ),
+    selectedRecordId: selectedRecordFromHash(url),
+  };
+  return canonicaliseState(parsed, bundle);
+}
+
+/** Serialise a canonical, shareable Explorer URL with stable parameter ordering. */
+export function serialiseExplorerUrl(
+  state: ExplorerState,
+  base: string | URL,
+  bundle: CatalogueBundle,
+): URL {
+  const canonical = canonicaliseState(state, bundle);
+  const url = base instanceof URL ? new URL(base.href) : new URL(base);
+  const search = new URLSearchParams();
+  search.append("view", canonical.view);
+  if (canonical.query) {
+    search.append("q", canonical.query);
+  }
+  const add = (key: string, values: readonly string[]): void => {
+    values.forEach((value) => search.append(key, value));
+  };
+  add("type", canonical.types);
+  add("authority", canonical.authority);
+  add("access", canonical.access);
+  add("rights", canonical.rights);
+  add("freshness", canonical.freshness);
+  add("tag", canonical.tags);
+  url.search = search.toString();
+
+  if (canonical.selectedRecordId === null) {
+    url.hash = "";
+  } else {
+    const hash = new URLSearchParams({ record: canonical.selectedRecordId });
+    url.hash = hash.toString();
+  }
+  return url;
+}
+
+export function explorerStatesEqual(left: ExplorerState, right: ExplorerState): boolean {
+  return (
+    left.view === right.view &&
+    left.query === right.query &&
+    left.selectedRecordId === right.selectedRecordId &&
+    left.types.join("\u0000") === right.types.join("\u0000") &&
+    left.authority.join("\u0000") === right.authority.join("\u0000") &&
+    left.access.join("\u0000") === right.access.join("\u0000") &&
+    left.rights.join("\u0000") === right.rights.join("\u0000") &&
+    left.freshness.join("\u0000") === right.freshness.join("\u0000") &&
+    left.tags.join("\u0000") === right.tags.join("\u0000")
+  );
+}

--- a/apps/public-explorer/src/styles.css
+++ b/apps/public-explorer/src/styles.css
@@ -1,0 +1,659 @@
+:root {
+  color: #0b0c0c;
+  background: #ffffff;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 100%;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 20rem;
+  scroll-padding-block-start: 1rem;
+}
+
+body {
+  min-width: 20rem;
+  margin: 0;
+  background: #ffffff;
+  color: #0b0c0c;
+}
+
+a {
+  color: #1d70b8;
+  text-decoration-thickness: max(1px, 0.0625rem);
+  text-underline-offset: 0.18em;
+}
+
+a:visited {
+  color: #4c2c92;
+}
+
+a:hover {
+  color: #003078;
+  text-decoration-thickness: max(3px, 0.1875rem);
+}
+
+:focus-visible {
+  outline: 3px solid #ffdd00;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px #0b0c0c;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.no-js #explorer-root > [role="status"] {
+  display: none;
+}
+
+.page-width {
+  width: min(100% - 2rem, 76rem);
+  margin-inline: auto;
+}
+
+.skip-link {
+  position: absolute;
+  z-index: 20;
+  top: -10rem;
+  left: 1rem;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+  background: #ffdd00;
+  color: #0b0c0c;
+  font-weight: 700;
+}
+
+.skip-link:focus {
+  top: 0.75rem;
+}
+
+.site-header {
+  border-bottom: 0.5rem solid #00a33b;
+  padding-block: 1.25rem;
+  background: #0b0c0c;
+  color: #ffffff;
+}
+
+.product-name {
+  margin: 0;
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.product-description,
+.boundary-label {
+  max-width: 55rem;
+  margin: 0.5rem 0 0;
+}
+
+.boundary-label {
+  font-weight: 700;
+}
+
+main {
+  display: block;
+  padding-block: 2rem 4rem;
+}
+
+h1,
+h2,
+h3 {
+  max-width: 32em;
+  margin-block: 1.5em 0.5em;
+  line-height: 1.2;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+}
+
+h2 {
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
+}
+
+h3 {
+  font-size: 1.25rem;
+}
+
+p,
+li,
+dd,
+dt,
+summary,
+label,
+button,
+input {
+  overflow-wrap: anywhere;
+}
+
+p,
+.measure {
+  max-width: 70ch;
+}
+
+.lede {
+  max-width: 52rem;
+  font-size: 1.25rem;
+}
+
+.answer-panel {
+  border: 2px solid #0b0c0c;
+  border-left: 0.6rem solid #00703c;
+  margin-block: 1.5rem 2rem;
+  padding: 1rem 1.25rem;
+  background: #f3f2f1;
+}
+
+.answer-panel strong:first-child {
+  font-size: 1.35rem;
+}
+
+.warning-panel {
+  border-left: 0.5rem solid #d4351c;
+  margin-block: 1rem;
+  padding: 0.75rem 1rem;
+  background: #f3f2f1;
+}
+
+.warning-panel > :first-child {
+  margin-top: 0;
+}
+
+.warning-panel > :last-child {
+  margin-bottom: 0;
+}
+
+.search-panel {
+  border-top: 1px solid #b1b4b6;
+  border-bottom: 1px solid #b1b4b6;
+  margin-block: 2rem;
+  padding-block: 1.5rem;
+}
+
+.form-group {
+  max-width: 48rem;
+  margin-block: 1rem;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 700;
+}
+
+.hint {
+  display: block;
+  margin-block: 0.25rem 0.5rem;
+  color: #505a5f;
+}
+
+.search-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+  max-width: 48rem;
+}
+
+input[type="search"] {
+  min-width: 0;
+  min-height: 2.75rem;
+  flex: 1 1 18rem;
+  border: 2px solid #0b0c0c;
+  border-radius: 0;
+  padding: 0.55rem 0.65rem;
+  background: #ffffff;
+  color: #0b0c0c;
+  font: inherit;
+}
+
+button,
+.button-link {
+  min-height: 2.75rem;
+  border: 2px solid #0b0c0c;
+  border-radius: 0;
+  padding: 0.55rem 1rem;
+  background: #1d70b8;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+button:hover,
+.button-link:hover {
+  background: #003078;
+  color: #ffffff;
+}
+
+.secondary-button {
+  background: #ffffff;
+  color: #0b0c0c;
+}
+
+.secondary-button:hover {
+  background: #f3f2f1;
+  color: #0b0c0c;
+}
+
+.facet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+  gap: 1rem;
+  margin-block: 1.25rem;
+}
+
+.facet-group {
+  min-width: 0;
+  border: 1px solid #b1b4b6;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.facet-group legend {
+  padding-inline: 0.25rem;
+  font-weight: 700;
+}
+
+.checkbox-item {
+  position: relative;
+  display: flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.checkbox-item input {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.checkbox-item label {
+  display: flex;
+  min-height: 2.75rem;
+  flex: 1 1 auto;
+  align-items: center;
+  cursor: pointer;
+}
+
+.view-navigation {
+  border-bottom: 1px solid #b1b4b6;
+  margin-block: 2rem 1rem;
+}
+
+.view-navigation ul,
+.download-list,
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.view-navigation a {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  border-bottom: 0.3rem solid transparent;
+  padding: 0.4rem 0.25rem 0.25rem;
+  font-weight: 700;
+}
+
+.view-navigation a[aria-current="page"] {
+  border-bottom-color: currentColor;
+  color: #0b0c0c;
+  text-decoration: none;
+}
+
+.result-summary {
+  margin-block: 1rem;
+  font-weight: 700;
+}
+
+.result-list {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.record-card {
+  border: 1px solid #b1b4b6;
+  border-left: 0.4rem solid #1d70b8;
+  padding: 1rem 1.25rem;
+}
+
+.record-card h3 {
+  margin-top: 0;
+}
+
+.record-card > :last-child {
+  margin-bottom: 0;
+}
+
+.metadata-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-block: 0.75rem;
+}
+
+.status-tag,
+.topic-tag {
+  display: inline-block;
+  border: 1px solid currentColor;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.topic-tag {
+  font-weight: 400;
+}
+
+.record-detail {
+  border-top: 0.35rem solid #0b0c0c;
+  margin-block: 2rem;
+  padding-top: 1rem;
+}
+
+.back-link {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.metadata-list {
+  display: grid;
+  grid-template-columns: minmax(10rem, 15rem) minmax(0, 1fr);
+  max-width: 64rem;
+  border-top: 1px solid #b1b4b6;
+  margin-block: 1rem;
+}
+
+.metadata-list dt,
+.metadata-list dd {
+  border-bottom: 1px solid #b1b4b6;
+  margin: 0;
+  padding: 0.65rem;
+}
+
+.metadata-list dt {
+  font-weight: 700;
+}
+
+.citation-box {
+  max-width: 70ch;
+  border: 2px solid #0b0c0c;
+  padding: 1rem;
+  background: #f3f2f1;
+}
+
+.citation-box p {
+  margin-top: 0;
+}
+
+.copy-status {
+  min-height: 1.5em;
+  margin-bottom: 0;
+}
+
+.visual-and-alternative {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.visual-panel {
+  max-width: 100%;
+  overflow: auto;
+  border: 1px solid #b1b4b6;
+  padding: 1rem;
+}
+
+.visual-panel svg {
+  display: block;
+  width: 100%;
+  min-width: 34rem;
+  height: auto;
+}
+
+.graph-node rect,
+.graph-node circle,
+.graph-node path,
+.map-area,
+.map-symbol {
+  fill: #ffffff;
+  stroke: #0b0c0c;
+  stroke-width: 2;
+}
+
+.graph-node--match rect,
+.graph-node--match circle {
+  fill: #d2e2f1;
+  stroke-width: 4;
+}
+
+.graph-edge,
+.map-connector {
+  fill: none;
+  stroke: #505a5f;
+  stroke-width: 2;
+}
+
+.graph-label,
+.map-label {
+  fill: #0b0c0c;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.adjacency-list,
+.timeline-list,
+.map-alternative {
+  max-width: 70ch;
+}
+
+.adjacency-list > li,
+.timeline-list > li {
+  border-bottom: 1px solid #b1b4b6;
+  padding-block: 0.75rem;
+}
+
+.adjacency-list ul {
+  margin-block: 0.25rem 0.5rem;
+}
+
+.timeline-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+  gap: 0.75rem;
+  margin-block: 1rem;
+}
+
+.timeline-legend > div {
+  border: 1px solid #b1b4b6;
+  padding: 0.75rem;
+}
+
+.timeline-legend dt {
+  font-weight: 700;
+}
+
+.timeline-legend dd {
+  margin: 0.25rem 0 0;
+}
+
+.timeline-event-type {
+  display: block;
+  font-weight: 700;
+}
+
+.empty-state,
+.error-state {
+  border: 2px solid #0b0c0c;
+  padding: 1rem;
+}
+
+.error-state {
+  border-left: 0.5rem solid #d4351c;
+}
+
+.about-section,
+.downloads-section {
+  border-top: 1px solid #b1b4b6;
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+}
+
+.download-list a {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+}
+
+.site-footer {
+  border-top: 1px solid #b1b4b6;
+  padding-block: 1.5rem 2.5rem;
+  background: #f3f2f1;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+}
+
+@media (max-width: 48rem) {
+  .search-row,
+  .visual-and-alternative {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .search-row button {
+    justify-self: start;
+  }
+
+  .metadata-list {
+    display: block;
+  }
+
+  .metadata-list dt {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .metadata-list dd {
+    padding-top: 0.25rem;
+  }
+
+  .visual-panel svg {
+    min-width: 30rem;
+  }
+}
+
+@media (max-width: 24rem) {
+  .page-width {
+    width: min(100% - 1rem, 76rem);
+  }
+
+  .view-navigation ul,
+  .download-list {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .view-navigation a,
+  .download-list a {
+    width: fit-content;
+  }
+}
+
+@media (forced-colors: active) {
+  .site-header,
+  button,
+  .button-link,
+  .answer-panel,
+  .warning-panel,
+  .citation-box,
+  .site-footer,
+  .graph-node--match rect,
+  .graph-node--match circle {
+    background: Canvas;
+    color: CanvasText;
+  }
+
+  .site-header,
+  .record-card,
+  .answer-panel,
+  .warning-panel,
+  .record-detail,
+  .status-tag,
+  .topic-tag {
+    border-color: CanvasText;
+  }
+
+  a,
+  a:visited {
+    color: LinkText;
+  }
+
+  :focus-visible {
+    outline-color: Highlight;
+    box-shadow: 0 0 0 2px Canvas;
+  }
+
+  .graph-node rect,
+  .graph-node circle,
+  .graph-node path,
+  .map-area,
+  .map-symbol {
+    fill: Canvas;
+    stroke: CanvasText;
+  }
+
+  .graph-edge,
+  .map-connector {
+    stroke: CanvasText;
+  }
+
+  .graph-label,
+  .map-label {
+    fill: CanvasText;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/apps/public-explorer/src/types.ts
+++ b/apps/public-explorer/src/types.ts
@@ -1,0 +1,199 @@
+export const RECORD_TYPES = ["bundle", "dataset", "provider", "source", "workflow"] as const;
+export type RecordType = (typeof RECORD_TYPES)[number];
+
+export const AUTHORITY_CLASSES = [
+  "derived",
+  "project-authoritative",
+  "source-authoritative",
+] as const;
+export type AuthorityClass = (typeof AUTHORITY_CLASSES)[number];
+
+export const ACCESS_STATES = ["planned-non-executing", "public", "public-metadata"] as const;
+export type AccessState = (typeof ACCESS_STATES)[number];
+
+export const RIGHTS_STATES = [
+  "metadata-citation",
+  "open-with-conditions",
+  "project-mit",
+] as const;
+export type RightsState = (typeof RIGHTS_STATES)[number];
+
+export const RECORD_STATUSES = [
+  "candidate",
+  "candidate-metadata",
+  "candidate-non-executing",
+  "external-source",
+] as const;
+export type RecordStatus = (typeof RECORD_STATUSES)[number];
+
+export const FRESHNESS_STATUSES = ["current", "review-required"] as const;
+export type FreshnessStatus = (typeof FRESHNESS_STATUSES)[number];
+
+export const EXPLORER_VIEWS = ["cards", "graph", "timeline", "map"] as const;
+export type ExplorerView = (typeof EXPLORER_VIEWS)[number];
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | readonly JsonValue[] | { readonly [key: string]: JsonValue };
+
+export interface RecordAuthority {
+  readonly class: AuthorityClass;
+  readonly statement: string;
+  readonly source: string;
+}
+
+export interface PublicationEnvelope {
+  readonly classification: "public";
+  readonly containsPersonalData: false;
+  readonly containsProtectedData: false;
+}
+
+export interface RecordAccess {
+  readonly tier: "open";
+  readonly state: AccessState;
+  readonly authentication: string;
+}
+
+export interface RecordRights {
+  readonly state: RightsState;
+  readonly recordLicence: string;
+  readonly describedResourceLicence: string;
+  readonly attribution: string;
+}
+
+export interface RecordFreshness {
+  readonly observedAt: string;
+  readonly reviewedAt: string;
+  readonly staleAfter: string;
+  readonly status: FreshnessStatus;
+}
+
+export interface CatalogueRecord {
+  readonly schema: "gis-ai-go-okf-concept.v1";
+  readonly id: string;
+  readonly type: RecordType;
+  readonly title: string;
+  readonly description: string;
+  readonly authority: RecordAuthority;
+  readonly publication: PublicationEnvelope;
+  readonly access: RecordAccess;
+  readonly rights: RecordRights;
+  readonly freshness: RecordFreshness;
+  readonly status: RecordStatus;
+  readonly sourceRefs: readonly string[];
+  readonly limitations: readonly string[];
+  readonly tags: readonly string[];
+  readonly details: Readonly<Record<string, JsonValue>>;
+}
+
+export interface CatalogueBundle {
+  readonly schema: "gis-ai-go-okf-bundle.v1";
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly okfVersion: "0.2";
+  readonly profile: string;
+  readonly profileStatus: "candidate-pending-consumer-acceptance";
+  readonly version: string;
+  readonly revision: string;
+  readonly status: "candidate";
+  readonly authority: {
+    readonly bundleAuthority: string;
+    readonly officialSourceAuthority: string;
+    readonly legalAdvice: false;
+    readonly notEndorsedBySource: true;
+  };
+  readonly scope: {
+    readonly kind: "bounded-public-metadata-discovery";
+    readonly metadataOnly: true;
+    readonly containsProtectedData: false;
+    readonly excludes: readonly string[];
+  };
+  readonly rights: {
+    readonly statement: string;
+    readonly thirdPartyNotices: "THIRD_PARTY.md";
+  };
+  readonly observedAt: string;
+  readonly reviewedAt: string;
+  readonly staleAfter: string;
+  readonly recordCount: number;
+  readonly records: readonly CatalogueRecord[];
+}
+
+export interface ExplorerState {
+  readonly view: ExplorerView;
+  readonly query: string;
+  readonly types: readonly RecordType[];
+  readonly authority: readonly AuthorityClass[];
+  readonly access: readonly AccessState[];
+  readonly rights: readonly RightsState[];
+  readonly freshness: readonly FreshnessStatus[];
+  readonly tags: readonly string[];
+  readonly selectedRecordId: string | null;
+}
+
+export interface FacetOption<T extends string = string> {
+  readonly value: T;
+  readonly count: number;
+}
+
+export interface FacetOptions {
+  readonly types: readonly FacetOption<RecordType>[];
+  readonly authority: readonly FacetOption<AuthorityClass>[];
+  readonly access: readonly FacetOption<AccessState>[];
+  readonly rights: readonly FacetOption<RightsState>[];
+  readonly freshness: readonly FacetOption<FreshnessStatus>[];
+  readonly tags: readonly FacetOption[];
+}
+
+export interface GraphNode {
+  readonly id: string;
+  readonly type: RecordType;
+  readonly title: string;
+  readonly status: RecordStatus;
+  readonly explicitlyIncluded: boolean;
+}
+
+export interface GraphEdge {
+  readonly from: string;
+  readonly to: string;
+  readonly relation: "source";
+  readonly selfReference: boolean;
+}
+
+export interface GraphAdjacency {
+  readonly recordId: string;
+  readonly recordTitle: string;
+  readonly sourceIds: readonly string[];
+}
+
+export interface GraphModel {
+  readonly nodes: readonly GraphNode[];
+  readonly edges: readonly GraphEdge[];
+  readonly adjacency: readonly GraphAdjacency[];
+}
+
+export const TIMELINE_EVENT_KINDS = [
+  "observation",
+  "modification",
+  "publication",
+  "release",
+] as const;
+export type TimelineEventKind = (typeof TIMELINE_EVENT_KINDS)[number];
+
+export interface TimelineEvent {
+  readonly id: string;
+  readonly recordId: string;
+  readonly recordTitle: string;
+  readonly kind: TimelineEventKind;
+  readonly date: string;
+}
+
+export interface TimelineMissingSummary {
+  readonly kind: TimelineEventKind;
+  readonly recordCount: number;
+}
+
+export interface TimelineModel {
+  readonly events: readonly TimelineEvent[];
+  readonly missing: readonly TimelineMissingSummary[];
+}

--- a/apps/public-explorer/src/views/cards.ts
+++ b/apps/public-explorer/src/views/cards.ts
@@ -1,0 +1,300 @@
+import {
+  appendChildren,
+  bulletList,
+  button,
+  definitionList,
+  element,
+  formatDate,
+  humaniseToken,
+  link,
+  recordHeadingId,
+  time,
+} from "../dom";
+import { safeNavigableHref } from "../links";
+import type { CatalogueRecord, JsonValue } from "../types";
+
+export interface CardNavigation {
+  readonly hrefForRecord: (recordId: string | null) => string;
+  readonly selectRecord: (recordId: string | null) => void;
+}
+
+function stringDetail(record: CatalogueRecord, name: string): string | null {
+  const value = record.details[name];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function stringArrayDetail(record: CatalogueRecord, name: string): readonly string[] {
+  const value = record.details[name];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function firstLimitation(record: CatalogueRecord): string {
+  const legalWarning = record.limitations.find((limitation) =>
+    /indicative|legal|definitive|ownership|boundary/iu.test(limitation),
+  );
+  return legalWarning ?? record.limitations[0] ?? "Consult the source before reuse.";
+}
+
+function navigationLink(
+  label: string,
+  recordId: string | null,
+  navigation: CardNavigation,
+  className?: string,
+): HTMLAnchorElement {
+  const node = link(label, navigation.hrefForRecord(recordId), className);
+  node.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    navigation.selectRecord(recordId);
+  });
+  return node;
+}
+
+function renderTags(record: CatalogueRecord): HTMLUListElement {
+  const list = element("ul", { className: "tag-list", id: `tags-${encodeURIComponent(record.id)}` });
+  for (const tag of record.tags) {
+    list.append(element("li", { className: "topic-tag", text: tag }));
+  }
+  return list;
+}
+
+export function renderRecordCard(
+  record: CatalogueRecord,
+  navigation: CardNavigation,
+): HTMLLIElement {
+  const item = element("li");
+  const article = element("article", { className: "record-card" });
+  const heading = element("h3");
+  heading.append(navigationLink(record.title, record.id, navigation));
+  const warningId = `warning-${encodeURIComponent(record.id)}`;
+  article.setAttribute("aria-describedby", warningId);
+  article.append(
+    heading,
+    element("p", { text: record.description }),
+    element("div", { className: "metadata-summary" }, [
+      element("span", { className: "status-tag", text: humaniseToken(record.type) }),
+      element("span", {
+        className: "status-tag",
+        text: humaniseToken(record.authority.class),
+      }),
+      element("span", {
+        className: "status-tag",
+        text: humaniseToken(record.rights.state),
+      }),
+    ]),
+    element("p", {
+      className: "warning-panel",
+      id: warningId,
+      text: `Important limitation: ${firstLimitation(record)}`,
+    }),
+    element("p", {}, [
+      "Observed ",
+      time(record.freshness.observedAt),
+      ". Review by ",
+      time(record.freshness.staleAfter),
+      ".",
+    ]),
+    renderTags(record),
+  );
+  item.append(article);
+  return item;
+}
+
+function publisherName(record: CatalogueRecord): string {
+  return stringDetail(record, "publisher") ??
+    stringDetail(record, "organisation") ??
+    "GIS AI GO catalogue";
+}
+
+function citationText(record: CatalogueRecord): string {
+  return `${publisherName(record)}, “${record.title}” (${record.id}), metadata observed ${formatDate(
+    record.freshness.observedAt,
+  )}; GIS AI GO metadata projection reviewed ${formatDate(record.freshness.reviewedAt)}.`;
+}
+
+function renderCitation(record: CatalogueRecord): HTMLElement {
+  const section = element("section", { className: "citation-box" });
+  const headingId = `citation-${encodeURIComponent(record.id)}`;
+  const citationId = `citation-text-${encodeURIComponent(record.id)}`;
+  section.setAttribute("aria-labelledby", headingId);
+  const copyButton = button("Copy citation", "secondary-button");
+  const status = element("p", { className: "copy-status" });
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
+  const citation = citationText(record);
+  copyButton.addEventListener("click", () => {
+    void navigator.clipboard
+      ?.writeText(citation)
+      .then(() => {
+        status.textContent = "Citation copied.";
+      })
+      .catch(() => {
+        status.textContent = "Copy unavailable. Select and copy the citation text.";
+      });
+    if (navigator.clipboard === undefined) {
+      status.textContent = "Copy unavailable. Select and copy the citation text.";
+    }
+  });
+  section.append(
+    element("h3", { id: headingId, text: "Cite this catalogue record" }),
+    element("p", { id: citationId, text: citation }),
+    copyButton,
+    status,
+  );
+  copyButton.setAttribute("aria-describedby", citationId);
+  return section;
+}
+
+function externalSourceLink(record: CatalogueRecord): HTMLAnchorElement | null {
+  const candidates = [stringDetail(record, "url"), record.authority.source];
+  for (const candidate of candidates) {
+    if (candidate === null || !/^https:/iu.test(candidate)) {
+      continue;
+    }
+    const safe = safeNavigableHref(candidate, document.baseURI);
+    if (safe !== null) {
+      return link(`Official source: ${new URL(candidate).hostname}`, safe);
+    }
+  }
+  return null;
+}
+
+function detailRows(record: CatalogueRecord): ReturnType<typeof definitionList> {
+  const formats = stringArrayDetail(record, "formats");
+  const rows = [
+    { term: "Source-native ID", description: record.id },
+    { term: "Record type", description: humaniseToken(record.type) },
+    { term: "Publisher", description: publisherName(record) },
+    { term: "Authority", description: `${humaniseToken(record.authority.class)} — ${record.authority.statement}` },
+    { term: "Publication classification", description: "Public metadata" },
+    { term: "Contains personal data", description: "No" },
+    { term: "Contains protected data", description: "No" },
+    { term: "Access", description: `${humaniseToken(record.access.state)}; ${record.access.authentication}` },
+    { term: "Rights state", description: humaniseToken(record.rights.state) },
+    { term: "Record licence", description: record.rights.recordLicence },
+    { term: "Described resource licence", description: record.rights.describedResourceLicence },
+    { term: "Attribution", description: record.rights.attribution },
+    { term: "Observed", description: time(record.freshness.observedAt) },
+    { term: "Reviewed", description: time(record.freshness.reviewedAt) },
+    { term: "Review by", description: time(record.freshness.staleAfter) },
+  ];
+
+  const jurisdiction = stringDetail(record, "jurisdiction");
+  const cadence = stringDetail(record, "cadence");
+  const accessModel = stringDetail(record, "accessModel");
+  if (jurisdiction !== null) {
+    rows.push({ term: "Geographic coverage", description: jurisdiction });
+  }
+  if (cadence !== null) {
+    rows.push({ term: "Update cadence", description: cadence });
+  }
+  if (accessModel !== null) {
+    rows.push({ term: "Source access model", description: accessModel });
+  }
+  if (formats.length > 0) {
+    rows.push({ term: "Formats", description: formats.join(", ") });
+  }
+  return definitionList(rows);
+}
+
+function renderSourceReferences(
+  record: CatalogueRecord,
+  recordsById: ReadonlyMap<string, CatalogueRecord>,
+  navigation: CardNavigation,
+): HTMLElement {
+  const section = element("section");
+  section.append(element("h3", { text: "Source evidence" }));
+  const list = element("ul");
+  for (const sourceId of record.sourceRefs) {
+    const source = recordsById.get(sourceId);
+    const item = element("li");
+    if (source === undefined || sourceId === record.id) {
+      item.textContent = source?.title ?? sourceId;
+    } else {
+      item.append(navigationLink(source.title, source.id, navigation));
+    }
+    list.append(item);
+  }
+  section.append(list);
+  const official = externalSourceLink(record);
+  if (official !== null) {
+    section.append(element("p", {}, [official]));
+  }
+  return section;
+}
+
+export function renderRecordDetail(
+  record: CatalogueRecord,
+  allRecords: readonly CatalogueRecord[],
+  navigation: CardNavigation,
+): HTMLElement {
+  const article = element("article", { className: "record-detail" });
+  const headingId = recordHeadingId(record.id);
+  article.setAttribute("aria-labelledby", headingId);
+  article.append(
+    navigationLink("Back to catalogue", null, navigation, "back-link"),
+    element("h2", { id: headingId, text: record.title }),
+    element("p", { className: "lede", text: record.description }),
+    element("div", { className: "warning-panel" }, [
+      element("h3", { text: "Important limitations" }),
+      bulletList(record.limitations),
+    ]),
+    detailRows(record),
+    renderSourceReferences(
+      record,
+      new Map(allRecords.map((candidate) => [candidate.id, candidate])),
+      navigation,
+    ),
+    element("section", {}, [
+      element("h3", { text: "Topics" }),
+      renderTags(record),
+    ]),
+    renderCitation(record),
+  );
+  return article;
+}
+
+export function renderCardsView(
+  records: readonly CatalogueRecord[],
+  allRecords: readonly CatalogueRecord[],
+  selectedRecord: CatalogueRecord | null,
+  navigation: CardNavigation,
+): HTMLElement {
+  const section = element("section");
+  section.setAttribute("aria-labelledby", "view-heading-cards");
+  section.append(element("h2", { id: "view-heading-cards", text: "Catalogue" }));
+
+  if (selectedRecord !== null) {
+    section.append(renderRecordDetail(selectedRecord, allRecords, navigation));
+    return section;
+  }
+
+  if (records.length === 0) {
+    section.append(
+      element("div", { className: "empty-state" }, [
+        element("h3", { text: "No catalogue records found" }),
+        element("p", { text: "Change or clear the search and filters to see more records." }),
+      ]),
+    );
+    return section;
+  }
+
+  const list = element("ol", { className: "result-list" });
+  for (const record of records) {
+    list.append(renderRecordCard(record, navigation));
+  }
+  section.append(list);
+  return section;
+}

--- a/apps/public-explorer/src/views/graph.ts
+++ b/apps/public-explorer/src/views/graph.ts
@@ -1,0 +1,216 @@
+import { element, link, svgElement } from "../dom";
+import type { CatalogueRecord, GraphEdge, GraphModel, GraphNode } from "../types";
+
+export interface GraphNavigation {
+  readonly hrefForRecord: (recordId: string | null) => string;
+  readonly selectRecord: (recordId: string | null) => void;
+}
+
+interface PositionedNode {
+  readonly node: GraphNode;
+  readonly x: number;
+  readonly y: number;
+}
+
+function recordLink(
+  record: GraphNode,
+  navigation: GraphNavigation,
+): HTMLAnchorElement {
+  const node = link(record.title, navigation.hrefForRecord(record.id));
+  node.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    navigation.selectRecord(record.id);
+  });
+  return node;
+}
+
+function visualEdges(model: GraphModel): readonly GraphEdge[] {
+  return model.edges.filter(
+    (edge) => !edge.selfReference && edge.from !== edge.to,
+  );
+}
+
+function positions(nodes: readonly GraphNode[]): readonly PositionedNode[] {
+  const columns = nodes.length <= 4 ? 2 : 3;
+  const columnWidth = 260;
+  const rowHeight = 120;
+  return nodes.map((node, index) => ({
+    node,
+    x: 30 + (index % columns) * columnWidth,
+    y: 30 + Math.floor(index / columns) * rowHeight,
+  }));
+}
+
+function clippedLabel(value: string): string {
+  return value.length > 33 ? `${value.slice(0, 30)}…` : value;
+}
+
+function renderGraphVisual(model: GraphModel): HTMLElement {
+  const wrapper = element("div", { className: "visual-panel" });
+  wrapper.append(
+    element("p", {
+      className: "hint",
+      text: "Visual evidence graph. The complete relationship list follows.",
+    }),
+  );
+  const positioned = positions(model.nodes);
+  const byId = new Map(positioned.map((item) => [item.node.id, item]));
+  const columns = model.nodes.length <= 4 ? 2 : 3;
+  const rows = Math.max(1, Math.ceil(model.nodes.length / columns));
+  const svg = svgElement("svg", {
+    "aria-hidden": "true",
+    focusable: "false",
+    role: "presentation",
+    viewBox: `0 0 ${columns * 260 + 30} ${rows * 120 + 30}`,
+  });
+
+  for (const edge of visualEdges(model)) {
+    const from = byId.get(edge.from);
+    const to = byId.get(edge.to);
+    if (from === undefined || to === undefined) {
+      continue;
+    }
+    svg.append(
+      svgElement("line", {
+        class: "graph-edge",
+        x1: String(from.x + 95),
+        y1: String(from.y + 32),
+        x2: String(to.x + 95),
+        y2: String(to.y + 32),
+      }),
+    );
+  }
+
+  for (const item of positioned) {
+    const group = svgElement("g", {
+      class: `graph-node${item.node.explicitlyIncluded ? " graph-node--match" : ""}`,
+      transform: `translate(${item.x} ${item.y})`,
+    });
+    group.append(
+      svgElement("rect", { height: "66", rx: "0", width: "190", x: "0", y: "0" }),
+    );
+    const title = svgElement("text", { class: "graph-label", x: "10", y: "25" });
+    title.textContent = clippedLabel(item.node.title);
+    const kind = svgElement("text", { class: "graph-label", x: "10", y: "49" });
+    kind.textContent = `${item.node.type}${item.node.explicitlyIncluded ? " — match" : " — source context"}`;
+    group.append(title, kind);
+    svg.append(group);
+  }
+  wrapper.append(svg);
+  return wrapper;
+}
+
+function relatedNodes(
+  nodeId: string,
+  edges: readonly GraphEdge[],
+  direction: "from" | "to",
+): readonly string[] {
+  const values = edges
+    .filter((edge) => edge[direction] === nodeId)
+    .map((edge) => (direction === "from" ? edge.to : edge.from));
+  return [...new Set(values)].sort();
+}
+
+function relationList(
+  label: string,
+  relatedIds: readonly string[],
+  nodesById: ReadonlyMap<string, GraphNode>,
+  navigation: GraphNavigation,
+): HTMLDivElement {
+  const container = element("div");
+  container.append(element("h4", { text: label }));
+  if (relatedIds.length === 0) {
+    container.append(element("p", { text: "None" }));
+    return container;
+  }
+  const list = element("ul");
+  for (const recordId of relatedIds) {
+    const record = nodesById.get(recordId);
+    const item = element("li");
+    if (record === undefined) {
+      item.textContent = recordId;
+    } else {
+      item.append(recordLink(record, navigation));
+    }
+    list.append(item);
+  }
+  container.append(list);
+  return container;
+}
+
+function renderAdjacency(model: GraphModel, navigation: GraphNavigation): HTMLElement {
+  const section = element("section");
+  section.setAttribute("aria-labelledby", "adjacency-heading");
+  section.append(
+    element("h3", { id: "adjacency-heading", text: "Complete relationship list" }),
+    element("p", {
+      className: "hint",
+      text: "“Cites” means the catalogue record names that source in sourceRefs. Identity self-references are not relationships and are omitted.",
+    }),
+  );
+  const list = element("ol", { className: "adjacency-list" });
+  const nodesById = new Map(model.nodes.map((node) => [node.id, node]));
+  const edges = visualEdges(model);
+  for (const node of model.nodes) {
+    const item = element("li");
+    const heading = element("h4");
+    heading.append(recordLink(node, navigation));
+    item.append(
+      heading,
+      element("p", {
+        text: `${node.type}; ${node.explicitlyIncluded ? "catalogue match" : "supporting source context"}. ID: ${node.id}`,
+      }),
+      relationList("Cites", relatedNodes(node.id, edges, "from"), nodesById, navigation),
+      relationList("Cited by", relatedNodes(node.id, edges, "to"), nodesById, navigation),
+    );
+    list.append(item);
+  }
+  section.append(list);
+  return section;
+}
+
+export function renderGraphView(
+  model: GraphModel,
+  _records: readonly CatalogueRecord[],
+  navigation: GraphNavigation,
+): HTMLElement {
+  const section = element("section");
+  section.setAttribute("aria-labelledby", "view-heading-graph");
+  section.append(
+    element("h2", { id: "view-heading-graph", text: "Evidence graph" }),
+    element("p", {
+      text: "The graph shows only source relationships explicitly recorded in the catalogue. Shared publishers and topics do not create edges.",
+    }),
+  );
+  if (model.nodes.length === 0) {
+    section.append(
+      element("div", { className: "empty-state" }, [
+        element("h3", { text: "No graph records found" }),
+        element("p", { text: "Change or clear the search and filters to see relationships." }),
+      ]),
+    );
+    return section;
+  }
+  section.append(
+    element("p", {
+      text: `${model.nodes.filter((node) => node.explicitlyIncluded).length} catalogue matches and ${
+        model.nodes.filter((node) => !node.explicitlyIncluded).length
+      } supporting source records.`,
+    }),
+    element("div", { className: "visual-and-alternative" }, [
+      renderGraphVisual(model),
+      renderAdjacency(model, navigation),
+    ]),
+  );
+  return section;
+}

--- a/apps/public-explorer/src/views/map.ts
+++ b/apps/public-explorer/src/views/map.ts
@@ -1,0 +1,173 @@
+import { bulletList, element, link, svgElement } from "../dom";
+import type { CatalogueRecord } from "../types";
+
+const FOCUSED_RECORD_ID = "hmlr:dataset:inspire-index-polygons";
+
+export interface MapNavigation {
+  readonly hrefForRecord: (recordId: string | null) => string;
+  readonly selectRecord: (recordId: string | null) => void;
+}
+
+function stringDetail(record: CatalogueRecord, name: string): string | null {
+  const value = record.details[name];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function recordLink(
+  record: CatalogueRecord,
+  navigation: MapNavigation,
+): HTMLAnchorElement {
+  const node = link(record.title, navigation.hrefForRecord(record.id));
+  node.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    navigation.selectRecord(record.id);
+  });
+  return node;
+}
+
+function chooseRecord(
+  records: readonly CatalogueRecord[],
+  selectedRecord: CatalogueRecord | null,
+): CatalogueRecord | null {
+  if (
+    selectedRecord !== null &&
+    (selectedRecord.tags.includes("geospatial-data") || selectedRecord.tags.includes("inspire"))
+  ) {
+    return selectedRecord;
+  }
+  return (
+    records.find((record) => record.id === FOCUSED_RECORD_ID) ??
+    records.find(
+      (record) =>
+        record.tags.includes("geospatial-data") || record.tags.includes("inspire"),
+    ) ??
+    null
+  );
+}
+
+function visualLabel(text: string, x: number, y: number): SVGTextElement {
+  const node = svgElement("text", {
+    class: "map-label",
+    x: String(x),
+    y: String(y),
+  });
+  node.textContent = text;
+  return node;
+}
+
+function renderSchematic(record: CatalogueRecord): HTMLElement {
+  const panel = element("div", { className: "visual-panel" });
+  const figure = element("figure");
+  const svg = svgElement("svg", {
+    "aria-hidden": "true",
+    focusable: "false",
+    role: "presentation",
+    viewBox: "0 0 720 430",
+  });
+  const isFocusedRecord = record.id === FOCUSED_RECORD_ID;
+  const groupingLabel = isFocusedRecord
+    ? "Local authority area files"
+    : "Grouping recorded by source";
+  const subsetLabel = isFocusedRecord
+    ? "Registered freehold property"
+    : "See complete text description";
+
+  svg.append(
+    svgElement("rect", { class: "map-area", height: "90", width: "250", x: "30", y: "40" }),
+    visualLabel("Coverage", 50, 73),
+    visualLabel(stringDetail(record, "jurisdiction") ?? "Coverage recorded by source", 50, 105),
+    svgElement("line", { class: "map-connector", x1: "280", x2: "370", y1: "85", y2: "85" }),
+    svgElement("rect", { class: "map-area", height: "90", width: "300", x: "370", y: "40" }),
+    visualLabel("Source grouping", 390, 73),
+    visualLabel(groupingLabel, 390, 105),
+    svgElement("line", { class: "map-connector", x1: "520", x2: "520", y1: "130", y2: "210" }),
+    svgElement("rect", { class: "map-area", height: "90", width: "300", x: "370", y: "210" }),
+    visualLabel("Described subset", 390, 243),
+    visualLabel(subsetLabel, 390, 275),
+    svgElement("line", { class: "map-connector", x1: "370", x2: "280", y1: "255", y2: "255" }),
+    svgElement("rect", { class: "map-symbol", height: "90", width: "250", x: "30", y: "210" }),
+    visualLabel("Geometry in Explorer", 50, 243),
+    visualLabel("None — metadata only", 50, 275),
+    svgElement("rect", { class: "map-area", height: "65", width: "640", x: "30", y: "345" }),
+    visualLabel("INDICATIVE — NOT AN EXACT LEGAL EXTENT", 150, 385),
+  );
+
+  figure.append(
+    svg,
+    element("figcaption", {
+      text: "Illustration only — not to scale — no real location, title extent or property boundary.",
+    }),
+  );
+  panel.append(figure);
+  return panel;
+}
+
+function alternativeFacts(record: CatalogueRecord): readonly string[] {
+  if (record.id === FOCUSED_RECORD_ID) {
+    return [
+      "Geographic coverage: England and Wales.",
+      "The source groups files by local authority area.",
+      "The described data is a registered freehold subset, not all registered titles or all land.",
+      "One title may have several polygons, and local-authority boundary polygons may be duplicated across files.",
+      "The source GML uses British National Grid, EPSG:27700; reprojection may introduce positional error.",
+      "The polygons are indicative and do not establish the exact legal extent of a title.",
+      "The Explorer contains metadata only and no geometry, property record or address.",
+    ];
+  }
+  const facts = [
+    `Geographic coverage: ${stringDetail(record, "jurisdiction") ?? "consult the source"}.`,
+    "The Explorer contains metadata only and no geometry, property record or address.",
+    ...record.limitations,
+  ];
+  return [...new Set(facts)];
+}
+
+export function renderMapView(
+  records: readonly CatalogueRecord[],
+  selectedRecord: CatalogueRecord | null,
+  navigation: MapNavigation,
+): HTMLElement {
+  const section = element("section");
+  section.setAttribute("aria-labelledby", "view-heading-map");
+  section.append(
+    element("h2", { id: "view-heading-map", text: "Coverage schematic — not a property map" }),
+    element("p", {
+      text: "This schematic summarises catalogue metadata. It uses no basemap, tiles, coordinates or real property geometry.",
+    }),
+  );
+  const record = chooseRecord(records, selectedRecord);
+  if (record === null) {
+    section.append(
+      element("div", { className: "empty-state" }, [
+        element("h3", { text: "No geospatial metadata found" }),
+        element("p", { text: "Change or clear the search and filters to see a coverage schematic." }),
+      ]),
+    );
+    return section;
+  }
+
+  const alternative = element("section", { className: "map-alternative" });
+  alternative.setAttribute("aria-labelledby", "map-alternative-heading");
+  alternative.append(
+    element("h3", { id: "map-alternative-heading", text: "Complete text description" }),
+    element("p", {}, ["Record: ", recordLink(record, navigation), "."]),
+    bulletList(alternativeFacts(record)),
+  );
+  section.append(
+    element("div", { className: "visual-and-alternative" }, [
+      renderSchematic(record),
+      alternative,
+    ]),
+  );
+  return section;
+}

--- a/apps/public-explorer/src/views/timeline.ts
+++ b/apps/public-explorer/src/views/timeline.ts
@@ -1,0 +1,134 @@
+import { element, humaniseToken, link, time } from "../dom";
+import type {
+  CatalogueRecord,
+  TimelineEvent,
+  TimelineEventKind,
+  TimelineModel,
+} from "../types";
+
+export interface TimelineNavigation {
+  readonly hrefForRecord: (recordId: string | null) => string;
+  readonly selectRecord: (recordId: string | null) => void;
+}
+
+const KIND_DEFINITIONS: Readonly<Record<TimelineEventKind, string>> = {
+  observation: "When the source metadata was retrieved or observed.",
+  modification: "When the publisher says the described resource was last changed.",
+  publication: "An explicit publication date supplied by the source.",
+  release: "An explicit release date supplied by the source.",
+};
+
+function recordLink(
+  event: TimelineEvent,
+  navigation: TimelineNavigation,
+): HTMLAnchorElement {
+  const node = link(event.recordTitle, navigation.hrefForRecord(event.recordId));
+  node.addEventListener("click", (clickEvent) => {
+    if (
+      clickEvent.defaultPrevented ||
+      clickEvent.button !== 0 ||
+      clickEvent.metaKey ||
+      clickEvent.ctrlKey ||
+      clickEvent.shiftKey ||
+      clickEvent.altKey
+    ) {
+      return;
+    }
+    clickEvent.preventDefault();
+    navigation.selectRecord(event.recordId);
+  });
+  return node;
+}
+
+function renderLegend(): HTMLDListElement {
+  const list = element("dl", { className: "timeline-legend" });
+  for (const kind of ["observation", "modification", "publication", "release"] as const) {
+    const wrapper = element("div");
+    wrapper.append(
+      element("dt", { text: humaniseToken(kind) }),
+      element("dd", { text: KIND_DEFINITIONS[kind] }),
+    );
+    list.append(wrapper);
+  }
+  return list;
+}
+
+function renderEvent(
+  event: TimelineEvent,
+  navigation: TimelineNavigation,
+): HTMLLIElement {
+  const item = element("li");
+  item.append(
+    element("span", {
+      className: "timeline-event-type",
+      text: humaniseToken(event.kind),
+    }),
+    time(event.date),
+    element("span", { text: " — " }),
+    recordLink(event, navigation),
+    element("span", { className: "visually-hidden", text: `, record ID ${event.recordId}` }),
+  );
+  return item;
+}
+
+export function renderTimelineView(
+  model: TimelineModel,
+  records: readonly CatalogueRecord[],
+  navigation: TimelineNavigation,
+): HTMLElement {
+  const section = element("section");
+  section.setAttribute("aria-labelledby", "view-heading-timeline");
+  section.append(
+    element("h2", { id: "view-heading-timeline", text: "Catalogue timeline" }),
+    element("p", {
+      text: "Dates retain their source meaning. Review dates and review-by dates are governance information and are not relabelled as publication or release dates.",
+    }),
+    renderLegend(),
+  );
+
+  if (records.length === 0) {
+    section.append(
+      element("div", { className: "empty-state" }, [
+        element("h3", { text: "No timeline records found" }),
+        element("p", { text: "Change or clear the search and filters to see dated records." }),
+      ]),
+    );
+    return section;
+  }
+
+  const missingSection = element("section");
+  missingSection.setAttribute("aria-labelledby", "missing-dates-heading");
+  missingSection.append(element("h3", { id: "missing-dates-heading", text: "Dates not recorded" }));
+  const missingList = element("ul");
+  const missingSummaries = model.missing.filter((summary) => summary.recordCount > 0);
+  for (const missing of missingSummaries) {
+    const qualifier =
+      missing.recordCount === records.length
+        ? "all shown records"
+        : `${missing.recordCount} of ${records.length} shown records`;
+    missingList.append(
+      element("li", {
+        text: `${humaniseToken(missing.kind)} date is not recorded for ${qualifier}.`,
+      }),
+    );
+  }
+  if (missingSummaries.length === 0) {
+    missingList.append(element("li", { text: "Every recognised date type is recorded." }));
+  }
+  missingSection.append(missingList);
+
+  const eventSection = element("section");
+  eventSection.setAttribute("aria-labelledby", "timeline-events-heading");
+  eventSection.append(element("h3", { id: "timeline-events-heading", text: "Recorded events" }));
+  if (model.events.length === 0) {
+    eventSection.append(element("p", { text: "No recognised dates are recorded." }));
+  } else {
+    const list = element("ol", { className: "timeline-list" });
+    for (const event of model.events) {
+      list.append(renderEvent(event, navigation));
+    }
+    eventSection.append(list);
+  }
+  section.append(missingSection, eventSection);
+  return section;
+}

--- a/apps/public-explorer/test/browser/accessibility.spec.ts
+++ b/apps/public-explorer/test/browser/accessibility.spec.ts
@@ -1,0 +1,108 @@
+import AxeBuilder from "@axe-core/playwright";
+
+import { expect, test } from "../fixtures/assurance";
+
+const views = [
+  ["cards", "Catalogue"],
+  ["graph", "Evidence graph"],
+  ["timeline", "Catalogue timeline"],
+  ["map", "Coverage schematic — not a property map"],
+] as const;
+
+for (const [view, heading] of views) {
+  test(`${view} view has no detectable WCAG A or AA violations`, async ({ page }) => {
+    await page.goto(`/?view=${view}`);
+    await expect(page.getByRole("heading", { level: 2, name: heading })).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+      .analyze();
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+}
+
+test("visual catalogue views provide complete text alternatives", async ({ page }) => {
+  await page.goto("/?view=graph");
+  await expect(
+    page.getByRole("heading", { level: 3, name: "Complete relationship list" }),
+  ).toBeVisible();
+  const visualNodes = await page.locator("svg .graph-node").count();
+  expect(visualNodes).toBeGreaterThan(0);
+  await expect(page.locator("ol.adjacency-list > li")).toHaveCount(visualNodes);
+
+  await page.goto("/?view=timeline");
+  await expect(page.getByRole("heading", { level: 3, name: "Dates not recorded" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 3, name: "Recorded events" })).toBeVisible();
+  await expect(page.locator(".timeline-legend dt")).toHaveText([
+    "Observation",
+    "Modification",
+    "Publication",
+    "Release",
+  ]);
+
+  await page.goto("/?view=map");
+  const alternative = page.locator(".map-alternative");
+  await expect(
+    alternative.getByRole("heading", { level: 3, name: "Complete text description" }),
+  ).toBeVisible();
+  await expect(alternative.getByRole("listitem")).toHaveCount(7);
+  await expect(
+    alternative.getByText(
+      "The polygons are indicative and do not establish the exact legal extent of a title.",
+      { exact: true },
+    ),
+  ).toBeVisible();
+});
+
+test.describe("small touch viewport", () => {
+  test.use({ hasTouch: true, viewport: { height: 800, width: 320 } });
+
+  test("remains operable without document-level horizontal scrolling", async ({ page }) => {
+    await page.goto("/?view=cards");
+    await page.getByRole("link", { name: /^Map$/i }).tap();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Coverage schematic — not a property map" }),
+    ).toBeVisible();
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});
+
+test("remains usable in forced-colours mode", async ({ page }) => {
+  await page.emulateMedia({ forcedColors: "active" });
+  await page.goto("/?view=graph");
+
+  expect(await page.evaluate(() => matchMedia("(forced-colors: active)").matches)).toBe(true);
+  await expect(page.getByRole("heading", { level: 2, name: "Evidence graph" })).toBeVisible();
+  const search = page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i });
+  await search.focus();
+  await expect(search).toBeFocused();
+  await page.getByRole("link", { name: /^Map$/i }).click();
+  await expect(
+    page.getByRole("heading", { level: 3, name: "Complete text description" }),
+  ).toBeVisible();
+});
+
+test("honours reduced-motion preference across view changes", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/?view=cards");
+
+  expect(await page.evaluate(() => matchMedia("(prefers-reduced-motion: reduce)").matches)).toBe(
+    true,
+  );
+  await page.getByRole("link", { name: /^Timeline$/i }).click();
+  await expect(page.getByRole("heading", { level: 2, name: "Catalogue timeline" })).toBeVisible();
+  const activeAnimations = await page.evaluate(() =>
+    document
+      .getAnimations()
+      .filter((animation) => {
+        const duration = animation.effect?.getComputedTiming().duration;
+        return animation.playState !== "finished" && typeof duration === "number" && duration > 1;
+      })
+      .map((animation) => animation.id),
+  );
+  expect(activeAnimations).toEqual([]);
+});

--- a/apps/public-explorer/test/browser/downloads.spec.ts
+++ b/apps/public-explorer/test/browser/downloads.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "../fixtures/assurance";
+
+test("offers the governed projections and checksum ledger as local downloads", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /Download catalogue/i })).toBeVisible();
+
+  const json = page.getByRole("link", { name: /^(?:Download )?JSON$/i });
+  const jsonLd = page.getByRole("link", { name: /^(?:Download )?JSON-LD$/i });
+  const checksums = page.getByRole("link", {
+    name: /^(?:Download )?(?:checksums|CHECKSUMS\.sha256)$/i,
+  });
+  await expect(json).toHaveAttribute("href", /catalogue\/okf-bundle\.json$/);
+  await expect(jsonLd).toHaveAttribute("href", /catalogue\/okf-bundle\.jsonld$/);
+  await expect(checksums).toHaveAttribute("href", /catalogue\/CHECKSUMS\.sha256$/);
+
+  const checksumReport = await page.evaluate(async () => {
+    const ledgerResponse = await fetch("./catalogue/CHECKSUMS.sha256", { cache: "no-store" });
+    if (!ledgerResponse.ok) {
+      return { entries: 0, failures: [`ledger returned ${ledgerResponse.status}`] };
+    }
+    const lines = (await ledgerResponse.text()).trimEnd().split("\n");
+    const failures: string[] = [];
+    let entries = 0;
+    for (const line of lines) {
+      const match = /^([0-9a-f]{64}) {2}(.+)$/u.exec(line);
+      if (match?.[1] === undefined || match[2] === undefined) {
+        failures.push(`invalid checksum row: ${line}`);
+        continue;
+      }
+      entries += 1;
+      const response = await fetch(`./catalogue/${match[2]}`, { cache: "no-store" });
+      if (!response.ok) {
+        failures.push(`${match[2]} returned ${response.status}`);
+        continue;
+      }
+      const bytes = await response.arrayBuffer();
+      const digest = [...new Uint8Array(await crypto.subtle.digest("SHA-256", bytes))]
+        .map((value) => value.toString(16).padStart(2, "0"))
+        .join("");
+      if (digest !== match[1]) failures.push(`${match[2]} checksum mismatch`);
+    }
+    return { entries, failures };
+  });
+
+  expect(checksumReport.entries).toBeGreaterThan(0);
+  expect(checksumReport.failures).toEqual([]);
+});
+
+test("downloaded JSON and JSON-LD expose the same record identifiers", async ({ page }) => {
+  await page.goto("/");
+
+  const identifiers = await page.evaluate(async () => {
+    const [jsonResponse, jsonLdResponse] = await Promise.all([
+      fetch("./catalogue/okf-bundle.json"),
+      fetch("./catalogue/okf-bundle.jsonld"),
+    ]);
+    if (!jsonResponse.ok || !jsonLdResponse.ok) {
+      throw new Error(`projection download failed: ${jsonResponse.status}/${jsonLdResponse.status}`);
+    }
+    const json = (await jsonResponse.json()) as { records: Array<{ id: string }> };
+    const jsonLd = (await jsonLdResponse.json()) as {
+      "@graph": Array<{ identifier: string }>;
+    };
+    return {
+      json: json.records.map((record) => record.id).sort(),
+      jsonLd: jsonLd["@graph"].map((record) => record.identifier).sort(),
+    };
+  });
+
+  expect(identifiers.json.length).toBeGreaterThan(0);
+  expect(identifiers.jsonLd).toEqual(identifiers.json);
+});

--- a/apps/public-explorer/test/browser/journeys.spec.ts
+++ b/apps/public-explorer/test/browser/journeys.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "../fixtures/assurance";
+
+const PRICE_PAID_ID = "hmlr:dataset:price-paid-data";
+
+test("answers the focused question by default without WebMCP", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", {
+      level: 1,
+      name: "INSPIRE polygon: indicative or legal boundary?",
+    }),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText(
+        "Polygons are indicative and do not establish the exact legal extent of a title.",
+        { exact: true },
+      )
+      .first(),
+  ).toBeVisible();
+
+  const canonical = new URL(page.url());
+  expect(canonical.searchParams.get("view")).toBe("cards");
+  expect(canonical.searchParams.get("q")).toBe("inspire");
+  expect(canonical.searchParams.getAll("type")).toEqual(["dataset"]);
+  expect(decodeURIComponent(canonical.hash)).toBe(
+    "#record=hmlr:dataset:inspire-index-polygons",
+  );
+
+  const optionalBrowserApis = await page.evaluate(() => ({
+    globalModelContext: Reflect.get(globalThis, "modelContext"),
+    navigatorModelContext: Reflect.get(navigator, "modelContext"),
+    webMCP: Reflect.get(globalThis, "webMCP"),
+  }));
+  expect(optionalBrowserApis).toEqual({
+    globalModelContext: undefined,
+    navigatorModelContext: undefined,
+    webMCP: undefined,
+  });
+});
+
+test("searches, filters and clears through labelled controls", async ({ page }) => {
+  await page.goto("/?view=cards");
+
+  const search = page.getByRole("searchbox", {
+    name: /Search(?: the public)? catalogue/i,
+  });
+  await search.fill("Price Paid");
+  await page.getByRole("checkbox", { name: /Dataset/i }).check();
+  await page.getByRole("button", { name: /^Search$/i }).click();
+
+  await expect(page.getByRole("link", { name: "Price Paid Data", exact: true })).toHaveCount(1);
+  await expect(
+    page.getByRole("link", { name: "Index polygons spatial data (INSPIRE)", exact: true }),
+  ).toHaveCount(0);
+  await expect.poll(() => new URL(page.url()).searchParams.get("q")).toBe("Price Paid");
+  expect(new URL(page.url()).searchParams.getAll("type")).toEqual(["dataset"]);
+
+  await page.getByRole("button", { name: "Clear search and filters", exact: true }).click();
+  await expect(search).toHaveValue("");
+  await expect(page.getByRole("checkbox", { name: /Dataset/i })).not.toBeChecked();
+  await expect.poll(() => new URL(page.url()).searchParams.has("q")).toBe(false);
+  expect(new URL(page.url()).searchParams.has("type")).toBe(false);
+});
+
+test("restores a direct URL containing every approved facet", async ({ page }) => {
+  const parameters = new URLSearchParams([
+    ["view", "cards"],
+    ["q", "Price Paid"],
+    ["type", "dataset"],
+    ["authority", "source-authoritative"],
+    ["access", "public"],
+    ["rights", "open-with-conditions"],
+    ["freshness", "current"],
+    ["tag", "hmlr"],
+  ]);
+  await page.goto(`/?${parameters.toString()}#record=${encodeURIComponent(PRICE_PAID_ID)}`);
+
+  await expect(page.getByRole("heading", { level: 2, name: "Price Paid Data" })).toBeVisible();
+  await expect(
+    page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i }),
+  ).toHaveValue("Price Paid");
+  for (const label of [
+    /Dataset/i,
+    /Source authoritative/i,
+    /^Public(?: \(\d+\))?$/i,
+    /Open with conditions/i,
+    /^Current(?: \(\d+\))?$/i,
+    /^hmlr(?: \(\d+\))?$/i,
+  ]) {
+    await expect(page.getByRole("checkbox", { name: label })).toBeChecked();
+  }
+
+  const current = new URL(page.url());
+  expect([...new Set(current.searchParams.keys())].sort()).toEqual([
+    "access",
+    "authority",
+    "freshness",
+    "q",
+    "rights",
+    "tag",
+    "type",
+    "view",
+  ]);
+  expect(current.hash.startsWith("#record=")).toBe(true);
+  expect(decodeURIComponent(current.hash)).toBe(`#record=${PRICE_PAID_ID}`);
+});
+
+test("keeps list and record state in browser history", async ({ page }) => {
+  await page.goto("/?view=cards&q=Price%20Paid&type=dataset");
+  await page.getByRole("link", { name: "Price Paid Data", exact: true }).click();
+
+  await expect.poll(() => decodeURIComponent(new URL(page.url()).hash)).toBe(
+    `#record=${PRICE_PAID_ID}`,
+  );
+  await expect(page.getByRole("heading", { level: 2, name: "Price Paid Data" })).toBeVisible();
+
+  await page.goBack();
+  await expect.poll(() => new URL(page.url()).hash).toBe("");
+  await expect(page.getByRole("link", { name: "Price Paid Data", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i }),
+  ).toHaveValue("Price Paid");
+
+  await page.goForward();
+  await expect.poll(() => decodeURIComponent(new URL(page.url()).hash)).toBe(
+    `#record=${PRICE_PAID_ID}`,
+  );
+  await expect(page.getByRole("heading", { level: 2, name: "Price Paid Data" })).toBeVisible();
+});
+
+test("supports skip navigation and view changes from the keyboard", async ({ page }) => {
+  await page.goto("/?view=cards");
+
+  await page.keyboard.press("Tab");
+  const skipLink = page.getByRole("link", { name: "Skip to main content" });
+  await expect(skipLink).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#main-content")).toBeFocused();
+
+  const graphLink = page.getByRole("link", { name: /^Graph$/i });
+  await graphLink.focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("heading", { level: 2, name: "Evidence graph" })).toBeVisible();
+  await expect(graphLink).toHaveAttribute("aria-current", "page");
+  await expect.poll(() => new URL(page.url()).searchParams.get("view")).toBe("graph");
+});

--- a/apps/public-explorer/test/browser/security.spec.ts
+++ b/apps/public-explorer/test/browser/security.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "../fixtures/assurance";
+
+test("fails hostile and unknown URL state closed without creating markup", async ({ page }) => {
+  const hostile = '<img src="https://attacker.invalid/track" onerror="alert(1)">';
+  await page.goto(
+    `/?view=javascript%3Aalert%281%29&q=${encodeURIComponent(hostile)}` +
+      "&unknown=https%3A%2F%2Fattacker.invalid#record=does-not-exist",
+  );
+
+  await expect(page.locator('.warning-panel[role="status"]')).toContainText(
+    /ignored|not recognised|invalid/i,
+  );
+  await expect(page.getByRole("heading", { name: "Record not found" })).toBeVisible();
+  await expect(
+    page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i }),
+  ).toHaveValue(hostile.slice(0, 200));
+  await expect(page.locator('img[src*="attacker.invalid"]')).toHaveCount(0);
+  await expect(page.locator("script:not([type=module])")).toHaveCount(0);
+  await expect(
+    page.getByRole("heading", { name: "Index polygons spatial data (INSPIRE)" }),
+  ).toHaveCount(0);
+
+  const current = new URL(page.url());
+  expect([...current.searchParams.keys()].every((key) => key === "view" || key === "q")).toBe(
+    true,
+  );
+  expect(current.searchParams.get("view")).toBe("cards");
+});
+
+test("primary controls retain 44 CSS-pixel targets", async ({ page }) => {
+  await page.goto("/?view=cards");
+  const controls = page.locator(
+    '.view-navigation a, button, input[type="search"], .checkbox-item label',
+  );
+  expect(await controls.count()).toBeGreaterThan(0);
+  for (const control of await controls.all()) {
+    const box = await control.boundingBox();
+    expect(box, await control.getAttribute("aria-label") ?? (await control.textContent()) ?? "control")
+      .not.toBeNull();
+    expect(box!.height).toBeGreaterThanOrEqual(44);
+  }
+});
+
+test.describe("JavaScript-free fallback", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("keeps the legal answer and governed downloads available", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", {
+        name: "INSPIRE polygon: indicative or legal boundary?",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Polygons are indicative and do not establish the exact legal extent of a title.",
+        { exact: true },
+      ),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Download JSON", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Download JSON-LD", exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Download checksums", exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/apps/public-explorer/test/build/build-boundary.test.mjs
+++ b/apps/public-explorer/test/build/build-boundary.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  EXPLORER_GENERATED_MARKER,
+  assertPreparedPublicInventory,
+  assertSafeBuildRoots,
+} from "../../scripts/build-boundary.mjs";
+
+const DIGEST = "0".repeat(64);
+
+async function temporaryTree(run) {
+  const root = await mkdtemp(join(tmpdir(), "gis-ai-go-build-boundary-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+async function validTree(root) {
+  const publicRoot = join(root, "public");
+  const distRoot = join(root, "dist");
+  const catalogueRoot = join(publicRoot, "catalogue");
+  await mkdir(catalogueRoot, { recursive: true });
+  await mkdir(distRoot, { recursive: true });
+  await writeFile(join(publicRoot, "favicon.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"/>\n");
+  await writeFile(join(catalogueRoot, ".explorer-generated"), EXPLORER_GENERATED_MARKER);
+  await writeFile(join(catalogueRoot, "CHECKSUMS.sha256"), `${DIGEST}  record.json\n`);
+  await writeFile(join(catalogueRoot, "record.json"), "{}\n");
+  return { publicRoot, distRoot };
+}
+
+test("rejects a symbolic link anywhere in the public input", async () => {
+  await temporaryTree(async (root) => {
+    const { publicRoot, distRoot } = await validTree(root);
+    const benignFile = join(root, "benign-local-file.txt");
+    await writeFile(benignFile, "harmless validation value\n");
+    await symlink(benignFile, join(publicRoot, "linked-local-file.txt"));
+
+    await assert.rejects(
+      assertSafeBuildRoots({ publicRoot, distRoot }),
+      /public directory must not contain a symbolic link: linked-local-file\.txt/u,
+    );
+  });
+});
+
+test("rejects an arbitrary extra regular file in the prepared public input", async () => {
+  await temporaryTree(async (root) => {
+    const { publicRoot, distRoot } = await validTree(root);
+    await writeFile(join(publicRoot, "unexpected.txt"), "not allowlisted\n");
+
+    await assert.rejects(
+      assertPreparedPublicInventory({ publicRoot, distRoot }),
+      /public inventory differs from the generated allowlist/u,
+    );
+  });
+});
+
+test("rejects a distribution root that is itself a symbolic link", async () => {
+  await temporaryTree(async (root) => {
+    const { publicRoot, distRoot } = await validTree(root);
+    const linkedDirectory = join(root, "linked-distribution");
+    await rm(distRoot, { recursive: true });
+    await mkdir(linkedDirectory);
+    await symlink(linkedDirectory, distRoot, "dir");
+
+    await assert.rejects(
+      assertSafeBuildRoots({ publicRoot, distRoot }),
+      /distribution directory root must not be a symbolic link/u,
+    );
+  });
+});
+
+test("accepts the exact regular prepared-public inventory", async () => {
+  await temporaryTree(async (root) => {
+    const { publicRoot, distRoot } = await validTree(root);
+
+    assert.deepEqual(await assertPreparedPublicInventory({ publicRoot, distRoot }), [
+      "catalogue/.explorer-generated",
+      "catalogue/CHECKSUMS.sha256",
+      "catalogue/record.json",
+      "favicon.svg",
+    ]);
+  });
+});

--- a/apps/public-explorer/test/build/dist-policy.test.mjs
+++ b/apps/public-explorer/test/build/dist-policy.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  inspectHtmlDocument,
+  REQUIRED_CSP,
+  requireExactCsp,
+  requireExactInventory,
+} from "../../scripts/dist-policy.mjs";
+
+function htmlWith({ csp = `content="${REQUIRED_CSP}"`, script = 'src="assets/app.js"' } = {}) {
+  return `<!doctype html><html lang="en-GB"><head>` +
+    `<meta name="viewport" content="width=device-width">` +
+    `<meta http-equiv="Content-Security-Policy" ${csp}>` +
+    `</head><body><script ${script}></script></body></html>`;
+}
+
+test("inspects the browser-parsed HTML document", () => {
+  assert.deepEqual(inspectHtmlDocument(htmlWith()), ["assets/app.js"]);
+});
+
+test("does not accept data attributes as policy or script attributes", () => {
+  assert.throws(
+    () =>
+      inspectHtmlDocument(
+        '<!doctype html><html lang="en-GB"><head>' +
+          '<meta name="viewport" content="width=device-width">' +
+          `<meta data-http-equiv="Content-Security-Policy" data-content="${REQUIRED_CSP}">` +
+          '</head><body><script data-src="assets/app.js">alert(1)</script></body></html>',
+      ),
+    /exactly one Content Security Policy/u,
+  );
+});
+
+test("rejects an unquoted weak policy before the exact duplicate", () => {
+  assert.throws(
+    () =>
+      inspectHtmlDocument(
+        htmlWith({ csp: `content=upgrade-insecure-requests content="${REQUIRED_CSP}"` }),
+      ),
+    /directive set differs/u,
+  );
+});
+
+test("rejects an unquoted external script source", () => {
+  assert.throws(
+    () => inspectHtmlDocument(htmlWith({ script: "src=https://attacker.invalid/payload.js" })),
+    /non-relative asset URL/u,
+  );
+});
+
+test("accepts the exact Explorer Content Security Policy", () => {
+  assert.doesNotThrow(() => requireExactCsp(REQUIRED_CSP));
+});
+
+test("rejects duplicate Content Security Policy directives", () => {
+  assert.throws(
+    () => requireExactCsp(`${REQUIRED_CSP}; img-src https:`),
+    /duplicate directive: img-src/u,
+  );
+});
+
+test("rejects a weaker Content Security Policy directive", () => {
+  assert.throws(
+    () => requireExactCsp(REQUIRED_CSP.replace("img-src 'self'", "img-src *")),
+    /img-src must be exactly/u,
+  );
+});
+
+test("rejects default-src self as an alternative", () => {
+  assert.throws(
+    () => requireExactCsp(REQUIRED_CSP.replace("default-src 'none'", "default-src 'self'")),
+    /default-src must be exactly/u,
+  );
+});
+
+test("rejects an omitted Content Security Policy directive", () => {
+  assert.throws(
+    () => requireExactCsp(REQUIRED_CSP.replace("; worker-src 'none'", "")),
+    /missing=worker-src/u,
+  );
+});
+
+test("rejects an extra Content Security Policy directive", () => {
+  assert.throws(
+    () => requireExactCsp(`${REQUIRED_CSP}; child-src 'none'`),
+    /extra=child-src/u,
+  );
+});
+
+test("rejects an arbitrary extra distribution file", () => {
+  assert.throws(
+    () =>
+      requireExactInventory(
+        ["index.html", "favicon.svg", "assets/app.js", "debug.txt"],
+        ["index.html", "favicon.svg", "assets/app.js"],
+      ),
+    /extra=debug\.txt/u,
+  );
+});
+
+test("accepts the exact distribution inventory independent of ordering", () => {
+  assert.doesNotThrow(() =>
+    requireExactInventory(
+      ["index.html", "assets/app.js", "favicon.svg"],
+      ["favicon.svg", "index.html", "assets/app.js"],
+    ),
+  );
+});

--- a/apps/public-explorer/test/component/cards.test.ts
+++ b/apps/public-explorer/test/component/cards.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { renderCardsView, renderRecordCard } from "../../src/views/cards";
+import { focusedRecord, navigation, sources } from "./fixtures";
+
+describe("catalogue cards", () => {
+  it("renders untrusted catalogue text without creating markup", () => {
+    const malicious = {
+      ...focusedRecord,
+      title: '<img src="https://attacker.invalid/track" onerror="alert(1)">',
+      description: "<script>globalThis.compromised = true</script>",
+    };
+
+    const rendered = renderRecordCard(malicious, navigation);
+
+    expect(rendered.querySelector("img")).toBeNull();
+    expect(rendered.querySelector("script")).toBeNull();
+    expect(rendered.textContent).toContain("<img");
+    expect(rendered.textContent).toContain("<script>");
+  });
+
+  it("puts the exact legal limitation and rights distinctions in the selected record", () => {
+    const rendered = renderCardsView(
+      [focusedRecord],
+      [focusedRecord, ...sources],
+      focusedRecord,
+      navigation,
+    );
+
+    expect(
+      [...rendered.querySelectorAll("h2[id]")].find(
+        (heading) => heading.id === `record-heading-${encodeURIComponent(focusedRecord.id)}`,
+      )?.textContent,
+    ).toBe(focusedRecord.title);
+    expect(rendered.textContent).toContain(
+      "Polygons are indicative and do not establish the exact legal extent of a title.",
+    );
+    expect(rendered.textContent).toContain("Record licence");
+    expect(rendered.textContent).toContain("Described resource licence");
+    expect(rendered.textContent).toContain("Contains protected data");
+    expect(rendered.textContent).toContain("No");
+    expect(
+      [...rendered.querySelectorAll("a")].some(
+        (anchor) => anchor.textContent === "Back to catalogue",
+      ),
+    ).toBe(true);
+  });
+
+  it("links each explicit source reference without inventing a provider", () => {
+    const rendered = renderCardsView(
+      [focusedRecord],
+      [focusedRecord, ...sources],
+      focusedRecord,
+      navigation,
+    );
+    const labels = [...rendered.querySelectorAll("a")].map((anchor) => anchor.textContent);
+
+    expect(labels).toContain("Official dataset page");
+    expect(labels).toContain("Official download page");
+    expect(labels).toContain("Official technical guidance");
+    expect(labels).not.toContain("HM Land Registry open publications");
+  });
+});

--- a/apps/public-explorer/test/component/fixtures.ts
+++ b/apps/public-explorer/test/component/fixtures.ts
@@ -1,0 +1,99 @@
+import type { CatalogueRecord } from "../../src/types";
+
+export const focusedRecord: CatalogueRecord = {
+  schema: "gis-ai-go-okf-concept.v1",
+  id: "hmlr:dataset:inspire-index-polygons",
+  type: "dataset",
+  title: "Index polygons spatial data (INSPIRE)",
+  description:
+    "Monthly GML files showing the indicative position and extent of registered freehold property in England and Wales by local authority area.",
+  authority: {
+    class: "source-authoritative",
+    statement:
+      "Source metadata is publisher-authored; GIS AI GO provides only a deterministic, metadata-only projection.",
+    source: "https://use-land-property-data.service.gov.uk/datasets/inspire",
+  },
+  publication: {
+    classification: "public",
+    containsPersonalData: false,
+    containsProtectedData: false,
+  },
+  access: {
+    tier: "open",
+    state: "public",
+    authentication: "none",
+  },
+  rights: {
+    state: "open-with-conditions",
+    recordLicence: "CC BY 4.0 for upstream metadata; GIS AI GO additions are MIT.",
+    describedResourceLicence:
+      "Open Government Licence v3.0 plus required HM Land Registry and Ordnance Survey attribution conditions",
+    attribution:
+      "HM Land Registry and Ordnance Survey attribution is required by the source terms.",
+  },
+  freshness: {
+    observedAt: "2026-07-29T07:53:38Z",
+    reviewedAt: "2026-08-19T00:00:00Z",
+    staleAfter: "2026-11-19T00:00:00Z",
+    status: "current",
+  },
+  status: "candidate-metadata",
+  sourceRefs: ["source:dataset", "source:download", "source:guidance"],
+  limitations: [
+    "Polygons are indicative and do not establish the exact legal extent of a title.",
+    "The source GML uses British National Grid (EPSG:27700); reprojection may introduce positional error.",
+    "This is a freehold subset, not all registered titles or all land.",
+    "A title may have several polygons; local-authority boundary polygons may be duplicated across files.",
+  ],
+  tags: ["epsg-27700", "geospatial-data", "hmlr", "inspire"],
+  details: {
+    publisher: "HM Land Registry",
+    jurisdiction: "England and Wales",
+    cadence: "monthly, on the first Sunday for the preceding month",
+    formats: ["GML"],
+    publisherLastUpdated: "2026-07-05",
+  },
+};
+
+export function sourceRecord(id: string, title: string): CatalogueRecord {
+  return {
+    ...focusedRecord,
+    id,
+    type: "source",
+    title,
+    description: "Public evidence page cited by the selected upstream metadata record.",
+    authority: {
+      class: "source-authoritative",
+      statement: "Official publisher evidence remains authoritative.",
+      source: `https://example.test/${encodeURIComponent(id)}`,
+    },
+    access: {
+      tier: "open",
+      state: "public-metadata",
+      authentication: "None.",
+    },
+    rights: {
+      state: "metadata-citation",
+      recordLicence: "MIT",
+      describedResourceLicence: "Source-specific.",
+      attribution: "Consult the publisher.",
+    },
+    status: "external-source",
+    sourceRefs: [id],
+    limitations: ["A public evidence page does not make linked data open."],
+    tags: ["source"],
+    details: { url: `https://example.test/${encodeURIComponent(id)}` },
+  };
+}
+
+export const sources = [
+  sourceRecord("source:dataset", "Official dataset page"),
+  sourceRecord("source:download", "Official download page"),
+  sourceRecord("source:guidance", "Official technical guidance"),
+];
+
+export const navigation = {
+  hrefForRecord: (recordId: string | null): string =>
+    recordId === null ? "?view=cards" : `?view=cards#record=${encodeURIComponent(recordId)}`,
+  selectRecord: (): void => undefined,
+};

--- a/apps/public-explorer/test/component/graph.test.ts
+++ b/apps/public-explorer/test/component/graph.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { renderGraphView } from "../../src/views/graph";
+import type { GraphModel } from "../../src/types";
+import { focusedRecord, navigation, sources } from "./fixtures";
+
+const model: GraphModel = {
+  nodes: [
+    {
+      id: focusedRecord.id,
+      type: "dataset",
+      title: focusedRecord.title,
+      status: focusedRecord.status,
+      explicitlyIncluded: true,
+    },
+    ...sources.map((source) => ({
+      id: source.id,
+      type: source.type,
+      title: source.title,
+      status: source.status,
+      explicitlyIncluded: false,
+    })),
+  ],
+  edges: [
+    ...sources.map((source) => ({
+      from: focusedRecord.id,
+      to: source.id,
+      relation: "source" as const,
+      selfReference: false,
+    })),
+    {
+      from: sources[0]!.id,
+      to: sources[0]!.id,
+      relation: "source",
+      selfReference: true,
+    },
+  ],
+  adjacency: [],
+};
+
+describe("evidence graph", () => {
+  it("renders a decorative visual and a complete semantic adjacency list", () => {
+    const rendered = renderGraphView(model, [focusedRecord, ...sources], navigation);
+
+    expect(rendered.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+    expect(rendered.querySelectorAll(".graph-edge")).toHaveLength(3);
+    expect(rendered.querySelectorAll(".adjacency-list > li")).toHaveLength(4);
+    expect(rendered.textContent).toContain("3 supporting source records");
+    expect(rendered.textContent).toContain("Cites");
+    expect(rendered.textContent).toContain("Cited by");
+  });
+
+  it("omits source identity self-references from both representations", () => {
+    const rendered = renderGraphView(model, [focusedRecord, ...sources], navigation);
+    const sourceItem = [...rendered.querySelectorAll(".adjacency-list > li")].find(
+      (item) => item.querySelector("h4")?.textContent === sources[0]!.title,
+    );
+
+    expect(sourceItem?.textContent).toContain("CitesNone");
+  });
+});

--- a/apps/public-explorer/test/component/map.test.ts
+++ b/apps/public-explorer/test/component/map.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { renderMapView } from "../../src/views/map";
+import { focusedRecord, navigation } from "./fixtures";
+
+describe("coverage schematic", () => {
+  it("keeps the visual decorative and provides a complete visible text description", () => {
+    const rendered = renderMapView([focusedRecord], focusedRecord, navigation);
+
+    expect(rendered.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+    expect(rendered.querySelector("canvas")).toBeNull();
+    expect(rendered.textContent).toContain("Illustration only — not to scale");
+    expect(rendered.textContent).toContain("Geographic coverage: England and Wales.");
+    expect(rendered.textContent).toContain("British National Grid, EPSG:27700");
+    expect(rendered.textContent).toContain(
+      "The polygons are indicative and do not establish the exact legal extent of a title.",
+    );
+    expect(rendered.textContent).toContain(
+      "The Explorer contains metadata only and no geometry, property record or address.",
+    );
+  });
+});

--- a/apps/public-explorer/test/component/timeline.test.ts
+++ b/apps/public-explorer/test/component/timeline.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { renderTimelineView } from "../../src/views/timeline";
+import type { TimelineModel } from "../../src/types";
+import { focusedRecord, navigation } from "./fixtures";
+
+const model: TimelineModel = {
+  events: [
+    {
+      id: `${focusedRecord.id}:observation`,
+      recordId: focusedRecord.id,
+      recordTitle: focusedRecord.title,
+      kind: "observation",
+      date: "2026-07-29T07:53:38Z",
+    },
+    {
+      id: `${focusedRecord.id}:modification`,
+      recordId: focusedRecord.id,
+      recordTitle: focusedRecord.title,
+      kind: "modification",
+      date: "2026-07-05",
+    },
+  ],
+  missing: [
+    { kind: "publication", recordCount: 1 },
+    { kind: "release", recordCount: 1 },
+  ],
+};
+
+describe("catalogue timeline", () => {
+  it("distinguishes source date meanings and exposes truthful empty categories", () => {
+    const rendered = renderTimelineView(model, [focusedRecord], navigation);
+
+    expect(rendered.textContent).toContain("Observation");
+    expect(rendered.textContent).toContain("Modification");
+    expect(rendered.textContent).toContain(
+      "Publication date is not recorded for all shown records.",
+    );
+    expect(rendered.textContent).toContain("Release date is not recorded for all shown records.");
+    expect(rendered.querySelector('time[datetime="2026-07-05"]')?.textContent).toBe(
+      "5 July 2026",
+    );
+  });
+
+  it("does not relabel governance dates as publication or release", () => {
+    const rendered = renderTimelineView(model, [focusedRecord], navigation);
+    const eventDates = [...rendered.querySelectorAll(".timeline-list time")].map((node) =>
+      node.getAttribute("datetime"),
+    );
+
+    expect(eventDates).not.toContain(focusedRecord.freshness.reviewedAt);
+    expect(eventDates).not.toContain(focusedRecord.freshness.staleAfter);
+  });
+});

--- a/apps/public-explorer/test/fixtures/assurance.ts
+++ b/apps/public-explorer/test/fixtures/assurance.ts
@@ -1,0 +1,56 @@
+import { expect, test as base } from "@playwright/test";
+
+import { isRequestFromConfiguredOrigin } from "./network";
+
+type AssuranceFixtures = { browserAssurance: void };
+
+export const test = base.extend<AssuranceFixtures>({
+  browserAssurance: [
+    async ({ baseURL, page }, use, testInfo) => {
+      if (!baseURL) throw new Error("Browser assurance requires a configured baseURL");
+      const failures: string[] = [];
+      const externalRequests: string[] = [];
+      page.on("console", (message) => {
+        if (message.type() === "error") failures.push(`console: ${message.text()}`);
+      });
+      page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
+      page.on("requestfailed", (request) => {
+        failures.push(`requestfailed: ${request.method()} ${request.url()}`);
+      });
+      page.on("response", (response) => {
+        if (response.status() >= 400) failures.push(`response ${response.status()}: ${response.url()}`);
+      });
+      page.on("request", (request) => {
+        if (!isRequestFromConfiguredOrigin(request.url(), baseURL)) {
+          externalRequests.push(`${request.method()} ${request.url()}`);
+        }
+      });
+      await page.addInitScript(() => {
+        Reflect.deleteProperty(globalThis, "webMCP");
+        Reflect.deleteProperty(globalThis, "modelContext");
+        try {
+          Object.defineProperty(navigator, "modelContext", {
+            configurable: true,
+            value: undefined,
+          });
+        } catch {
+          // An absent or non-configurable experimental API is a valid no-WebMCP state.
+        }
+      });
+      await use();
+      if (failures.length || externalRequests.length) {
+        await testInfo.attach("browser-assurance-errors", {
+          body: [...failures, ...externalRequests.map((value) => `external: ${value}`)].join("\n"),
+          contentType: "text/plain",
+        });
+      }
+      expect(externalRequests, "the static Explorer must use its configured origin only").toEqual(
+        [],
+      );
+      expect(failures, "the browser console and request lifecycle must stay clean").toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/apps/public-explorer/test/fixtures/network.ts
+++ b/apps/public-explorer/test/fixtures/network.ts
@@ -1,0 +1,3 @@
+export function isRequestFromConfiguredOrigin(requestUrl: string, baseURL: string): boolean {
+  return new URL(requestUrl).origin === new URL(baseURL).origin;
+}

--- a/apps/public-explorer/test/unit/catalogue.test.ts
+++ b/apps/public-explorer/test/unit/catalogue.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_BOUNDARY_CAVEAT,
+  DEFAULT_RECORD_ID,
+  deriveFacetOptions,
+  deriveGraph,
+  deriveTimeline,
+  parseCatalogue,
+  parseCatalogueJson,
+  searchRecords,
+} from "../../src/catalogue.js";
+import { createDefaultExplorerState } from "../../src/state.js";
+import type { ExplorerState } from "../../src/types.js";
+import { validCatalogueFixture } from "./fixtures.js";
+
+function cloneFixture() {
+  return structuredClone(validCatalogueFixture());
+}
+
+describe("canonical catalogue validation", () => {
+  it("accepts the bounded public fixture and preserves the legal-boundary caveat", () => {
+    const bundle = parseCatalogue(cloneFixture());
+    expect(bundle.recordCount).toBe(2);
+    expect(bundle.records.find((record) => record.id === DEFAULT_RECORD_ID)?.limitations).toContain(
+      DEFAULT_BOUNDARY_CAVEAT,
+    );
+    expect(parseCatalogueJson(JSON.stringify(validCatalogueFixture()))).toEqual(bundle);
+  });
+
+  it("rejects protected flags, extra fields and unresolved references", () => {
+    const protectedFixture = cloneFixture();
+    protectedFixture.records[0]!.publication.containsProtectedData = true;
+    expect(() => parseCatalogue(protectedFixture)).toThrow(/containsProtectedData/);
+
+    const extraFixture = cloneFixture();
+    Object.assign(extraFixture.records[0]!, { unexpected: true });
+    expect(() => parseCatalogue(extraFixture)).toThrow(/expected keys/);
+
+    const unresolvedFixture = cloneFixture();
+    unresolvedFixture.records[0]!.sourceRefs = ["source:missing"];
+    expect(() => parseCatalogue(unresolvedFixture)).toThrow(/unresolved source reference/);
+  });
+
+  it("rejects unsafe HTML, bidi controls and unsafe navigable URLs", () => {
+    const markup = cloneFixture();
+    markup.records[0]!.title = '<img src=x onerror="globalThis.pwned=true">';
+    expect(() => parseCatalogue(markup)).toThrow(/HTML-like/);
+
+    const bidi = cloneFixture();
+    bidi.records[0]!.description = "Trusted\u202eevil";
+    expect(() => parseCatalogue(bidi)).toThrow(/unsafe control/);
+
+    const unsafeUrl = cloneFixture();
+    unsafeUrl.records[0]!.details.url = "javascript:alert(1)";
+    expect(() => parseCatalogue(unsafeUrl)).toThrow(/navigable URL/);
+  });
+
+  it("rejects a missing legal caveat and dangerous object keys", () => {
+    const missingCaveat = cloneFixture();
+    missingCaveat.records[0]!.limitations = ["Not a complete dataset."];
+    expect(() => parseCatalogue(missingCaveat)).toThrow(/indicative-versus-legal-boundary/);
+
+    const dangerous = JSON.parse(JSON.stringify(validCatalogueFixture())) as ReturnType<
+      typeof validCatalogueFixture
+    >;
+    Object.defineProperty(dangerous.records[0]!.details, "__proto__", {
+      enumerable: true,
+      value: { polluted: true },
+    });
+    expect(() => parseCatalogue(dangerous)).toThrow(/dangerous object key/);
+
+    const nonJsonObject = cloneFixture();
+    nonJsonObject.records[0]!.details.publisher = new Date("2026-08-19T00:00:00Z") as never;
+    expect(() => parseCatalogue(nonJsonObject)).toThrow(/plain JSON object/);
+  });
+});
+
+describe("search and facets", () => {
+  it("searches only controlled fields with NFKC normalisation and ten terms", () => {
+    const bundle = parseCatalogue(cloneFixture());
+    const base = createDefaultExplorerState(bundle);
+    const state: ExplorerState = {
+      ...base,
+      query: "HM Land Registry England GML Monthly polygons indicative extent metadata hmlr ignored",
+      types: ["dataset"],
+      authority: ["source-authoritative"],
+      access: ["public"],
+      rights: ["open-with-conditions"],
+      freshness: ["current"],
+      tags: ["inspire"],
+    };
+    expect(searchRecords(bundle.records, state).map((record) => record.id)).toEqual([
+      DEFAULT_RECORD_ID,
+    ]);
+
+    const rightsOnly = { ...base, query: "upstream", types: [] as const };
+    expect(searchRecords(bundle.records, rightsOnly)).toHaveLength(0);
+  });
+
+  it("derives state-aware counts while retaining zero-count known choices", () => {
+    const bundle = parseCatalogue(cloneFixture());
+    const state: ExplorerState = {
+      ...createDefaultExplorerState(bundle),
+      query: "inspire",
+      types: ["source"],
+    };
+    const facets = deriveFacetOptions(bundle.records, state);
+    expect(facets.types).toEqual([
+      { value: "dataset", count: 1 },
+      { value: "source", count: 1 },
+    ]);
+    expect(facets.access).toContainEqual({ value: "public", count: 0 });
+    expect(facets.tags).toContainEqual({ value: "metadata-only", count: 0 });
+  });
+});
+
+describe("derived evidence views", () => {
+  it("derives one-hop evidence without self-loop edges", () => {
+    const bundle = parseCatalogue(cloneFixture());
+    const graph = deriveGraph(bundle.records, [DEFAULT_RECORD_ID]);
+    expect(graph.nodes.map((node) => node.id)).toEqual([DEFAULT_RECORD_ID, "source:hmlr-inspire"]);
+    expect(graph.edges).toEqual([
+      {
+        from: DEFAULT_RECORD_ID,
+        to: "source:hmlr-inspire",
+        relation: "source",
+        selfReference: false,
+      },
+    ]);
+    expect(graph.adjacency.map((item) => item.sourceIds)).toEqual([
+      ["source:hmlr-inspire"],
+      [],
+    ]);
+  });
+
+  it("keeps observation, modification, publication and release semantics separate", () => {
+    const bundle = parseCatalogue(cloneFixture());
+    const timeline = deriveTimeline(bundle.records);
+    expect(timeline.events.filter((event) => event.kind === "observation")).toHaveLength(2);
+    expect(timeline.events.filter((event) => event.kind === "modification")).toHaveLength(1);
+    expect(timeline.events.filter((event) => event.kind === "publication")).toHaveLength(1);
+    expect(timeline.events.filter((event) => event.kind === "release")).toHaveLength(0);
+    expect(timeline.missing).toEqual([
+      { kind: "modification", recordCount: 1 },
+      { kind: "publication", recordCount: 1 },
+      { kind: "release", recordCount: 2 },
+    ]);
+  });
+});

--- a/apps/public-explorer/test/unit/fixtures.ts
+++ b/apps/public-explorer/test/unit/fixtures.ts
@@ -1,0 +1,122 @@
+import { DEFAULT_BOUNDARY_CAVEAT, DEFAULT_RECORD_ID } from "../../src/catalogue.js";
+
+const SOURCE_ID = "source:hmlr-inspire";
+
+export function validCatalogueFixture() {
+  const common = {
+    schema: "gis-ai-go-okf-concept.v1",
+    publication: {
+      classification: "public",
+      containsPersonalData: false,
+      containsProtectedData: false,
+    },
+    access: {
+      tier: "open",
+      state: "public-metadata",
+      authentication: "None.",
+    },
+    freshness: {
+      observedAt: "2026-07-29T07:53:38Z",
+      reviewedAt: "2026-08-19T00:00:00Z",
+      staleAfter: "2026-11-19T00:00:00Z",
+      status: "current",
+    },
+  };
+
+  return {
+    schema: "gis-ai-go-okf-bundle.v1",
+    id: "https://chris-page-gov.github.io/gis-ai-go/id/bundle/public-discovery",
+    title: "GIS AI GO public discovery bundle",
+    description: "A bounded public metadata catalogue.",
+    okfVersion: "0.2",
+    profile: "https://chris-page-gov.github.io/gis-ai-go/profile/public-discovery/v1/",
+    profileStatus: "candidate-pending-consumer-acceptance",
+    version: "0.0.0",
+    revision: "4ff9cc79946b1977a2022428336687a3dedb04b3",
+    status: "candidate",
+    authority: {
+      bundleAuthority: "Metadata normalisation and publication only.",
+      officialSourceAuthority: "External live publisher sources.",
+      legalAdvice: false,
+      notEndorsedBySource: true,
+    },
+    scope: {
+      kind: "bounded-public-metadata-discovery",
+      metadataOnly: true,
+      containsProtectedData: false,
+      excludes: ["Property records and real geometry."],
+    },
+    rights: {
+      statement: "Project material is MIT; third-party records retain their terms.",
+      thirdPartyNotices: "THIRD_PARTY.md",
+    },
+    observedAt: "2026-07-29T07:53:38Z",
+    reviewedAt: "2026-08-19T00:00:00Z",
+    staleAfter: "2026-11-19T00:00:00Z",
+    recordCount: 2,
+    records: [
+      {
+        ...common,
+        id: DEFAULT_RECORD_ID,
+        type: "dataset",
+        title: "Index polygons spatial data (INSPIRE)",
+        description:
+          "Indicative freehold extent metadata for England and Wales, not a title plan.",
+        authority: {
+          class: "source-authoritative",
+          statement: "HM Land Registry is authoritative for the source metadata.",
+          source: "https://www.gov.uk/guidance/inspire-index-polygons-spatial-data",
+        },
+        access: { ...common.access, state: "public" },
+        rights: {
+          state: "open-with-conditions",
+          recordLicence: "CC BY 4.0 for upstream metadata.",
+          describedResourceLicence: "Use is subject to the named source terms.",
+          attribution: "HM Land Registry and Ordnance Survey.",
+        },
+        status: "candidate-metadata",
+        sourceRefs: [SOURCE_ID],
+        limitations: [
+          DEFAULT_BOUNDARY_CAVEAT,
+          "The catalogue contains no provider geometry.",
+        ],
+        tags: ["hmlr", "inspire", "metadata-only"],
+        details: {
+          publisher: "HM Land Registry",
+          jurisdiction: "England and Wales",
+          formats: ["GML"],
+          cadence: "Monthly",
+          publisherLastUpdated: "2026-07-05",
+          url: "https://www.gov.uk/guidance/inspire-index-polygons-spatial-data",
+        },
+      },
+      {
+        ...common,
+        id: SOURCE_ID,
+        type: "source",
+        title: "Official HMLR INSPIRE guidance",
+        description: "The official public evidence page.",
+        authority: {
+          class: "source-authoritative",
+          statement: "The named publisher is authoritative for this evidence page.",
+          source: "https://www.gov.uk/guidance/inspire-index-polygons-spatial-data",
+        },
+        rights: {
+          state: "metadata-citation",
+          recordLicence: "MIT for the catalogue record.",
+          describedResourceLicence: "Source-specific.",
+          attribution: "HM Land Registry.",
+        },
+        status: "external-source",
+        sourceRefs: [SOURCE_ID],
+        limitations: ["A cited page does not relicense linked content."],
+        tags: ["hmlr", "official-source"],
+        details: {
+          publisher: "HM Land Registry",
+          published: "2026-06-01",
+          url: "https://www.gov.uk/guidance/inspire-index-polygons-spatial-data",
+        },
+      },
+    ],
+  };
+}

--- a/apps/public-explorer/test/unit/links.test.ts
+++ b/apps/public-explorer/test/unit/links.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isSafeNavigableHref, safeNavigableHref } from "../../src/links.js";
+
+const BASE = "https://example.test/gis-ai-go/index.html";
+
+describe("navigable link policy", () => {
+  it("allows HTTPS destinations and deployment-relative paths", () => {
+    expect(safeNavigableHref("https://www.gov.uk/guidance/example", BASE)).toBe(
+      "https://www.gov.uk/guidance/example",
+    );
+    expect(isSafeNavigableHref("catalogue/okf-bundle.json", BASE)).toBe(true);
+    expect(isSafeNavigableHref("./records/example", BASE)).toBe(true);
+    expect(isSafeNavigableHref("?view=graph#record=example", BASE)).toBe(true);
+  });
+
+  it("rejects same-origin relative links outside the deployment base", () => {
+    expect(isSafeNavigableHref("../outside.html", BASE)).toBe(false);
+    expect(isSafeNavigableHref("/outside.html", BASE)).toBe(false);
+    expect(isSafeNavigableHref("/gis-ai-go/catalogue/okf-bundle.json", BASE)).toBe(false);
+    expect(isSafeNavigableHref("%252e%252e/outside.html", BASE)).toBe(false);
+  });
+
+  it.each([
+    "http://example.test/unsafe",
+    "javascript:alert(1)",
+    "data:text/html,unsafe",
+    "file:///tmp/unsafe",
+    "//example.test/unsafe",
+    "https://user:password@example.test/",
+    " https://example.test/",
+    "https://example.test/a%2fb",
+    "https://example.test/\u202eunsafe",
+  ])("rejects %s", (value) => {
+    expect(isSafeNavigableHref(value, BASE)).toBe(false);
+  });
+});

--- a/apps/public-explorer/test/unit/network.test.ts
+++ b/apps/public-explorer/test/unit/network.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { isRequestFromConfiguredOrigin } from "../fixtures/network";
+
+describe("browser request origin assurance", () => {
+  const baseURL = "http://127.0.0.1:4173/";
+
+  it("allows the configured origin", () => {
+    expect(isRequestFromConfiguredOrigin("http://127.0.0.1:4173/assets/app.js", baseURL)).toBe(
+      true,
+    );
+  });
+
+  it("rejects a different port on the same host", () => {
+    expect(isRequestFromConfiguredOrigin("http://127.0.0.1:43117/track", baseURL)).toBe(false);
+  });
+
+  it("rejects a localhost alias and a different scheme", () => {
+    expect(isRequestFromConfiguredOrigin("http://localhost:4173/track", baseURL)).toBe(false);
+    expect(isRequestFromConfiguredOrigin("https://127.0.0.1:4173/track", baseURL)).toBe(false);
+  });
+});

--- a/apps/public-explorer/test/unit/state.test.ts
+++ b/apps/public-explorer/test/unit/state.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_RECORD_ID, parseCatalogue } from "../../src/catalogue.js";
+import {
+  canonicaliseState,
+  createDefaultExplorerState,
+  explorerStatesEqual,
+  parseExplorerUrl,
+  serialiseExplorerUrl,
+} from "../../src/state.js";
+import type { ExplorerState } from "../../src/types.js";
+import { validCatalogueFixture } from "./fixtures.js";
+
+const bundle = parseCatalogue(validCatalogueFixture());
+
+describe("Explorer URL state", () => {
+  it("defines the focused default journey", () => {
+    expect(createDefaultExplorerState(bundle)).toEqual({
+      view: "cards",
+      query: "inspire",
+      types: ["dataset"],
+      authority: [],
+      access: [],
+      rights: [],
+      freshness: [],
+      tags: [],
+      selectedRecordId: DEFAULT_RECORD_ID,
+    });
+  });
+
+  it("parses only the controlled facets and preserves an unknown direct record", () => {
+    const state = parseExplorerUrl(
+      "https://example.test/gis-ai-go/?view=graph&q=inspire&type=dataset&type=unknown" +
+        "&authority=source-authoritative&access=public&rights=open-with-conditions" +
+        "&freshness=current&tag=hmlr&status=candidate&unknown=value#record=missing%3Arecord",
+      bundle,
+    );
+    expect(state).toMatchObject({
+      view: "graph",
+      query: "inspire",
+      types: ["dataset"],
+      authority: ["source-authoritative"],
+      access: ["public"],
+      rights: ["open-with-conditions"],
+      freshness: ["current"],
+      tags: ["hmlr"],
+      selectedRecordId: "missing:record",
+    });
+  });
+
+  it("leaves a direct filtered-list URL unselected and round trips it", () => {
+    const parsed = parseExplorerUrl("https://example.test/gis-ai-go/?q=hmlr&type=dataset", bundle);
+    expect(parsed.selectedRecordId).toBeNull();
+    const url = serialiseExplorerUrl(parsed, "https://example.test/gis-ai-go/", bundle);
+    expect(url.href).toBe(
+      "https://example.test/gis-ai-go/?view=cards&q=hmlr&type=dataset",
+    );
+    expect(explorerStatesEqual(parseExplorerUrl(url, bundle), parsed)).toBe(true);
+  });
+
+  it("serialises in a stable order with a canonical hash record", () => {
+    const state: ExplorerState = {
+      view: "map",
+      query: "  inspire   boundary ",
+      types: ["source", "dataset", "dataset"],
+      authority: ["source-authoritative"],
+      access: ["public"],
+      rights: ["open-with-conditions"],
+      freshness: ["current"],
+      tags: ["inspire", "hmlr"],
+      selectedRecordId: DEFAULT_RECORD_ID,
+    };
+    const url = serialiseExplorerUrl(state, "https://example.test/gis-ai-go/?ignored=yes#old", bundle);
+    expect(url.href).toBe(
+      "https://example.test/gis-ai-go/?view=map&q=inspire+boundary&type=dataset&type=source" +
+        "&authority=source-authoritative&access=public&rights=open-with-conditions" +
+        "&freshness=current&tag=hmlr&tag=inspire#record=hmlr%3Adataset%3Ainspire-index-polygons",
+    );
+    expect(explorerStatesEqual(parseExplorerUrl(url, bundle), canonicaliseState(state, bundle))).toBe(
+      true,
+    );
+  });
+
+  it("fails closed on oversized, duplicate and bidi-controlled values", () => {
+    const oversized = "x".repeat(201);
+    expect(
+      parseExplorerUrl(`https://example.test/gis-ai-go/?q=${oversized}&q=second#record=a`, bundle),
+    ).toMatchObject({ query: "", selectedRecordId: "a" });
+    expect(
+      parseExplorerUrl("https://example.test/gis-ai-go/?q=safe%20%E2%80%AEevil#record=a", bundle)
+        .query,
+    ).toBe("");
+    expect(
+      parseExplorerUrl(
+        "https://example.test/gis-ai-go/?q=safe#record=a&record=b",
+        bundle,
+    ).selectedRecordId,
+    ).toBeNull();
+  });
+
+  it("normalises compatibility characters and bounds committed search terms", () => {
+    const canonical = canonicaliseState(
+      {
+        ...createDefaultExplorerState(bundle),
+        query: "ＩＮＳＰＩＲＥ one two three four five six seven eight nine ten eleven",
+      },
+      bundle,
+    );
+    expect(canonical.query).toBe("INSPIRE one two three four five six seven eight nine");
+  });
+});

--- a/apps/public-explorer/tsconfig.json
+++ b/apps/public-explorer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["node", "vite/client", "vitest/globals"]
+  },
+  "include": [
+    "playwright.config.ts",
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "vite.config.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/apps/public-explorer/vite.config.ts
+++ b/apps/public-explorer/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  build: {
+    assetsInlineLimit: 0,
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+});

--- a/apps/public-explorer/vitest.config.ts
+++ b/apps/public-explorer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["test/unit/**/*.test.ts", "test/component/**/*.test.ts"],
+  },
+});

--- a/changelog.d/DISC-102.added.md
+++ b/changelog.d/DISC-102.added.md
@@ -1,0 +1,4 @@
+- Added an accessible static public Explorer with governed catalogue search, facets,
+  source-backed graph and timeline views, a non-legal coverage schematic, durable
+  URLs, machine-readable downloads, exact-origin browser assurance and symlink-safe,
+  checksum-bound static builds.

--- a/docs/decisions/ADR-0005-static-public-explorer.md
+++ b/docs/decisions/ADR-0005-static-public-explorer.md
@@ -1,0 +1,44 @@
+# ADR-0005: Static public Explorer
+
+- status: accepted
+- decided on: 19 August 2026
+- work item: DISC-102
+
+## Context
+
+The first public product must let people inspect the governed catalogue without an
+account, MCP host, provider credential or optional browser integration. The
+checksum-verified OKF bundle is the canonical discovery source. The historical
+research viewer is immutable evidence and is not suitable for deployment.
+
+## Decision
+
+Build the Explorer as a progressively enhanced static TypeScript application. Its
+production runtime has no third-party JavaScript dependency and makes no provider,
+analytics, font, tile or other external request. The build copies the complete,
+checksum-verified OKF output without transforming it and fails closed when its
+inventory, hashes or public-data envelope are invalid.
+
+Use ordinary query parameters for search, facets and the selected view, and the
+source-native record identifier in the URL fragment. Canonicalisation uses browser
+history replacement; committed navigation uses history entries. All core journeys
+work without WebMCP, storage, cookies or JavaScript-only visual meaning.
+
+The graph derives edges only from explicit `sourceRefs`. Timeline dates retain their
+source meaning. The map is a coverage schematic with a complete text alternative,
+not real property geometry or a legal boundary. Catalogue values are rendered as
+text, and navigable links are limited to HTTPS or safe same-publication paths.
+
+Use a relative application base so the same artefact can be verified locally and
+later mounted at the GitHub Pages project path. Publication, hosting headers and the
+immutable deployment receipt remain the separate DISC-104 gate.
+
+## Consequences
+
+- the Explorer can be built, tested and archived independently of a server;
+- JSON and JSON-LD downloads remain byte-for-byte projections of the canonical OKF
+  build;
+- visual graph, timeline and schematic views need complete semantic alternatives;
+- browser, accessibility, malicious-input, network and built-artefact checks are
+  mandatory repository assurance;
+- GitHub Pages remains disabled until the publication gate passes.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ research recommendations remain unchanged in the preserved pack at
 - [ADR-0002: GIS AI GO project name](ADR-0002-project-name.md)
 - [ADR-0003: MIT licence](ADR-0003-mit-licence.md)
 - [ADR-0004: Public autonomous delivery](ADR-0004-public-autonomous-delivery.md)
+- [ADR-0005: Static public Explorer](ADR-0005-static-public-explorer.md)
 
 Research decisions D01–D19 are accepted as constraints for building and evaluating
 Stage 0, not as blanket authority for later production stages. Research decision D20

--- a/docs/operations/DEPENDENCIES.md
+++ b/docs/operations/DEPENDENCIES.md
@@ -10,13 +10,18 @@ All installed dependencies are exact in `pnpm-lock.yaml` or `uv.lock`.
 | `@types/node` | `24.13.3` | Node.js 24 types |
 | `@modelcontextprotocol/server` | `2.0.0` | Pinned Stage 2 gateway SDK target; no server is started |
 | `@viz-js/viz` | `3.29.0` | Lockfile-pinned WebAssembly Graphviz renderer |
+| Vite | `8.2.1` | Static Explorer build and local preview only |
+| Vitest | `4.1.11` | Explorer unit and component assurance |
+| jsdom | `30.0.1` | Explorer component DOM used only in tests |
+| Playwright | `1.62.1` | Real-browser Explorer acceptance using runner Chrome |
+| axe-core Playwright integration | `4.13.0` | Automated WCAG 2.2 A and AA checks |
 | Python | `>=3.12` | Portable deterministic service and assurance scripts |
 | uv | `0.12.2` | Python workspace and lock |
 | jsonschema | `4.26.0` | Draft 2020-12 OKF, schema and fixture validation |
 
-No provider SDK, web framework, geospatial runtime, OPA binary, database driver or
-cloud dependency is present yet. Additions follow the live roadmap and dependency
-assurance rules.
+The Explorer has no production runtime dependency. No provider SDK, server-side web
+framework, geospatial runtime, OPA binary, database driver or cloud dependency is
+present yet. Additions follow the live roadmap and dependency assurance rules.
 
 GitHub Actions are pinned to immutable commits in `.github/workflows/ci.yml`; the
 comments record the corresponding release tags checked on 19 August 2026.

--- a/docs/operations/DEPENDENCIES.md
+++ b/docs/operations/DEPENDENCIES.md
@@ -12,7 +12,7 @@ All installed dependencies are exact in `pnpm-lock.yaml` or `uv.lock`.
 | `@viz-js/viz` | `3.29.0` | Lockfile-pinned WebAssembly Graphviz renderer |
 | Vite | `8.2.1` | Static Explorer build and local preview only |
 | Vitest | `4.1.11` | Explorer unit and component assurance |
-| jsdom | `30.0.1` | Explorer component DOM used only in tests |
+| jsdom | `30.0.1` | Standards-based HTML parsing in build-policy and component tests |
 | Playwright | `1.62.1` | Real-browser Explorer acceptance using runner Chrome |
 | axe-core Playwright integration | `4.13.0` | Automated WCAG 2.2 A and AA checks |
 | Python | `>=3.12` | Portable deterministic service and assurance scripts |

--- a/docs/operations/DISC-102_VERIFICATION.md
+++ b/docs/operations/DISC-102_VERIFICATION.md
@@ -1,0 +1,90 @@
+# DISC-102 Explorer verification record
+
+Verified locally on 19 August 2026. The pull request and squash merge identify the
+exact source revision; embedding that future identifier in this change would be
+self-referential.
+
+## Outcome
+
+The static public Explorer implements the issue 4 acceptance journey without an
+account, provider request, MCP host or WebMCP implementation. Its default route
+answers “INSPIRE polygon: indicative or legal boundary?” and states that the
+polygons are indicative and do not establish the exact legal extent of a title.
+
+The Explorer publishes metadata only. It contains no property record, address,
+real geometry, credential, protected data or legal boundary assertion.
+
+## Source and build integrity
+
+- the only runtime corpus is the deterministic 18-record DISC-101 OKF bundle;
+- the build verifies the canonical checksum ledger, complete inventory, regular
+  files and byte-for-byte parity before publishing the catalogue projections;
+- JSON and JSON-LD expose the same source-native record identifiers;
+- production assets use relative paths, contain no source maps or historical
+  research pack, and pass a strict static Content Security Policy check;
+- the deployed candidate makes same-origin catalogue requests only and has no
+  analytics, remote font, tile, service-worker or provider dependency.
+
+## Functional and accessibility assurance
+
+The Explorer package passed TypeScript checking, 16 build-policy tests, 36 unit
+and component tests and 18 Chrome browser journeys. The browser suite covers:
+
+- the focused default answer and operation without WebMCP;
+- search, six facet groups, direct routes, canonical URLs and browser history;
+- keyboard, touch and skip-link operation;
+- axe checks on catalogue, graph, timeline and schematic-map views;
+- a 320 CSS-pixel reflow viewport, representing a 1,280-pixel layout at 400%
+  zoom;
+- forced colours and reduced motion;
+- graph adjacency, timeline semantics and complete schematic-map text
+  alternatives;
+- hostile URL and catalogue values, 44-pixel target sizes and the no-JavaScript
+  fallback;
+- local-only network traffic, a clean browser console and downloadable checksum
+  parity.
+
+A separate Playwright CLI review inspected the built default and schematic-map
+views at 1,440 by 1,000 CSS pixels. The visual hierarchy, legal caveat, authority
+boundary and non-property-map labelling were clear and no layout blocker was
+found.
+
+The repository-wide `pnpm run check` gate also passed unchanged after security
+remediation. In addition to the Explorer checks, it ran 4 gateway tests, 23
+repository tests, 2 execution boundary tests, validation of 8 schemas and 53
+records, 279 local Markdown links, 183 immutable research hashes, 2 source-ledger
+snapshots and 71 source identifiers.
+The baseline secret scan checked 405 text files, 9 diagrams rendered, and the
+CycloneDX generator recorded 145 components.
+
+## Security and privacy boundary
+
+Runtime parsing limits input size, depth, record count and string length; rejects
+unexpected fields, controls, HTML-like content, unsafe object keys and
+non-public classifications; and checks source-reference closure. Search and URL
+state are allowlisted, bounded and canonicalised. Dynamic DOM content is created
+with text nodes and typed properties, while navigable links must be confined
+relative paths or credential-free HTTPS URLs.
+
+The repository security diff review covered every changed runtime, user-interface
+and build-assurance file. Its isolated validation initially confirmed one Low
+publication-assurance finding: a weakened CSP and different loopback origin could
+pass both automated gates. The owner authorised remediation. The final build now
+requires the exact CSP and distribution inventory, validates browser-parsed HTML
+attribute semantics, compares browser requests with the exact configured origin,
+and always starts a fresh candidate preview for browser assurance.
+
+The same review proved two filesystem footguns that were not reportable under the
+current attacker model but were still hardened: public and distribution trees must
+be regular, symlink-free allowlisted inputs before Vite runs. All local Python
+entrypoints also enforce the reviewed `uv.lock`. Sixteen regression tests cover the
+validated build patterns, and the complete post-remediation gate passes. This is a
+bounded review of DISC-102, not a guarantee that future code or third-party content
+is vulnerability-free.
+
+## Publication and rollback
+
+This record verifies a local candidate only. GitHub Pages remains disabled until
+DISC-103 source-family review and the DISC-104 immutable deployment gate pass.
+Before deployment, rollback is ordinary pull-request reversion. After deployment,
+DISC-104 must retain and be able to redeploy the previous checksum-bound build.

--- a/docs/operations/DISC-102_VERIFICATION.md
+++ b/docs/operations/DISC-102_VERIFICATION.md
@@ -57,6 +57,11 @@ snapshots and 71 source identifiers.
 The baseline secret scan checked 405 text files, 9 diagrams rendered, and the
 CycloneDX generator recorded 145 components.
 
+The first pull-request run exposed an undeclared CI-only FFmpeg dependency from
+Playwright video retention before any browser assertion ran. Browser video is now
+disabled; failure screenshots and traces remain enabled and are uploaded with CI
+evidence. This keeps runner Chrome as the sole browser dependency.
+
 ## Security and privacy boundary
 
 Runtime parsing limits input size, depth, record count and string length; rejects

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -8,3 +8,4 @@ pause. There is no deployed product yet.
 - [Stage 0 boundary](STAGE_0_BOUNDARY.md)
 - [Dependency baseline](DEPENDENCIES.md)
 - [Stage 0 verification record](STAGE_0_VERIFICATION.md)
+- [DISC-102 Explorer verification record](DISC-102_VERIFICATION.md)

--- a/package.json
+++ b/package.json
@@ -10,19 +10,22 @@
     "node": ">=24.19.0"
   },
   "scripts": {
-    "build": "pnpm --recursive --if-present run build",
+    "build": "pnpm run build:okf && pnpm --recursive --if-present run build",
     "typecheck": "pnpm --recursive --if-present run typecheck",
     "test:typescript": "pnpm --filter @gis-ai-go/mcp-gateway run test",
-    "test:python": "uv run --cache-dir .uv-cache python -m unittest discover -s tests -p 'test_*.py' && uv run --cache-dir .uv-cache python -m unittest discover -s services/geo-execution/tests -p 'test_*.py'",
-    "test": "pnpm run test:typescript && pnpm run test:python",
-    "build:okf": "uv run --cache-dir .uv-cache python scripts/build_okf.py --output artifacts/okf",
-    "validate:contracts": "uv run --cache-dir .uv-cache python scripts/validate_contracts.py",
-    "validate:versions": "uv run --cache-dir .uv-cache python scripts/check_versions.py",
-    "validate:links": "uv run --cache-dir .uv-cache python scripts/check_links.py",
-    "validate:secrets": "uv run --cache-dir .uv-cache python scripts/scan_secrets.py",
+    "test:explorer": "pnpm --filter @gis-ai-go/public-explorer run test:unit",
+    "test:browser": "pnpm run build:explorer && pnpm --filter @gis-ai-go/public-explorer run test:browser",
+    "test:python": "uv run --locked --cache-dir .uv-cache python -m unittest discover -s tests -p 'test_*.py' && uv run --locked --cache-dir .uv-cache python -m unittest discover -s services/geo-execution/tests -p 'test_*.py'",
+    "test": "pnpm run test:typescript && pnpm run test:explorer && pnpm run test:python",
+    "build:okf": "uv run --locked --cache-dir .uv-cache python scripts/build_okf.py --output artifacts/okf",
+    "build:explorer": "pnpm run build:okf && pnpm --filter @gis-ai-go/public-explorer run build",
+    "validate:contracts": "uv run --locked --cache-dir .uv-cache python scripts/validate_contracts.py",
+    "validate:versions": "uv run --locked --cache-dir .uv-cache python scripts/check_versions.py",
+    "validate:links": "uv run --locked --cache-dir .uv-cache python scripts/check_links.py",
+    "validate:secrets": "uv run --locked --cache-dir .uv-cache python scripts/scan_secrets.py",
     "render:diagrams": "node scripts/render_diagrams.mjs --output artifacts/diagrams",
-    "sbom": "uv run --cache-dir .uv-cache python scripts/generate_sbom.py --output artifacts/sbom.cdx.json",
-    "check": "pnpm run typecheck && pnpm run test && pnpm run build:okf && pnpm run validate:versions && pnpm run validate:contracts && pnpm run validate:links && pnpm run validate:secrets && pnpm run render:diagrams && pnpm run sbom"
+    "sbom": "uv run --locked --cache-dir .uv-cache python scripts/generate_sbom.py --output artifacts/sbom.cdx.json",
+    "check": "pnpm run typecheck && pnpm run test && pnpm run test:browser && pnpm run validate:versions && pnpm run validate:contracts && pnpm run validate:links && pnpm run validate:secrets && pnpm run render:diagrams && pnpm run sbom"
   },
   "devDependencies": {
     "@types/node": "24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,92 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
 
+  apps/public-explorer:
+    devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.13.0
+        version: 4.13.0(playwright-core@1.62.1)
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
+      jsdom:
+        specifier: 30.0.1
+        version: 30.0.1
+      vite:
+        specifier: 8.2.1
+        version: 8.2.1(@types/node@24.13.3)
+      vitest:
+        specifier: 4.1.11
+        version: 4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3))
+
   packages/contracts: {}
 
 packages:
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@modelcontextprotocol/core@2.0.0':
     resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
@@ -35,6 +118,125 @@ packages:
   '@modelcontextprotocol/server@2.0.0':
     resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
     engines: {node: '>=20'}
+
+  '@oxc-project/types@0.146.0':
+    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -159,8 +361,302 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
   '@viz-js/viz@3.29.0':
     resolution: {integrity: sha512-iq4MTqNCr8pinP4C73JRFx/h2w4QbtHvXINNiPeBv3/C5tSamXwakst6ODlR/l6uh3/SGr7IAGIfSk2qMekiNw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.2.5:
+    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
@@ -170,10 +666,182 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@axe-core/playwright@4.13.0(playwright-core@1.62.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.62.1
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@exodus/bytes@1.15.1': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
@@ -183,6 +851,70 @@ snapshots:
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
       zod: 4.4.3
+
+  '@oxc-project/types@0.146.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/node@24.13.3':
     dependencies:
@@ -248,7 +980,279 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.2.1(@types/node@24.13.3))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@24.13.3)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@viz-js/viz@3.29.0': {}
+
+  assertion-error@2.0.1: {}
+
+  axe-core@4.13.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
+
+  detect-libc@2.1.2: {}
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.3.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  lru-cache@11.5.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  nanoid@3.3.18: {}
+
+  obug@2.1.4: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.2.5:
+    dependencies:
+      '@oxc-project/types': 0.146.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.5
+      '@rolldown/binding-android-arm64': 1.2.5
+      '@rolldown/binding-darwin-arm64': 1.2.5
+      '@rolldown/binding-darwin-x64': 1.2.5
+      '@rolldown/binding-freebsd-x64': 1.2.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
+      '@rolldown/binding-linux-arm64-gnu': 1.2.5
+      '@rolldown/binding-linux-arm64-musl': 1.2.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
+      '@rolldown/binding-linux-s390x-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-musl': 1.2.5
+      '@rolldown/binding-openharmony-arm64': 1.2.5
+      '@rolldown/binding-win32-arm64-msvc': 1.2.5
+      '@rolldown/binding-win32-x64-msvc': 1.2.5
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   typescript@7.0.2:
     optionalDependencies:
@@ -274,5 +1278,79 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.18.2: {}
+
+  undici@8.10.0: {}
+
+  vite@8.2.1(@types/node@24.13.3):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+
+  vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@24.13.3))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@24.13.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   zod@4.4.3: {}

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 RESEARCH = ROOT / "docs" / "research" / "2026-08-19"
 PACK = RESEARCH / "research-pack"
 VENDORED_OKF = ROOT / "okf" / "vendor"
+GENERATED_EXPLORER_CATALOGUE = ROOT / "apps" / "public-explorer" / "public" / "catalogue"
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*]\(([^)]+)\)")
 SOURCE_ID = re.compile(r"^S-[A-Z0-9-]+$")
 SKIP_PARTS = {".git", ".venv", "node_modules", "artifacts", "dist"}
@@ -42,7 +43,11 @@ def check_markdown_links() -> tuple[int, list[str]]:
         # Exact vendored Markdown may contain upstream-relative links to files outside
         # the selected input set. Its bytes and complete local inventory are enforced
         # by the OKF source lock instead of rewriting those links.
-        if SKIP_PARTS.intersection(path.parts) or path.is_relative_to(VENDORED_OKF):
+        if (
+            SKIP_PARTS.intersection(path.parts)
+            or path.is_relative_to(VENDORED_OKF)
+            or path.is_relative_to(GENERATED_EXPLORER_CATALOGUE)
+        ):
             continue
         text = path.read_text(encoding="utf-8")
         for match in MARKDOWN_LINK.finditer(text):

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -33,6 +33,7 @@ def main() -> None:
     for relative in (
         "package.json",
         "apps/mcp-gateway/package.json",
+        "apps/public-explorer/package.json",
         "packages/contracts/package.json",
     ):
         value = load_json(ROOT / relative).get("version")

--- a/tests/contract/test_repository_boundary.py
+++ b/tests/contract/test_repository_boundary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import tomllib
 import unittest
 from pathlib import Path
@@ -30,6 +31,7 @@ class RepositoryBoundaryTests(unittest.TestCase):
         for relative in (
             "package.json",
             "apps/mcp-gateway/package.json",
+            "apps/public-explorer/package.json",
             "packages/contracts/package.json",
         ):
             package = json.loads((ROOT / relative).read_text(encoding="utf-8"))
@@ -52,6 +54,33 @@ class RepositoryBoundaryTests(unittest.TestCase):
             )
         )
         self.assertEqual(receipt["software"][0]["name"], "gis-ai-go-execution")
+
+    def test_package_uv_run_commands_are_lock_strict(self) -> None:
+        excluded_parts = {".git", "artifacts", "dist", "node_modules"}
+        uv_run = re.compile(r"(?<![\w-])uv\s+run(?=\s)")
+        locked_option = re.compile(r"^\s+--locked(?:\s|$)")
+
+        for path in sorted(ROOT.rglob("package.json")):
+            relative = path.relative_to(ROOT)
+            if excluded_parts.intersection(relative.parts):
+                continue
+            package = json.loads(path.read_text(encoding="utf-8"))
+            scripts = package.get("scripts", {})
+            self.assertIsInstance(scripts, dict)
+            for script_name, command in scripts.items():
+                if not isinstance(command, str):
+                    continue
+                for invocation, match in enumerate(uv_run.finditer(command), start=1):
+                    with self.subTest(
+                        package=relative.as_posix(),
+                        script=script_name,
+                        invocation=invocation,
+                    ):
+                        self.assertRegex(
+                            command[match.end() :],
+                            locked_option,
+                            "repository package scripts must start every uv run with --locked",
+                        )
 
 
 if __name__ == "__main__":

--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -1,4 +1,6 @@
 # Security-test boundary
 
-Stage 0 runs the repository secret scan and live-execution regression tests. This is
-not a penetration test or production security assessment.
+Repository assurance runs the baseline secret scan, fail-closed execution tests and
+static Explorer malicious-input, Content Security Policy, navigation, network and
+built-artefact checks. These are not a penetration test or production security
+assessment.


### PR DESCRIPTION
Closes #4.

## Outcome

Builds the accessible static GIS AI GO public Explorer from the deterministic
18-record OKF bundle. The default journey answers the HMLR INSPIRE question and
states that indicative polygons do not establish the exact legal extent of a title.

## Included

- search, six facet groups, governed cards and durable query/hash navigation;
- source-backed graph, truthful timeline and non-legal coverage schematic, each
  with a complete text alternative;
- local JSON, JSON-LD and checksum downloads with source-native identifier parity;
- keyboard, touch, 320-pixel reflow, forced-colour and reduced-motion support;
- no-JavaScript fallback and operation without WebMCP;
- exact checksum/inventory, CSP, symlink, browser-origin and locked-dependency
  publication boundaries.

## Assurance

- full `pnpm run check` passes on the final commit candidate;
- 16 build-policy tests, 36 unit/component tests and 18 Playwright journeys;
- 4 gateway, 23 repository and 2 execution-boundary tests;
- 8 schemas and 53 records, 279 Markdown links, 183 research hashes, 2 source
  ledgers and 71 source identifiers validated;
- 405 text files scanned, 9 diagrams rendered and 145 SBOM components recorded;
- bounded security review covered every changed runtime, interface and build file.
  Its confirmed Low CSP/origin assurance gap and the independent review findings
  were remediated and regression-tested before this PR.

## Publication boundary

This PR does not deploy the Explorer. GitHub Pages remains disabled until the
DISC-103 source review and DISC-104 immutable deployment gate pass.
