### PR TITLE
feat(discovery): add reviewed geospatial examples

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Current context
 
-Last updated: 19 August 2026
+Last updated: 20 August 2026
 
 ## Authority and reading order
 
@@ -34,16 +34,18 @@ Start every implementation task by reading, in order:
 ## Current implementation state
 
 Stage 0 is complete at commit `983b1a102aa8038c9f50ae1b1894315c3ae0b89f`.
-It provides governance, candidate contracts, synthetic fixtures, architecture
-sources, locked workspaces and an assurance harness. It is not a functional product:
-there is no deployed Explorer, MCP listener, live provider adapter, policy engine,
-identity integration or evidence store.
+The canonical OKF build and accessible static Explorer are merged through
+`DISC-101` and `DISC-102`; protected `main` is at
+`6984f3097cff578f0d22088ca8582ebe55725115`. The Explorer is a functional static
+candidate in repository and CI, but it is not deployed. There is no MCP listener,
+live provider adapter, policy engine, identity integration or evidence store.
 
 The owner has authorised autonomous implementation in the open under
 [`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The active
 outcome is the `v0.1.0` public discovery product. The repository is public under the
 owner's personal `chris-page-gov` account. Pull-request assurance, security controls
-and branch protection govern development on `main`.
+and branch protection govern development on `main`. The active outcome is DISC-103:
+reviewed, metadata-only public geospatial examples before the DISC-104 Pages gate.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Delivery progress
 
-Last updated: 19 August 2026
+Last updated: 20 August 2026
 
 ## Current outcome
 
@@ -10,14 +10,14 @@ reproducible GitHub Pages deployment.
 
 ## Active workstream
 
-`DISC-102 — Build the accessible public Explorer`
+`DISC-103 — Add reviewed public geospatial examples`
 
-- build a static search, facet and governed data-card journey from the canonical OKF
-  bundle;
-- provide complete graph, timeline and schematic-map non-visual alternatives;
-- preserve direct URL state and browser history without requiring WebMCP;
-- prove keyboard, touch, zoom, forced-colour, reduced-motion and hostile-record
-  behaviour in real-browser assurance.
+- add digest-locked HM Land Registry journeys LR-Q003, LR-Q006 and LR-Q012;
+- add non-executing ONS data, ONS geography and LandIS capability records;
+- preserve exact source, release, retrieval, review, rights and access semantics;
+- fail closed on forbidden fields, unresolved evidence or mixed rights presented as
+  open;
+- prove the new journeys through contract, Explorer and real-browser assurance.
 
 ## Completed
 
@@ -38,13 +38,19 @@ reproducible GitHub Pages deployment.
   passing main assurance and CodeQL;
 - canonical OKF generation now produces 18 source-locked public metadata records in
   equivalent Markdown, JSON and JSON-LD projections;
-- full local `pnpm run check` passed on 19 August 2026.
+- `DISC-102` merged through [pull request 9](https://github.com/chris-page-gov/gis-ai-go/pull/9)
+  at `6984f3097cff578f0d22088ca8582ebe55725115` with passing assurance and
+  CodeQL;
+- the accessible static Explorer now provides search, facets, governed cards,
+  graph, timeline, non-legal schematic map, durable URLs and machine-readable
+  downloads;
+- full local `pnpm run check` passed on 20 August 2026.
 
 ## Next
 
-1. Merge `DISC-102` after component, browser, security and accessibility assurance.
-2. Add the reviewed public source families through `DISC-103`.
-3. Publish the immutable static product through `DISC-104` after the final gate.
+1. Complete and merge the reviewed examples through `DISC-103`.
+2. Publish the immutable static product through `DISC-104` after the final gate.
+3. Assemble, tag and verify the first supported `v0.1.0` release.
 
 ## Current blockers
 
@@ -55,15 +61,21 @@ reproducible GitHub Pages deployment.
 
 ## Latest evidence
 
-- canonical OKF content: merged and passing on protected `main` at `4ff9cc7`;
-- remote assurance and CodeQL: passing on `main`, 19 August 2026;
-- active Explorer branch: the complete `pnpm run check` gate passes, including
+- canonical OKF content and Explorer: merged on protected `main` at `6984f30`;
+- main assurance and CodeQL: passing at `6984f30` on 20 August 2026;
+- Explorer assurance includes
   16 build-policy tests, 36 unit and component tests, 18 browser journeys and
   production integrity checks;
 - bounded security diff review: all changed runtime, interface and build-assurance
   files covered; the confirmed Low CSP/origin assurance gap, exact HTML-attribute
   parsing, fresh preview-server enforcement, and defensive symlink and lock-strict
   hardening are remediated with passing regressions;
+- DISC-103 source review: exact provider snapshots and HMLR `v0.3.0` inputs are
+  selected; the 36-record local candidate passes the complete repository gate,
+  including 25 browser journeys, and independent review is complete;
+- DISC-103 security review: the selected HMLR inputs and copied licence are
+  independently bound to approved v0.3.0 digests, and coordinated source, rights,
+  licence and lock mutations now fail closed;
 - public repository: verified with personal `noreply` commit identity;
 - deployed product: none;
 - latest supported release: none.

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -18,3 +18,19 @@ The derivative public bundle must attribute HM Land Registry and any named third
 party according to each selected record. It contains metadata only. HMLR, GOV.UK,
 Ordnance Survey, Royal Mail and other source content, names and trade marks retain
 their own rights and conditions and are not relicensed by the GIS AI GO MIT licence.
+
+## Public provider and source metadata
+
+GIS AI GO also projects metadata-only descriptions of Office for National
+Statistics and Land Information System capabilities from the dated, checksum-locked
+research pack. The descriptions are original GIS AI GO research released under this
+repository's MIT licence; the organisations, source services, datasets, names and
+trade marks they describe retain their own rights.
+
+ONS material is attributed to the Office for National Statistics. The Open
+Government Licence applies only where the named ONS source or product says it does;
+Ordnance Survey, Royal Mail and other third-party conditions remain product-specific.
+
+LandIS material is attributed to Cranfield University and the Land Information
+System. Its catalogue has mixed access and per-record rights. This repository does
+not grant blanket reuse rights in LandIS records, services or data.

--- a/apps/public-explorer/README.md
+++ b/apps/public-explorer/README.md
@@ -13,7 +13,8 @@ pnpm run build:explorer
 
 Generated catalogue files and browser reports are ignored. The eventual GitHub Pages
 workflow publishes only `dist/`, never the repository root or immutable research
-viewer. Deployment remains outside DISC-102.
+viewer. Deployment remains outside DISC-103 and is controlled by the separate
+DISC-104 publication gate.
 
 Before Vite runs, the build rejects symlinked or special-file public and distribution
 trees and requires the exact checksum-derived public inventory. The finished
@@ -29,8 +30,11 @@ browser storage, analytics, map tiles, provider APIs or WebMCP.
 Search and selected facets use the query string. The selected view uses `view`, and
 the source-native record identifier uses `#record=…`. Supported facets are `type`,
 `authority`, `access`, `rights`, `freshness` and `tag`; unknown or oversized state is
-discarded with a visible warning. The graph contains only explicit `sourceRefs`, and
-the coverage schematic contains no real geometry or legal boundary.
+discarded with a visible warning. Search is limited to the governed record fields and
+an explicit allowlist of question and provider-capability details. It does not index
+arbitrary nested details, rights conditions or forbidden-target notes. The graph
+contains only explicit `sourceRefs`, and the coverage schematic contains no real
+geometry or legal boundary.
 
 Run the focused checks with:
 

--- a/apps/public-explorer/src/catalogue.ts
+++ b/apps/public-explorer/src/catalogue.ts
@@ -382,7 +382,17 @@ function parseRecord(value: unknown, index: number): CatalogueRecord {
   const tags = uniqueStringsAt(record.tags, `${path}.tags`);
   const details = objectAt(record.details, `${path}.details`);
   validateDetailLinks(details, `${path}.details`);
-  for (const key of ["publisherLastUpdated", "published", "releasedAt", "releaseDate"] as const) {
+  for (const key of [
+    "metadataSnapshotGeneratedAt",
+    "publisherLastUpdated",
+    "published",
+    "questionResearchCutoff",
+    "retrieved",
+    "retrievedOn",
+    "releaseTaggedAt",
+    "releasedAt",
+    "releaseDate",
+  ] as const) {
     const detail = details[key];
     if (detail !== undefined && detail !== null) {
       dateLikeAt(detail, `${path}.details.${key}`);
@@ -626,6 +636,28 @@ function approvedDetailText(value: JsonValue | undefined): string[] {
   return [];
 }
 
+// This is deliberately an allowlist. In particular, do not replace it with a
+// recursive walk of `details` or include rights text: those fields may contain
+// long, provider-specific material that is not part of the controlled search
+// contract.
+const SEARCHABLE_DETAIL_FIELDS = [
+  "publisher",
+  "organisation",
+  "jurisdiction",
+  "geographicScope",
+  "formats",
+  "cadence",
+  "updateFrequency",
+  "accessModel",
+  "questionId",
+  "query",
+  "intent",
+  "expectedTerms",
+  "expectedPropositions",
+  "datasetsServices",
+  "mechanisms",
+] as const;
+
 function searchableText(record: CatalogueRecord): string {
   return normaliseSearchText(
     [
@@ -636,10 +668,9 @@ function searchableText(record: CatalogueRecord): string {
       record.authority.statement,
       ...record.limitations,
       ...record.tags,
-      ...approvedDetailText(record.details.publisher),
-      ...approvedDetailText(record.details.jurisdiction),
-      ...approvedDetailText(record.details.formats),
-      ...approvedDetailText(record.details.cadence),
+      ...SEARCHABLE_DETAIL_FIELDS.flatMap((field) =>
+        approvedDetailText(record.details[field]),
+      ),
     ].join(" "),
   );
 }
@@ -882,7 +913,11 @@ export function deriveTimeline(records: readonly CatalogueRecord[]): TimelineMod
     add(record, "observation", record.freshness.observedAt);
     add(record, "modification", optionalDetailDate(record, ["publisherLastUpdated"]));
     add(record, "publication", optionalDetailDate(record, ["published"]));
-    add(record, "release", optionalDetailDate(record, ["releasedAt", "releaseDate"]));
+    add(
+      record,
+      "release",
+      optionalDetailDate(record, ["releaseTaggedAt", "releasedAt", "releaseDate"]),
+    );
   }
 
   const kindOrder = new Map(TIMELINE_EVENT_KINDS.map((kind, index) => [kind, index]));

--- a/apps/public-explorer/src/views/cards.ts
+++ b/apps/public-explorer/src/views/cards.ts
@@ -172,8 +172,7 @@ function externalSourceLink(record: CatalogueRecord): HTMLAnchorElement | null {
 }
 
 function detailRows(record: CatalogueRecord): ReturnType<typeof definitionList> {
-  const formats = stringArrayDetail(record, "formats");
-  const rows = [
+  const rows: Array<{ term: string; description: Node | string }> = [
     { term: "Source-native ID", description: record.id },
     { term: "Record type", description: humaniseToken(record.type) },
     { term: "Publisher", description: publisherName(record) },
@@ -191,22 +190,69 @@ function detailRows(record: CatalogueRecord): ReturnType<typeof definitionList> 
     { term: "Review by", description: time(record.freshness.staleAfter) },
   ];
 
-  const jurisdiction = stringDetail(record, "jurisdiction");
-  const cadence = stringDetail(record, "cadence");
-  const accessModel = stringDetail(record, "accessModel");
-  if (jurisdiction !== null) {
-    rows.push({ term: "Geographic coverage", description: jurisdiction });
-  }
-  if (cadence !== null) {
-    rows.push({ term: "Update cadence", description: cadence });
-  }
-  if (accessModel !== null) {
-    rows.push({ term: "Source access model", description: accessModel });
-  }
-  if (formats.length > 0) {
-    rows.push({ term: "Formats", description: formats.join(", ") });
-  }
+  const addString = (term: string, ...keys: readonly string[]): void => {
+    for (const key of keys) {
+      const value = stringDetail(record, key);
+      if (value !== null) {
+        rows.push({ term, description: value });
+        return;
+      }
+    }
+  };
+  const addDate = (term: string, ...keys: readonly string[]): void => {
+    for (const key of keys) {
+      const value = stringDetail(record, key);
+      if (value !== null) {
+        rows.push({ term, description: time(value) });
+        return;
+      }
+    }
+  };
+  const addList = (
+    term: string,
+    key: string,
+    format: (value: string) => string = (value) => value,
+  ): void => {
+    const values = stringArrayDetail(record, key);
+    if (values.length > 0) {
+      rows.push({ term, description: bulletList(values.map(format)) });
+    }
+  };
+
+  addString("Worked question", "questionId");
+  addString("Question", "query");
+  addString("Purpose", "intent");
+  addList("Expected findings", "expectedPropositions");
+  addString("Near-miss safeguard", "nearMissRule");
+  addString("Geographic coverage", "jurisdiction", "geographicScope");
+  addString("Update cadence", "cadence", "updateFrequency");
+  addString("Source access model", "accessModel");
+  addList("Described capabilities", "datasetsServices");
+  addList("Access mechanisms", "mechanisms");
+  addList("Described access tiers", "accessTiers", humaniseToken);
+  addList("Identifiers", "identifiers");
+  addList("Formats", "formats");
+  addString("Non-executing integration note", "recommendedIntegration");
+  addString("Caching and redistribution", "cachingRedistribution");
+  addDate("Metadata snapshot generated", "metadataSnapshotGeneratedAt");
+  addDate("Question research vintage", "questionResearchCutoff");
+  addDate("Publisher last updated", "publisherLastUpdated");
+  addDate("Source published", "published");
+  addDate("Source retrieved", "retrieved", "retrievedOn");
+  addDate("Source release", "releaseTaggedAt", "releasedAt", "releaseDate");
   return definitionList(rows);
+}
+
+function publisherEvidenceLink(source: CatalogueRecord): HTMLAnchorElement | null {
+  const candidate = stringDetail(source, "url");
+  if (candidate === null) {
+    return null;
+  }
+  const safe = safeNavigableHref(candidate, document.baseURI);
+  if (safe === null) {
+    return null;
+  }
+  return link(`Open publisher evidence for ${source.title}`, safe);
 }
 
 function renderSourceReferences(
@@ -224,6 +270,10 @@ function renderSourceReferences(
       item.textContent = source?.title ?? sourceId;
     } else {
       item.append(navigationLink(source.title, source.id, navigation));
+      const publisherEvidence = publisherEvidenceLink(source);
+      if (publisherEvidence !== null) {
+        appendChildren(item, [" — ", publisherEvidence]);
+      }
     }
     list.append(item);
   }

--- a/apps/public-explorer/test/browser/journeys.spec.ts
+++ b/apps/public-explorer/test/browser/journeys.spec.ts
@@ -81,15 +81,15 @@ test("restores a direct URL containing every approved facet", async ({ page }) =
   await expect(
     page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i }),
   ).toHaveValue("Price Paid");
-  for (const label of [
-    /Dataset/i,
-    /Source authoritative/i,
-    /^Public(?: \(\d+\))?$/i,
-    /Open with conditions/i,
-    /^Current(?: \(\d+\))?$/i,
-    /^hmlr(?: \(\d+\))?$/i,
+  for (const id of [
+    "#facet-types-dataset",
+    "#facet-authority-source-authoritative",
+    "#facet-access-public",
+    "#facet-rights-open-with-conditions",
+    "#facet-freshness-current",
+    "#facet-tags-hmlr",
   ]) {
-    await expect(page.getByRole("checkbox", { name: label })).toBeChecked();
+    await expect(page.locator(id)).toBeChecked();
   }
 
   const current = new URL(page.url());

--- a/apps/public-explorer/test/browser/reviewed-examples.spec.ts
+++ b/apps/public-explorer/test/browser/reviewed-examples.spec.ts
@@ -1,0 +1,205 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "../fixtures/assurance";
+
+async function searchAndOpen(
+  page: Page,
+  query: string,
+  marker: string,
+  exactRecordId?: string,
+): Promise<void> {
+  await page.goto("/?view=cards");
+  const search = page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i });
+  await search.fill(query);
+  await page.getByRole("button", { name: /^Search$/i }).click();
+
+  if (exactRecordId === undefined) {
+    const card = page.locator("article.record-card").filter({ hasText: marker });
+    await expect(card).toHaveCount(1);
+    await card.getByRole("link").first().click();
+  } else {
+    const recordLink = page.locator(
+      `article.record-card a[href*="#record=${encodeURIComponent(exactRecordId)}"]`,
+    );
+    await expect(recordLink).toHaveCount(1);
+    await recordLink.click();
+  }
+  await expect(page.locator("article.record-detail")).toBeVisible();
+}
+
+async function expectPublisherEvidence(page: Page, urls: readonly string[]): Promise<void> {
+  const detail = page.locator("article.record-detail");
+  const sourceSection = detail
+    .getByRole("heading", { level: 3, name: "Source evidence" })
+    .locator("..");
+  for (const url of urls) {
+    await expect(sourceSection.locator(`a[href="${url}"]`)).toHaveCount(1);
+  }
+}
+
+async function catalogueText(page: Page): Promise<string> {
+  return page.evaluate(async () => {
+    const response = await fetch("./catalogue/okf-bundle.json");
+    if (!response.ok) {
+      throw new Error(`catalogue returned ${response.status}`);
+    }
+    return response.text();
+  });
+}
+
+test("LR-Q003 distinguishes an online copy from an official copy", async ({ page }) => {
+  await searchAndOpen(page, "online copy or official copy proof of ownership", "LR-Q003");
+
+  const detail = page.locator("article.record-detail");
+  await expect(detail.getByRole("heading", { level: 2 })).toContainText("LR-Q003");
+  await expect(detail).toContainText("An online copy is not proof of ownership.");
+  await expect(detail).toContainText(
+    "Official copies have a distinct order route and evidential role.",
+  );
+  await expect(detail).toContainText("non-executing", { ignoreCase: true });
+  await expectPublisherEvidence(page, [
+    "https://www.gov.uk/search-property-information-land-registry",
+    "https://www.gov.uk/guidance/land-registry-portal-how-to-request-official-copies",
+  ]);
+
+  expect(await catalogueText(page)).not.toContain(
+    "https://businessgateway.landregistry.gov.uk/bg2/s1/v1",
+  );
+});
+
+test("LR-Q006 gives the documented index-map recovery route", async ({ page }) => {
+  await searchAndOpen(
+    page,
+    "address search misses title search of the index map",
+    "LR-Q006",
+  );
+
+  const detail = page.locator("article.record-detail");
+  await expect(detail).toContainText(
+    "Searching only by property details may not show every title affecting the property.",
+  );
+  await expect(detail).toContainText(
+    "A search of the index map is the documented alternative for the relevant task.",
+  );
+  await expectPublisherEvidence(page, [
+    "https://www.gov.uk/guidance/land-registry-portal-how-to-request-official-copies",
+    "https://www.gov.uk/guidance/land-registry-portal-request-a-search-of-the-index-map",
+    "https://www.gov.uk/search-property-information-land-registry",
+  ]);
+
+  const bundle = await catalogueText(page);
+  expect(bundle).not.toContain("https://github.com/LandRegistry/address-search-api");
+  expect(bundle).not.toContain("https://businessgateway.landregistry.gov.uk/bg2/s1/v1");
+});
+
+test("LR-Q012 keeps INSPIRE geometry indicative and links LLC evidence", async ({ page }) => {
+  await searchAndOpen(page, "INSPIRE polygon indicative or legal boundary", "LR-Q012");
+
+  const detail = page.locator("article.record-detail");
+  await expect(detail).toContainText(
+    "Local Land Charges INSPIRE data shows indicative locations.",
+  );
+  await expect(detail).toContainText(
+    "Indicative geometry is a discovery aid and does not establish an exact legal title boundary.",
+  );
+  await expectPublisherEvidence(page, [
+    "https://use-land-property-data.service.gov.uk/datasets/llc",
+    "https://www.gov.uk/government/publications/hm-land-registry-plans-boundaries-pg40s3",
+  ]);
+
+  expect(await catalogueText(page)).not.toContain(
+    "https://use-land-property-data.service.gov.uk/datasets/nps",
+  );
+});
+
+test("Price Paid shows source date and third-party conditions without publishing rows", async ({
+  page,
+}) => {
+  await searchAndOpen(
+    page,
+    "Price Paid",
+    "Price Paid Data",
+    "hmlr:dataset:price-paid-data",
+  );
+
+  const detail = page.locator("article.record-detail");
+  await expect(detail).toContainText("Open Government Licence v3.0");
+  await expect(detail).toContainText("HM Land Registry");
+  await expect(detail).toContainText("Ordnance Survey");
+  await expect(detail).toContainText("Royal Mail");
+  await expect(detail.getByText("28 July 2026", { exact: true })).toBeVisible();
+
+  const selected = await page.evaluate(async () => {
+    const response = await fetch("./catalogue/okf-bundle.json");
+    const bundle = (await response.json()) as {
+      records: Array<{ id: string; details: Record<string, unknown> }>;
+    };
+    return bundle.records.find((record) => record.id === "hmlr:dataset:price-paid-data");
+  });
+  expect(selected).toBeDefined();
+  expect(selected?.details.publisherLastUpdated).toBe("2026-07-28");
+  const forbiddenKeys = new Set([
+    "address",
+    "addresses",
+    "row",
+    "rows",
+    "transaction",
+    "transactions",
+  ]);
+  expect(Object.keys(selected?.details ?? {}).filter((key) => forbiddenKeys.has(key))).toEqual([]);
+});
+
+test("both ONS records expose bounded capabilities without executing a provider", async ({
+  page,
+}) => {
+  await searchAndOpen(page, "PV-ONS-DATA", "ONS Data API");
+  let detail = page.locator("article.record-detail");
+  for (const capability of [
+    "datasets",
+    "versions",
+    "editions",
+    "dimensions",
+    "observations",
+  ] as const) {
+    await expect(detail).toContainText(capability);
+  }
+  await expect(detail).toContainText("No provider connection is made");
+
+  await searchAndOpen(page, "PV-ONS-GEO", "ONS Geography and Open Geography Portal");
+  detail = page.locator("article.record-detail");
+  for (const capability of [
+    "boundaries",
+    "lookups",
+    "names and codes",
+    "change history",
+  ] as const) {
+    await expect(detail).toContainText(capability);
+  }
+  await expect(detail).toContainText("No provider connection is made");
+});
+
+test("LandIS remains visibly mixed, per-record and non-executing", async ({ page }) => {
+  await searchAndOpen(page, "PV-LANDIS", "LandIS");
+
+  const detail = page.locator("article.record-detail");
+  await expect(detail).toContainText("commercial or restricted where record terms require", {
+    ignoreCase: true,
+  });
+  await expect(detail).toContainText("Read and enforce each record licence");
+  await expect(detail).toContainText("do not infer one blanket licence", { ignoreCase: true });
+  await expect(detail).toContainText("No provider connection is made");
+  await expect(detail).toContainText("No live provider call");
+});
+
+test("timeline keeps the verified HMLR upstream release date distinct", async ({ page }) => {
+  await page.goto("/?view=timeline&q=Digest-locked%20okf-LandRegistry");
+
+  const releaseEvent = page
+    .locator(".timeline-list .timeline-event-type", { hasText: /^Release$/ })
+    .locator("..")
+    .filter({ hasText: "Digest-locked okf-LandRegistry v0.3.0 release" });
+  await expect(releaseEvent).toHaveCount(1);
+  const releaseTime = releaseEvent.locator("time");
+  await expect(releaseTime).toHaveAttribute("datetime", "2026-08-12T01:43:30+01:00");
+  await expect(releaseTime).toContainText("12 August 2026");
+});

--- a/apps/public-explorer/test/component/cards.test.ts
+++ b/apps/public-explorer/test/component/cards.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { renderCardsView, renderRecordCard } from "../../src/views/cards";
-import { focusedRecord, navigation, sources } from "./fixtures";
+import {
+  focusedRecord,
+  landisProviderRecord,
+  navigation,
+  onsProviderRecord,
+  sources,
+  workedQuestionRecord,
+} from "./fixtures";
 
 describe("catalogue cards", () => {
   it("renders untrusted catalogue text without creating markup", () => {
@@ -59,5 +66,51 @@ describe("catalogue cards", () => {
     expect(labels).toContain("Official download page");
     expect(labels).toContain("Official technical guidance");
     expect(labels).not.toContain("HM Land Registry open publications");
+    expect(
+      [...rendered.querySelectorAll("a")].some(
+        (anchor) =>
+          anchor.textContent === "Open publisher evidence for Official dataset page" &&
+          anchor.href.includes("source%3Adataset"),
+      ),
+    ).toBe(true);
+  });
+
+  it("shows reviewed worked-question findings as governed, non-executing detail", () => {
+    const rendered = renderCardsView(
+      [workedQuestionRecord],
+      [workedQuestionRecord, ...sources],
+      workedQuestionRecord,
+      navigation,
+    );
+
+    expect(rendered.textContent).toContain("Worked question");
+    expect(rendered.textContent).toContain("LR-Q003");
+    expect(rendered.textContent).toContain("online copy or official copy proof of ownership");
+    expect(rendered.textContent).toContain("An online copy is not proof of ownership.");
+    expect(rendered.textContent).toContain("Planned Non Executing");
+  });
+
+  it("shows bounded ONS capabilities and mixed, per-record LandIS conditions", () => {
+    const ons = renderCardsView(
+      [onsProviderRecord],
+      [onsProviderRecord, ...sources],
+      onsProviderRecord,
+      navigation,
+    );
+    expect(ons.textContent).toContain("datasets");
+    expect(ons.textContent).toContain("observations");
+    expect(ons.textContent).toContain("REST API");
+    expect(ons.textContent).toContain("No provider connection is made");
+
+    const landis = renderCardsView(
+      [landisProviderRecord],
+      [landisProviderRecord, ...sources],
+      landisProviderRecord,
+      navigation,
+    );
+    expect(landis.textContent).toContain("Commercial or restricted where record terms require");
+    expect(landis.textContent).toContain("Read and enforce each record licence");
+    expect(landis.textContent).toContain("No live provider call");
+    expect(landis.textContent).toContain("do not execute here");
   });
 });

--- a/apps/public-explorer/test/component/fixtures.ts
+++ b/apps/public-explorer/test/component/fixtures.ts
@@ -92,6 +92,100 @@ export const sources = [
   sourceRecord("source:guidance", "Official technical guidance"),
 ];
 
+export const workedQuestionRecord: CatalogueRecord = {
+  ...focusedRecord,
+  id: "LR-Q003",
+  type: "workflow",
+  title: "LR-Q003 — Online copy or official copy?",
+  description: "A reviewed, non-executing retrieval question.",
+  access: {
+    tier: "open",
+    state: "planned-non-executing",
+    authentication: "Not applicable: this is a non-executing description.",
+  },
+  rights: {
+    state: "project-mit",
+    recordLicence: "MIT",
+    describedResourceLicence: "Not applicable; this is a non-executing description.",
+    attribution: "Copyright © 2026 Chris Page.",
+  },
+  status: "candidate-non-executing",
+  sourceRefs: ["source:dataset", "source:guidance"],
+  limitations: [
+    "An online copy is not proof of ownership.",
+    "Official copies and ordinary online downloads are distinct products.",
+  ],
+  tags: ["hmlr", "official-copy", "worked-question"],
+  details: {
+    questionId: "LR-Q003",
+    query: "online copy or official copy proof of ownership",
+    intent: "Distinguish informational downloads from official copies.",
+    expectedPropositions: [
+      "An online copy is not proof of ownership.",
+      "Official copies have a distinct order route and evidential role.",
+    ],
+    nearMissRule:
+      "Merely linking to a paid download without explaining its evidential status is insufficient.",
+  },
+};
+
+export const onsProviderRecord: CatalogueRecord = {
+  ...focusedRecord,
+  id: "PV-ONS-DATA",
+  type: "provider",
+  title: "ONS Data API",
+  description: "Version-bound discovery of public ONS data capabilities.",
+  access: {
+    tier: "open",
+    state: "public-metadata",
+    authentication: "No provider connection is made by this candidate bundle.",
+  },
+  rights: {
+    state: "metadata-citation",
+    recordLicence: "MIT",
+    describedResourceLicence: "Open Government Licence where stated.",
+    attribution: "Office for National Statistics.",
+  },
+  status: "candidate-metadata",
+  sourceRefs: ["source:dataset"],
+  limitations: ["No live provider call, data distribution or service response is included."],
+  tags: ["ons", "provider"],
+  details: {
+    geographicScope: "UK statistics; dataset-specific",
+    datasetsServices: ["datasets", "versions", "editions", "dimensions", "observations"],
+    mechanisms: ["REST API", "bulk downloads"],
+    updateFrequency: "Dataset-specific",
+    formats: ["JSON", "CSV"],
+    recommendedIntegration: "Version-bound observation retrieval; this record does not execute it.",
+  },
+};
+
+export const landisProviderRecord: CatalogueRecord = {
+  ...onsProviderRecord,
+  id: "PV-LANDIS",
+  title: "LandIS",
+  description: "Cranfield University soil information service metadata.",
+  rights: {
+    ...onsProviderRecord.rights,
+    describedResourceLicence:
+      "Read and enforce each record licence; do not infer one blanket licence from open access.",
+    attribution: "Cranfield University and LandIS; apply source-specific attribution.",
+  },
+  limitations: [
+    "No live provider call, data distribution or service response is included.",
+    "Access and rights remain mixed and product-specific.",
+  ],
+  tags: ["landis", "provider", "soil"],
+  details: {
+    geographicScope: "England and Wales; product-specific",
+    datasetsServices: ["NATMAP", "Soilscapes", "National Soil Inventory"],
+    mechanisms: ["public portal", "downloads", "OGC API – Records catalogue"],
+    accessTiers: ["open", "commercial or restricted where record terms require"],
+    recommendedIntegration:
+      "Harvest records as metadata; cache only licence-confirmed products; do not execute here.",
+  },
+};
+
 export const navigation = {
   hrefForRecord: (recordId: string | null): string =>
     recordId === null ? "?view=cards" : `?view=cards#record=${encodeURIComponent(recordId)}`,

--- a/apps/public-explorer/test/unit/catalogue.test.ts
+++ b/apps/public-explorer/test/unit/catalogue.test.ts
@@ -54,6 +54,10 @@ describe("canonical catalogue validation", () => {
     const unsafeUrl = cloneFixture();
     unsafeUrl.records[0]!.details.url = "javascript:alert(1)";
     expect(() => parseCatalogue(unsafeUrl)).toThrow(/navigable URL/);
+
+    const invalidRetrievalDate = cloneFixture();
+    Object.assign(invalidRetrievalDate.records[0]!.details, { retrieved: "not-a-date" });
+    expect(() => parseCatalogue(invalidRetrievalDate)).toThrow(/valid calendar date|RFC 3339/);
   });
 
   it("rejects a missing legal caveat and dangerous object keys", () => {
@@ -98,6 +102,66 @@ describe("search and facets", () => {
     expect(searchRecords(bundle.records, rightsOnly)).toHaveLength(0);
   });
 
+  it("searches reviewed question and capability fields but not arbitrary details or rights", () => {
+    const bundle = parseCatalogue(cloneFixture());
+    const base = createDefaultExplorerState(bundle);
+    const template = bundle.records[1]!;
+    const question = {
+      ...template,
+      id: "LR-Q003",
+      type: "workflow" as const,
+      title: "LR-Q003 worked question",
+      rights: {
+        ...template.rights,
+        describedResourceLicence: "rights-only-sentinel",
+      },
+      details: {
+        questionId: "LR-Q003",
+        query: "online copy or official copy proof of ownership",
+        expectedPropositions: [
+          "An online copy is not proof of ownership.",
+          "Official copies have a distinct route.",
+        ],
+        arbitrarySummary: "unknown-detail-sentinel",
+        forbiddenTargets: [
+          { id: "NEGATIVE-TARGET", reason: "nested-detail-sentinel" },
+        ],
+      },
+    };
+    const provider = {
+      ...template,
+      id: "PV-ONS-DATA",
+      type: "provider" as const,
+      title: "ONS Data API",
+      details: {
+        datasetsServices: ["datasets", "versions", "editions", "dimensions", "observations"],
+      },
+    };
+    const records = [...bundle.records, question, provider];
+
+    expect(
+      searchRecords(records, {
+        ...base,
+        query: "online copy official copy proof ownership",
+        types: [],
+      }).map((record) => record.id),
+    ).toContain("LR-Q003");
+    expect(
+      searchRecords(records, { ...base, query: "dimensions observations", types: [] }).map(
+        (record) => record.id,
+      ),
+    ).toEqual(["PV-ONS-DATA"]);
+    expect(searchRecords(records, { ...base, query: "rights-only-sentinel", types: [] })).toEqual(
+      [],
+    );
+    expect(
+      searchRecords(records, { ...base, query: "unknown-detail-sentinel", types: [] }),
+    ).toEqual([]);
+    expect(
+      searchRecords(records, { ...base, query: "nested-detail-sentinel", types: [] }),
+    ).toEqual([]);
+  });
+
   it("derives state-aware counts while retaining zero-count known choices", () => {
     const bundle = parseCatalogue(cloneFixture());
     const state: ExplorerState = {
@@ -135,16 +199,25 @@ describe("derived evidence views", () => {
   });
 
   it("keeps observation, modification, publication and release semantics separate", () => {
-    const bundle = parseCatalogue(cloneFixture());
+    const fixture = cloneFixture();
+    Object.assign(fixture.records[0]!.details, {
+      releaseTaggedAt: "2026-08-12T01:43:30+01:00",
+    });
+    const bundle = parseCatalogue(fixture);
     const timeline = deriveTimeline(bundle.records);
     expect(timeline.events.filter((event) => event.kind === "observation")).toHaveLength(2);
     expect(timeline.events.filter((event) => event.kind === "modification")).toHaveLength(1);
     expect(timeline.events.filter((event) => event.kind === "publication")).toHaveLength(1);
-    expect(timeline.events.filter((event) => event.kind === "release")).toHaveLength(0);
+    expect(timeline.events.filter((event) => event.kind === "release")).toEqual([
+      expect.objectContaining({
+        recordId: DEFAULT_RECORD_ID,
+        date: "2026-08-12T01:43:30+01:00",
+      }),
+    ]);
     expect(timeline.missing).toEqual([
       { kind: "modification", recordCount: 1 },
       { kind: "publication", recordCount: 1 },
-      { kind: "release", recordCount: 2 },
+      { kind: "release", recordCount: 1 },
     ]);
   });
 });

--- a/changelog.d/DISC-103.added.md
+++ b/changelog.d/DISC-103.added.md
@@ -1,0 +1,3 @@
+- Added digest-locked HM Land Registry journeys and metadata-only ONS and LandIS
+  capability records with explicit source, date, access, rights and non-legal
+  boundaries.

--- a/docs/decisions/ADR-0006-reviewed-public-geospatial-examples.md
+++ b/docs/decisions/ADR-0006-reviewed-public-geospatial-examples.md
@@ -1,0 +1,52 @@
+# ADR-0006: Reviewed public geospatial examples
+
+- status: accepted
+- decided on: 20 August 2026
+- work item: DISC-103
+
+## Context
+
+The public discovery product needs useful examples from HM Land Registry, the
+Office for National Statistics and LandIS without importing provider payloads or
+repeating the completed research. Rights, access and dates differ by source. A
+public landing page does not make every described service or dataset open.
+
+The research pack records an unresolved HM Land Registry commit prefix. The local
+source repository contains an approved immutable `v0.3.0` release with a verified
+tag, commit, tree and release-root digest.
+
+## Decision
+
+Generate the examples only from checksum-locked research snapshots and selected
+files from HM Land Registry OKF release `v0.3.0`. Record that release as the
+superseding source identity; do not import mutable repository branches.
+
+Represent LR-Q003, LR-Q006 and LR-Q012 as non-executing discovery workflows. They
+preserve source-native identifiers, positive official sources, expected
+propositions and mandatory caveats, but do not expose or invoke their negative
+operational targets. Provider records describe capabilities only.
+
+Treat the published catalogue records as public metadata. Preserve described-source
+access and rights separately:
+
+- paid, authenticated and professional HM Land Registry services remain restricted;
+- selected HMLR datasets retain their per-record licence and attribution;
+- ONS products use the Open Government Licence only where the product says so and
+  retain named third-party conditions;
+- LandIS remains mixed access with rights determined per record and no blanket open
+  assertion.
+
+Keep source observation, upstream release, retrieval, GIS AI GO review and eventual
+deployment dates distinct. The Explorer remains a discovery aid and must never
+present indicative geometry as an exact legal boundary.
+
+## Consequences
+
+- source locks, record digests, rights review and forbidden-target checks are part
+  of deterministic build assurance;
+- the output contains no property, address, transaction, credential, service
+  response, provider dataset or real geometry payload;
+- provider names and source citations do not imply endorsement;
+- live provider adapters remain outside `v0.1.0`;
+- GitHub Pages remains disabled until DISC-104 verifies and deploys an immutable
+  artefact.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,6 +9,7 @@ research recommendations remain unchanged in the preserved pack at
 - [ADR-0003: MIT licence](ADR-0003-mit-licence.md)
 - [ADR-0004: Public autonomous delivery](ADR-0004-public-autonomous-delivery.md)
 - [ADR-0005: Static public Explorer](ADR-0005-static-public-explorer.md)
+- [ADR-0006: Reviewed public geospatial examples](ADR-0006-reviewed-public-geospatial-examples.md)
 
 Research decisions D01–D19 are accepted as constraints for building and evaluating
 Stage 0, not as blanket authority for later production stages. Research decision D20

--- a/docs/operations/DISC-103_VERIFICATION.md
+++ b/docs/operations/DISC-103_VERIFICATION.md
@@ -1,0 +1,79 @@
+# DISC-103 verification record
+
+- status: implementation candidate
+- reviewed on: 20 August 2026
+- work item: DISC-103
+- publication: none; GitHub Pages remains disabled
+
+## Outcome
+
+DISC-103 adds checksum-locked, metadata-only HM Land Registry, ONS and LandIS
+examples to the canonical OKF build and Explorer. It adds no live provider adapter,
+credential, property record, transaction, dataset payload or real geometry.
+
+## Source and rights gate
+
+The exact inputs, immutable HMLR release, date meanings, rights treatment and
+excluded fields are recorded in the
+[reviewed source ledger](../source-ledger/reviewed-public-examples-2026-08-20.md).
+The deterministic builder must fail on a digest mismatch, unknown or mixed rights
+presented as open, unresolved source, missing mandatory caveat or forbidden target.
+The four upstream HMLR files used by the projection or copied into its rights
+notices are bound to builder-owned v0.3.0 digests as well as the complete editable
+source-lock inventory.
+
+## Functional gate
+
+The final candidate must prove:
+
+- LR-Q003 retrieves the online-copy versus official-copy distinction and correct
+  public guidance without invoking a restricted ordering route;
+- LR-Q006 retrieves the documented index-map recovery route without treating source
+  code or address retrying as the official process;
+- LR-Q012 retains the indicative, non-legal conclusion and source evidence;
+- Price Paid displays its date, licence, attribution and address-field conditions
+  without publishing a row or address;
+- ONS exposes two non-executing capability records;
+- LandIS visibly retains mixed access and per-record rights;
+- the existing accessibility, security, clean-console and no-external-request
+  journeys continue to pass.
+
+## Local candidate evidence
+
+The complete `pnpm run check` gate passed on 20 August 2026 against the uncommitted
+candidate based on protected `main` at
+`6984f3097cff578f0d22088ca8582ebe55725115`:
+
+- 36 deterministic records: 1 bundle, 3 datasets, 4 providers, 24 sources and
+  4 workflows;
+- 4 gateway tests, 16 Explorer build-policy tests, 39 Explorer unit and component
+  tests, 31 repository Python tests and 2 execution-boundary tests;
+- 25 real-browser journeys, including 7 reviewed-example journeys and the existing
+  WCAG, keyboard, touch, forced-colour, reduced-motion and clean-console coverage;
+- 8 schemas and 53 evaluation records validated;
+- 286 local links, 183 immutable research hashes, 2 source-ledger snapshots and
+  71 source identifiers checked;
+- 429 text files scanned without a baseline secret or machine-path match;
+- 9 diagrams rendered and a 145-component CycloneDX SBOM generated.
+
+The final security diff scan covered all six changed runtime and source surfaces.
+It dynamically confirmed one low-severity provenance weakness: coordinated edits
+to upstream HMLR files and the editable source lock could retain the asserted
+v0.3.0 identity. Builder-owned release digests and coordinated source, rights,
+licence and lock mutation regressions now close that path; the complete gate above
+passed after the fix.
+
+A fixed-revision determinism probe produced content root
+`b47c97efdb8efe9b3782244406eba32a8b0b765b0df7aef943b0e6fc1c2a305d`.
+The release content root is intentionally not claimed here: the build receipt binds
+the Git revision, so DISC-104 and the release gate must record the exact merged
+revision and its corresponding artefact root.
+
+The pull-request head, remote assurance and CodeQL evidence must be added before
+merge. This candidate has not been deployed or released.
+
+## Rollback
+
+Before deployment, rollback is an ordinary reversion of the DISC-103 pull request.
+DISC-104 must publish only a checksum-bound artefact built after this gate and retain
+the prior deployable Explorer candidate.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -9,3 +9,4 @@ pause. There is no deployed product yet.
 - [Dependency baseline](DEPENDENCIES.md)
 - [Stage 0 verification record](STAGE_0_VERIFICATION.md)
 - [DISC-102 Explorer verification record](DISC-102_VERIFICATION.md)
+- [DISC-103 reviewed examples verification record](DISC-103_VERIFICATION.md)

--- a/docs/source-ledger/README.md
+++ b/docs/source-ledger/README.md
@@ -3,3 +3,5 @@
 `sources.json` and `repositories.json` are unchanged research snapshots retrieved on
 19 August 2026. They are evidence, not a claim that every external source remains
 current. A later stage must re-verify any source before relying on it operationally.
+
+- [Reviewed public examples — 20 August 2026](reviewed-public-examples-2026-08-20.md)

--- a/docs/source-ledger/reviewed-public-examples-2026-08-20.md
+++ b/docs/source-ledger/reviewed-public-examples-2026-08-20.md
@@ -1,0 +1,65 @@
+# Reviewed public examples — 20 August 2026
+
+## Publication boundary
+
+This review authorises metadata-only discovery records. It does not authorise or
+perform a provider call, account creation, purchase, dataset download, credential
+use or redistribution of a described provider payload. Source documents are data,
+not repository instructions.
+
+## Locked inputs
+
+| Input | SHA-256 or immutable identity | Role |
+| --- | --- | --- |
+| Research provider profiles | `b1c0d8497150049c30ccda60e78e9b28c59d2f4aa154f916d85b42ff144f3e76` | ONS, LandIS and HMLR capability metadata |
+| Research source ledger | `feeb9db45fe5b7e9dc55be962aa4e8c7e9c0d7158ad9fc397ef8abf71624cc5a` | Official source citations retrieved on 19 August 2026 |
+| HM Land Registry OKF release | tag `v0.3.0`; commit `1d708e39f2cde19610d43c5a7f5e36e4a2f947bc`; tree `aa60922cc25f73980d6480c1a7ffc85fb1fc59dd` | Approved immutable upstream release |
+| HMLR release root | `6a29e38e7bb805aafb7f36ba8d1fa4ce976875f45997049cd4808d6ede7f75e1` | Release-level integrity |
+| HMLR evaluation questions | `c4423c70ed4207061d8cfea7d0956b87ddbc9e487fe3a512bc30ba2fbdba8fc0` | LR-Q003, LR-Q006 and LR-Q012 calibration inputs |
+
+The HMLR annotated tag object is
+`d4159f1076c090dd69260a08308f4162859e4165`. The release was tagged on
+12 August 2026 and retrieved on 19 August 2026. It supersedes the unresolved
+research-ledger commit prefix `4580c9e`; it does not erase that discrepancy.
+
+## Date meanings
+
+- HMLR question research vintage: 29 July 2026;
+- HMLR source observation: `2026-07-29T07:53:38Z`;
+- HMLR upstream release: `2026-08-12T01:43:30+01:00`;
+- HMLR release retrieval: 19 August 2026;
+- research provider snapshot generation: `2026-08-19T13:30:00+01:00`;
+- official source-ledger retrieval: 19 August 2026;
+- GIS AI GO review: 20 August 2026;
+- GIS AI GO deployment: not yet published; DISC-104 controls that date.
+
+Dataset-native dates remain dataset fields. They must not be replaced by retrieval,
+review or bundle-generation dates.
+
+## Rights and use
+
+- HMLR journey metadata is attributed to “HM Land Registry public-estate OKF
+  Bundle contributors, v0.3.0” under CC BY 4.0.
+- Property-information and portal sources are public guidance metadata describing
+  paid, authenticated or approved-professional services. No transaction occurs.
+- Selected HMLR datasets retain their per-record terms. Price Paid address fields
+  have additional Ordnance Survey and Royal Mail conditions; no address or row is
+  published.
+- ONS capability metadata does not apply the Open Government Licence to every
+  described product. Named third-party rights remain product-specific.
+- LandIS is attributed to Cranfield University and LandIS. Access is mixed and
+  rights must be determined per record.
+
+## Excluded inputs and outputs
+
+Mutable HMLR `main`, the dirty local ONS repository, MCP-Geo provider payloads,
+authenticated material and warehouse records are excluded. The derivative excludes
+title, ownership, address, transaction, UPRN, coordinate, geometry, feature,
+credential, cookie, certificate, signed-URL, service-response, logo and provider
+payload fields. It does not expose or request the three negative operational targets
+in LR-Q003, LR-Q006 and LR-Q012.
+
+HM Land Registry, ONS, Ordnance Survey, Royal Mail, Cranfield University and LandIS
+remain authoritative for their own current sources and terms. GIS AI GO is
+authoritative only for its normalised metadata publication and is not endorsed by
+those organisations.

--- a/okf/profile/public-discovery-v1.json
+++ b/okf/profile/public-discovery-v1.json
@@ -28,16 +28,25 @@
   "forbidden_payload_keys": [
     "address",
     "apiKey",
+    "certificate",
     "coordinates",
+    "cookie",
     "credential",
+    "feature",
     "features",
     "geometry",
+    "logo",
     "ownerName",
+    "ownership",
     "password",
     "personalData",
     "propertyAddress",
+    "serviceResponse",
+    "signedUrl",
+    "titleNumber",
     "token",
-    "transactionRow"
+    "transactionRow",
+    "uprn"
   ],
   "url_policy": {
     "allowed": [

--- a/okf/source-lock.json
+++ b/okf/source-lock.json
@@ -4,7 +4,7 @@
   "inputs": [
     {
       "path": "THIRD_PARTY.md",
-      "sha256": "b6663752dffd08483b5ef2c371cca332f2f408fbc94f1a5db01f56e9852b4465",
+      "sha256": "1d243b9fe1319a2705c2e82d8ca5394361ddbe180fa7f2d0b6e39b1c0d76442e",
       "role": "live-third-party-notice"
     },
     {
@@ -24,12 +24,12 @@
     },
     {
       "path": "okf/profile/public-discovery-v1.json",
-      "sha256": "b7a691d076436f41fee5ea1b4ec04e1edd71ba9d450259f0c728b67ddc33466d",
+      "sha256": "d69cd91bd2e5ebdcb4d71686b0990476c9011dc0e4b2b117ba3ebec673171ded",
       "role": "live-publication-profile"
     },
     {
       "path": "okf/source/publication.json",
-      "sha256": "317a63811029f25314fcfd17dd27807b1fc855b9b182fa76e1b6d4f2368a081f",
+      "sha256": "0f9f2f074796225bfe00a711641c7b3e56c0ebf03ee0a495ae8f8a61df49c91a",
       "role": "live-publication-selection"
     },
     {
@@ -39,8 +39,13 @@
     },
     {
       "path": "okf/vendor/okf-landregistry/v0.3.0/PROVENANCE.md",
-      "sha256": "f801360d07d261e36d5178335374b92d93a703a0e258f5e46f35b9c5f6a77951",
+      "sha256": "1193e604d5751484a8672d503e645e34caddcfe8619000a465e80c819a66c6b8",
       "role": "project-provenance-note"
+    },
+    {
+      "path": "okf/vendor/okf-landregistry/v0.3.0/evaluation/questions.json",
+      "sha256": "c4423c70ed4207061d8cfea7d0956b87ddbc9e487fe3a512bc30ba2fbdba8fc0",
+      "role": "upstream-evaluation-questions"
     },
     {
       "path": "okf/vendor/okf-landregistry/v0.3.0/governance/rights-review.json",
@@ -82,11 +87,13 @@
     "repository": "https://github.com/chris-page-gov/okf-LandRegistry",
     "retrieved_on": "2026-08-19",
     "tag": "v0.3.0",
+    "tagged_at": "2026-08-12T01:43:30+01:00",
     "annotated_tag_object": "d4159f1076c090dd69260a08308f4162859e4165",
     "commit": "1d708e39f2cde19610d43c5a7f5e36e4a2f947bc",
     "tree": "aa60922cc25f73980d6480c1a7ffc85fb1fc59dd",
     "approved_candidate": "751b6c1e80fbbad3c07f19798c74aebd603eb62c",
-    "release_root_sha256": "6a29e38e7bb805aafb7f36ba8d1fa4ce976875f45997049cd4808d6ede7f75e1"
+    "release_root_sha256": "6a29e38e7bb805aafb7f36ba8d1fa4ce976875f45997049cd4808d6ede7f75e1",
+    "evaluation_questions_sha256": "c4423c70ed4207061d8cfea7d0956b87ddbc9e487fe3a512bc30ba2fbdba8fc0"
   },
   "supersedes_unresolved_research_reference": {
     "recorded_commit_prefix": "4580c9e",

--- a/okf/source/publication.json
+++ b/okf/source/publication.json
@@ -8,12 +8,22 @@
   "compatibility_profile": "https://chris-page-gov.github.io/okf-explorer/profile/bundle-wiki/v1/",
   "status": "candidate",
   "observed_at": "2026-07-29T07:53:38Z",
-  "reviewed_at": "2026-08-19T00:00:00Z",
-  "stale_after": "2026-11-19T00:00:00Z",
+  "reviewed_at": "2026-08-20T00:00:00Z",
+  "stale_after": "2026-11-20T00:00:00Z",
+  "expected_record_count": 36,
   "selected": {
     "research_provider_ids": [
-      "PV-HMLR-OPEN"
+      "PV-HMLR-OPEN",
+      "PV-LANDIS",
+      "PV-ONS-DATA",
+      "PV-ONS-GEO"
     ],
+    "research_provider_sha256_by_id": {
+      "PV-HMLR-OPEN": "2c9b1712ad8995bd4e6bd37699bad6fc233462cf874f7fdba14e5e0bfb23f824",
+      "PV-LANDIS": "a735efba3e6d58d533f17d438e053246f7902705881186de542f5d26043e2c2a",
+      "PV-ONS-DATA": "535e6eb65fc9af4507e30700d425393a658a085a3a240689f4b37124dc8f8622",
+      "PV-ONS-GEO": "75f4313b278f360c0e60a8095ffdedca16aaabc7ce7ec91448ba1a1659203c1c"
+    },
     "research_workflow_ids": [
       "WF01"
     ],
@@ -21,7 +31,17 @@
       "hmlr:dataset:inspire-index-polygons",
       "hmlr:dataset:local-land-charges-inspire",
       "hmlr:dataset:price-paid-data"
-    ]
+    ],
+    "hmlr_question_ids": [
+      "LR-Q003",
+      "LR-Q006",
+      "LR-Q012"
+    ],
+    "hmlr_question_sha256_by_id": {
+      "LR-Q003": "1ceea667a350027240418de79439ecbe83f77a7243290b7970e3847a19f84547",
+      "LR-Q006": "3d4980bd7f63ff5c65bd519584a42c85adab907bad17d216345467d07c507ab0",
+      "LR-Q012": "84269ab3c74e31517e7fb9a2c3eb7fba71b9e9757418be5674cfe778b88d452c"
+    }
   },
   "attribution_by_record": {
     "hmlr:dataset:inspire-index-polygons": "HM Land Registry and Ordnance Survey attribution is required by the source terms. This bundle contains metadata only.",
@@ -29,8 +49,10 @@
     "hmlr:dataset:price-paid-data": "HM Land Registry attribution is required. Address fields in the source data have additional Ordnance Survey and Royal Mail conditions; this bundle contains no address or transaction rows."
   },
   "limitations": [
-    "This candidate contains metadata only and does not include provider distributions, property records, addresses, transactions or geometry.",
-    "It does not implement an Explorer, MCP listener, provider call, policy decision or legal determination.",
+    "This candidate contains metadata only and does not include provider distributions, property records, addresses, transaction rows or geometry.",
+    "The HMLR question journeys are non-executing discovery aids. They do not authenticate to, order from or automate a paid, portal, Business Gateway or terms-restricted service.",
+    "ONS Open Government Licence coverage and LandIS access and rights remain product- or record-specific; a public catalogue page is not a blanket reuse grant.",
+    "It does not implement an MCP listener, provider call, policy decision or legal determination.",
     "Source URLs, release dates, fees and terms must be revalidated before the first supported release.",
     "The HMLR source release records no independent human legal, licence, privacy, security or accessibility audit."
   ]

--- a/okf/vendor/okf-landregistry/v0.3.0/PROVENANCE.md
+++ b/okf/vendor/okf-landregistry/v0.3.0/PROVENANCE.md
@@ -10,6 +10,7 @@ under its upstream licence: code is Apache-2.0 and original metadata, evaluation
 governance material is CC BY 4.0. HMLR, GOV.UK and other third-party source material
 retains its own rights and conditions.
 
-GIS AI GO projects only three reviewed metadata records. It imports no dataset rows,
-addresses, transactions, property records, geometry, credentials or service responses.
-Public access to a source page is not treated as blanket permission for its contents.
+GIS AI GO projects three reviewed dataset metadata records and three non-executing
+evaluation journeys. It imports no dataset rows, addresses, transactions, property
+records, geometry, credentials or service responses. Public access to a source page
+is not treated as blanket permission for its contents.

--- a/okf/vendor/okf-landregistry/v0.3.0/evaluation/questions.json
+++ b/okf/vendor/okf-landregistry/v0.3.0/evaluation/questions.json
@@ -1,0 +1,1575 @@
+{
+  "schema": "okf-explorer-evaluation-suite.v1",
+  "title": "HM Land Registry OKF v0.3.0 candidate calibration questions",
+  "description": "A bounded calibration set of 24 competency and retrieval questions. Executable forbidden-target and required-caveat assertions supplement, but do not replace, reviewer-owned held-out cases.",
+  "status": "candidate-input-v0.3.0",
+  "verification_status": "version-scoped-digest-bound-external-evidence",
+  "research_cutoff": "2026-07-29",
+  "target_bundle": "../okf-explorer.json",
+  "persona_catalogue": "../personas/personas-and-user-stories.json",
+  "question_count": 24,
+  "suite_boundary": "The suite samples critical first-release roles and risks. It does not claim complete coverage of HM Land Registry services, users, law, guidance, datasets or APIs.",
+  "direct_source_baseline": {
+    "id": "BASELINE-DIRECT-OFFICIAL-SOURCES",
+    "method": "For each question, open the named canonical official source, record the page or contract identity and observation date, then compare the expected propositions and limitations with the bundle result.",
+    "comparison_dimensions": [
+      "correct official route",
+      "source and assertion authority",
+      "access and licence",
+      "scope and denominator",
+      "release, observation, registration and catalogue dates",
+      "legal or spatial limitation",
+      "language and accessibility"
+    ],
+    "restrictions": [
+      "Do not create an account or make a paid transaction.",
+      "Do not call authenticated APIs, the portal, Business Gateway or restricted search services.",
+      "Do not store credentials, certificates, session state or signed download links.",
+      "Treat expected propositions as bounded acceptance expectations, not verified gold answers."
+    ]
+  },
+  "hard_failures": [
+    {
+      "id": "HF-LEGAL-BOUNDARY",
+      "description": "A general or indicative boundary, title-plan line or INSPIRE polygon is presented as the exact legal boundary or definitive registered extent."
+    },
+    {
+      "id": "HF-LICENCE-ACCESS",
+      "description": "The result states or implies open, free or reusable access where an account, fee, bespoke licence, third-party right or other restriction applies."
+    },
+    {
+      "id": "HF-DATE-CURRENCY",
+      "description": "A GOV.UK or catalogue modification date, bundle generation date or observation date is presented as dataset release, registration or legal currency."
+    },
+    {
+      "id": "HF-AUTHORITY",
+      "description": "An unofficial, derived, normalised or catalogue assertion is presented as an official HMLR statement, or an informational online copy is presented as official proof."
+    },
+    {
+      "id": "HF-RESTRICTED-AUTOMATION",
+      "description": "The bundle performs, recommends or appears to authorise automated access to an authenticated, paid, portal, Business Gateway or terms-restricted service, or exposes a credential."
+    },
+    {
+      "id": "HF-COVERAGE",
+      "description": "The result claims complete geographic, authority, service or dataset coverage without a named denominator, as-of date and visible exclusions."
+    },
+    {
+      "id": "HF-ACCESSIBILITY",
+      "description": "A critical discovery or evidence-inspection task cannot be completed using a keyboard or lacks an accessible name, visible focus, status announcement or non-visual equivalent."
+    },
+    {
+      "id": "HF-WELSH-LANGUAGE",
+      "description": "Welsh availability or source-native Welsh content is suppressed, mistranslated, merged into English without a language distinction or falsely described as unavailable."
+    }
+  ],
+  "metrics": {
+    "retrieval": [
+      "expected-source recall at 5",
+      "first relevant result rank",
+      "facet task completion",
+      "zero-result recovery",
+      "query and filter URL restoration"
+    ],
+    "display": [
+      "expected proposition visibility",
+      "legal and spatial limitation visibility",
+      "licence and access visibility",
+      "date-label separation",
+      "plain-language metadata-gap wording"
+    ],
+    "accessibility": [
+      "keyboard task completion",
+      "accessible name coverage",
+      "visible and unobscured focus",
+      "status announcement",
+      "usable layout at 400 percent zoom",
+      "language metadata on Welsh text"
+    ],
+    "provenance_and_safety": [
+      "canonical-source resolution rate",
+      "citation coverage per material proposition",
+      "authority and derivation label accuracy",
+      "observation and release date traceability",
+      "hard-failure count",
+      "restricted-route non-invocation"
+    ]
+  },
+  "rubric": {
+    "retrieval": {
+      "points": 35,
+      "description": "Find the expected official source or evidence-bearing bundle record and preserve search/filter state."
+    },
+    "display": {
+      "points": 25,
+      "description": "Show the expected proposition, scope, access, date and legal or spatial limitation clearly."
+    },
+    "accessibility": {
+      "points": 20,
+      "description": "Support keyboard and assistive-technology inspection, focus, status and language requirements."
+    },
+    "govuk": {
+      "points": 20,
+      "description": "Resolve canonical provenance, distinguish authority and derivation, state licence/access correctly and avoid every hard failure."
+    }
+  },
+  "questions": [
+    {
+      "id": "LR-Q001",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "What does HM Land Registry cover?",
+      "intent": "Find the official statement of HMLR's remit and avoid applying the bundle outside its jurisdiction or authority.",
+      "persona_ids": [
+        "LR-P01",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S01"
+      ],
+      "expected_terms": [
+        "HM Land Registry",
+        "England and Wales",
+        "ownership",
+        "official source"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/organisations/land-registry"
+        }
+      ],
+      "expected_propositions": [
+        "HMLR registers ownership of land and property in England and Wales.",
+        "The OKF bundle is a discovery aid and does not replace HMLR's authoritative records or services."
+      ],
+      "near_miss_rule": "A result about Scotland, Northern Ireland, UK-wide housing statistics or a secondary catalogue does not establish HMLR's remit; an England-and-Wales label also does not prove that every linked dataset has complete coverage.",
+      "hard_failure_ids": [
+        "HF-AUTHORITY",
+        "HF-COVERAGE"
+      ],
+      "tags": [
+        "public",
+        "scope",
+        "authority"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDED-COVERAGE",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q001-HM-LAND-REGISTRY-ANNUAL-REPORTS",
+          "canonical_url": "https://www.gov.uk/government/collections/hm-land-registry-annual-reports-and-accounts",
+          "max_rank": 3,
+          "reason": "An annual-report collection is an organisational publication, not the authoritative remit statement, and must not outrank it."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/organisations/land-registry"
+    },
+    {
+      "id": "LR-Q002",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "title register title summary title plan differences",
+      "intent": "Distinguish the main property-information products and what each contains.",
+      "persona_ids": [
+        "LR-P01",
+        "LR-P02",
+        "LR-P03"
+      ],
+      "story_ids": [
+        "LR-S02"
+      ],
+      "expected_terms": [
+        "title register",
+        "title summary",
+        "title plan",
+        "general boundaries"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-PROPERTY-SERVICE",
+          "canonical_url": "https://www.gov.uk/search-property-information-land-registry"
+        }
+      ],
+      "expected_propositions": [
+        "The title register, title summary and title plan expose different information.",
+        "A title plan normally shows general rather than exact boundaries."
+      ],
+      "near_miss_rule": "A result that treats the three products as interchangeable or describes the title plan as exact is not correct.",
+      "hard_failure_ids": [
+        "HF-LEGAL-BOUNDARY",
+        "HF-AUTHORITY"
+      ],
+      "tags": [
+        "public",
+        "conveyancing",
+        "lending",
+        "title-information"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDARY-NOT-CONCLUSION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q002-LOCAL-LAND-CHARGES-POLYGONS",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/llc",
+          "max_rank": 5,
+          "reason": "A Local Land Charges polygon dataset does not explain the distinct evidential roles of a title summary, register and plan."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/search-property-information-land-registry"
+    },
+    {
+      "id": "LR-Q003",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "online copy or official copy proof of ownership",
+      "intent": "Find the route and limitation that distinguishes informational downloads from official copies.",
+      "persona_ids": [
+        "LR-P01",
+        "LR-P02"
+      ],
+      "story_ids": [
+        "LR-S02"
+      ],
+      "expected_terms": [
+        "online copy",
+        "official copy",
+        "proof of ownership",
+        "fee"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-PROPERTY-SERVICE",
+          "canonical_url": "https://www.gov.uk/search-property-information-land-registry"
+        },
+        {
+          "source_id": "SRC-PORTAL",
+          "canonical_url": "https://www.gov.uk/guidance/land-registry-portal-how-to-request-official-copies"
+        }
+      ],
+      "expected_propositions": [
+        "An online copy is not proof of ownership.",
+        "Official copies have a distinct order route and evidential role."
+      ],
+      "near_miss_rule": "Merely linking to a paid download without explaining its evidential status is insufficient.",
+      "hard_failure_ids": [
+        "HF-AUTHORITY",
+        "HF-LICENCE-ACCESS"
+      ],
+      "tags": [
+        "public",
+        "conveyancing",
+        "official-copy"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-RIGHTS-AND-ACCESS",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q003-BUSINESS-GATEWAY-OFFICIAL-COPY",
+          "canonical_url": "https://businessgateway.landregistry.gov.uk/bg2/s1/v1",
+          "max_rank": 4,
+          "reason": "A restricted ordering endpoint must not outrank public guidance explaining cost, access and evidential status."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/guidance/land-registry-portal-how-to-request-official-copies"
+    },
+    {
+      "id": "LR-Q004",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "does a title plan show the exact legal boundary",
+      "intent": "Retrieve authoritative boundary guidance and expose the general-boundaries limitation.",
+      "persona_ids": [
+        "LR-P01",
+        "LR-P02",
+        "LR-P04",
+        "LR-P06"
+      ],
+      "story_ids": [
+        "LR-S03"
+      ],
+      "expected_terms": [
+        "general boundary",
+        "determined boundary",
+        "exact line",
+        "title plan"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/publications/hm-land-registry-plans-boundaries-pg40s3"
+        }
+      ],
+      "expected_propositions": [
+        "Most registered title boundaries are general boundaries.",
+        "A determined boundary is a distinct recorded status and must not be inferred from map precision."
+      ],
+      "near_miss_rule": "A map scale, red edging or coordinate precision does not establish an exact legal boundary.",
+      "hard_failure_ids": [
+        "HF-LEGAL-BOUNDARY"
+      ],
+      "tags": [
+        "public",
+        "conveyancing",
+        "gis",
+        "boundaries"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDARY-NOT-CONCLUSION"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q004-NATIONAL-POLYGON-SERVICE",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/nps",
+          "max_rank": 9,
+          "reason": "A precise polygon product must not outrank guidance explaining that title-plan geometry is not an exact legal boundary."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/publications/hm-land-registry-plans-boundaries-pg40s3"
+    },
+    {
+      "id": "LR-Q005",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "practice guide general agreed determined boundaries",
+      "intent": "Find the current official practice guidance needed to distinguish boundary concepts.",
+      "persona_ids": [
+        "LR-P02"
+      ],
+      "story_ids": [
+        "LR-S03"
+      ],
+      "expected_terms": [
+        "practice guide 40",
+        "general boundaries",
+        "boundary agreement",
+        "determined boundary"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/publications/hm-land-registry-plans-boundaries-pg40s3"
+        }
+      ],
+      "expected_propositions": [
+        "HMLR practice-guide supplements distinguish general boundaries from agreements and determined boundaries.",
+        "The current official guide identity and update context remain inspectable."
+      ],
+      "near_miss_rule": "A blog post, forum answer or old PDF without a current canonical guide route is not sufficient authority.",
+      "hard_failure_ids": [
+        "HF-AUTHORITY",
+        "HF-LEGAL-BOUNDARY"
+      ],
+      "tags": [
+        "conveyancing",
+        "practice-guide",
+        "boundaries"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDARY-NOT-CONCLUSION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q005-AGREED-NOTICE-PORTAL",
+          "canonical_url": "https://www.gov.uk/guidance/land-registry-portal-agreed-notice-to-note-a-charge-e-an1",
+          "max_rank": 3,
+          "reason": "A portal transaction containing the word agreed is not guidance on agreed or determined boundaries."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/publications/hm-land-registry-plans-boundaries-pg40s3"
+    },
+    {
+      "id": "LR-Q006",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "address search misses title search of the index map",
+      "intent": "Find the official recovery route when a property address search may not reveal every affected title.",
+      "persona_ids": [
+        "LR-P02"
+      ],
+      "story_ids": [
+        "LR-S04"
+      ],
+      "expected_terms": [
+        "property details",
+        "title number",
+        "search of the index map",
+        "official copies"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-PORTAL",
+          "canonical_url": "https://www.gov.uk/guidance/land-registry-portal-how-to-request-official-copies"
+        },
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/guidance/land-registry-portal-request-a-search-of-the-index-map"
+        },
+        {
+          "source_id": "SRC-PROPERTY-SERVICE",
+          "canonical_url": "https://www.gov.uk/search-property-information-land-registry"
+        }
+      ],
+      "expected_propositions": [
+        "Searching only by property details may not show every title affecting the property.",
+        "A search of the index map is the documented alternative for the relevant task."
+      ],
+      "near_miss_rule": "Retrying broader address text is not equivalent to the documented index-map process.",
+      "hard_failure_ids": [
+        "HF-AUTHORITY",
+        "HF-RESTRICTED-AUTOMATION"
+      ],
+      "tags": [
+        "conveyancing",
+        "official-copy",
+        "index-map"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-NO-RESTRICTED-AUTOMATION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q006-ADDRESS-SEARCH-CODE",
+          "canonical_url": "https://github.com/LandRegistry/address-search-api",
+          "max_rank": 6,
+          "reason": "A source-code repository for address search is not the documented index-map process and must not outrank it."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/guidance/land-registry-portal-how-to-request-official-copies"
+    },
+    {
+      "id": "LR-Q007",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "portal Business Gateway professional access requirements",
+      "intent": "Distinguish professional service guidance from public discovery and make access restrictions visible.",
+      "persona_ids": [
+        "LR-P02",
+        "LR-P05"
+      ],
+      "story_ids": [
+        "LR-S04"
+      ],
+      "expected_terms": [
+        "Business e-services",
+        "portal",
+        "approved customer",
+        "Business Gateway"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-PORTAL",
+          "canonical_url": "https://www.gov.uk/government/collections/how-to-use-the-land-registry-portal"
+        },
+        {
+          "source_id": "SRC-BG-TECHDOC",
+          "canonical_url": "https://landregistry.github.io/bg-dev-pack-redesign/"
+        }
+      ],
+      "expected_propositions": [
+        "Portal and Business Gateway are professional service surfaces with approval or credential requirements.",
+        "Public documentation does not authorise the bundle to make a transaction or production call."
+      ],
+      "near_miss_rule": "A public developer page is not evidence that the production service is anonymous or open for unrestricted automation.",
+      "hard_failure_ids": [
+        "HF-RESTRICTED-AUTOMATION",
+        "HF-LICENCE-ACCESS"
+      ],
+      "tags": [
+        "conveyancing",
+        "api",
+        "restricted-access"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-NO-RESTRICTED-AUTOMATION",
+        "CAV-RIGHTS-AND-ACCESS"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q007-DIRECT-INTEGRATION-GUIDE",
+          "canonical_url": "https://www.gov.uk/guidance/direct-integration-with-business-gateway",
+          "max_rank": 10,
+          "reason": "A public integration guide is not evidence of anonymous production access and must not displace the official access route."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/collections/how-to-use-the-land-registry-portal"
+    },
+    {
+      "id": "LR-Q008",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "what mortgage or lender information is in title information",
+      "intent": "Find what title information says about a lender or discharged mortgage without overstating evidential completeness.",
+      "persona_ids": [
+        "LR-P02",
+        "LR-P03"
+      ],
+      "story_ids": [
+        "LR-S05"
+      ],
+      "expected_terms": [
+        "lender",
+        "mortgage",
+        "discharged",
+        "title register"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-PROPERTY-SERVICE",
+          "canonical_url": "https://www.gov.uk/get-information-about-property-and-land/search-the-register"
+        },
+        {
+          "source_id": "SRC-PROPERTY-SERVICE",
+          "canonical_url": "https://www.gov.uk/search-property-information-land-registry"
+        }
+      ],
+      "expected_propositions": [
+        "Official register guidance says the title register may show whether a mortgage has been discharged, while the title summary may show a lender's name and address when there is a mortgage.",
+        "The current property-information service promises only whether the property has a mortgage; downloaded online information is not official proof and the official-copy route remains distinct."
+      ],
+      "near_miss_rule": "A summary that only says a mortgage is present or absent is not evidence of lender identity, discharge status or absence of other charge entries; an informational online copy is not official proof.",
+      "hard_failure_ids": [
+        "HF-AUTHORITY"
+      ],
+      "tags": [
+        "lending",
+        "mortgage",
+        "title-information"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q008-ONLINE-OWNER-VERIFICATION",
+          "canonical_url": "https://businessgateway.landregistry.gov.uk/b2b/EOOV_SoapEngine/OnlineOwnershipVerificationV1_0WebService?wsdl=",
+          "max_rank": 7,
+          "reason": "A restricted ownership-verification service must not displace public guidance about what title information can establish."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/get-information-about-property-and-land/search-the-register"
+    },
+    {
+      "id": "LR-Q009",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "Price Paid Data current property value limitations",
+      "intent": "Retrieve the official Price Paid Data description, temporal coverage and reuse limitations.",
+      "persona_ids": [
+        "LR-P03",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S05"
+      ],
+      "expected_terms": [
+        "Price Paid Data",
+        "transaction",
+        "1995",
+        "accuracy"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads"
+        }
+      ],
+      "expected_propositions": [
+        "Price Paid Data records qualifying lodged transactions rather than a current valuation.",
+        "Its coverage, update and accuracy notes must remain visible."
+      ],
+      "near_miss_rule": "A historic transaction amount is not a current valuation or proof of the current registered proprietor.",
+      "hard_failure_ids": [
+        "HF-DATE-CURRENCY",
+        "HF-AUTHORITY"
+      ],
+      "tags": [
+        "lending",
+        "valuation",
+        "price-paid-data"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-DATE-SEPARATION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q009-HISTORIC-PRICE-PAID-NEWS",
+          "canonical_url": "https://www.gov.uk/government/news/april-2016-price-paid-data",
+          "max_rank": 2,
+          "reason": "A historic monthly release notice must not outrank the current dataset guidance or be treated as a present valuation."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads"
+    },
+    {
+      "id": "LR-Q010",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "data.gov.uk land ownership catalogue modified date versus OCOD publisher dataset release date",
+      "intent": "Test whether the bundle keeps catalogue, observation, release and registration dates separate.",
+      "persona_ids": [
+        "LR-P03",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S05"
+      ],
+      "expected_terms": [
+        "data.gov.uk catalogue modified",
+        "OCOD",
+        "publisher release",
+        "covered month"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-NDL",
+          "canonical_url": "https://www.data.gov.uk/collections/land-and-property/land-and-property-ownership"
+        },
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/ocod"
+        }
+      ],
+      "expected_propositions": [
+        "The data.gov.uk collection modification timestamp describes catalogue metadata, not the underlying dataset release, register update or legal currency.",
+        "The OCOD publisher page and file identity are the operational evidence for release cadence and covered month; observation, bundle-build and registration dates remain distinct."
+      ],
+      "near_miss_rule": "A recent catalogue, page, observation or bundle timestamp cannot repair an unknown publisher release date or covered month.",
+      "hard_failure_ids": [
+        "HF-DATE-CURRENCY",
+        "HF-AUTHORITY"
+      ],
+      "tags": [
+        "lending",
+        "provenance",
+        "dates"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-DATE-SEPARATION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q010-GEOSPATIAL-CATALOGUE",
+          "canonical_url": "https://www.gov.uk/government/publications/geospatial-commission-data-catalogue-hm-land-registry",
+          "max_rank": 3,
+          "reason": "A broad catalogue record cannot substitute its modification date for the publisher dataset release identity."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.data.gov.uk/collections/land-and-property/land-and-property-ownership"
+    },
+    {
+      "id": "LR-Q011",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "HM Land Registry publisher spatial datasets format cost licence update API GIS file size",
+      "intent": "Discover the publisher catalogue and compare spatial products by format, access and GIS requirement.",
+      "persona_ids": [
+        "LR-P04"
+      ],
+      "story_ids": [
+        "LR-S06"
+      ],
+      "expected_terms": [
+        "GIS",
+        "GML",
+        "shapefile",
+        "API"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/"
+        },
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/publications/geospatial-commission-data-catalogue-hm-land-registry"
+        }
+      ],
+      "expected_propositions": [
+        "The publisher-operated Use land and property data catalogue is the operational route for current format, cost, licence, update cadence, API availability and product-specific tooling information.",
+        "The Geospatial Commission catalogue is a 2020 discovery snapshot covering only some HMLR datasets; its page-modification date is not dataset currency and underlying product licences vary.",
+        "Some spatial downloads are large and require GIS software; the current product page controls the applicable details."
+      ],
+      "near_miss_rule": "A generic or 2020 catalogue row alone cannot establish current access, licence, release cadence, API availability, file size or completeness; follow the publisher-operated product page.",
+      "hard_failure_ids": [
+        "HF-LICENCE-ACCESS",
+        "HF-AUTHORITY",
+        "HF-DATE-CURRENCY",
+        "HF-COVERAGE"
+      ],
+      "tags": [
+        "data",
+        "gis",
+        "formats"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDED-COVERAGE",
+        "CAV-DATE-SEPARATION",
+        "CAV-RIGHTS-AND-ACCESS",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q011-PORTAL-ACCOUNT-UPDATE",
+          "canonical_url": "https://www.gov.uk/guidance/land-registry-portal-update-a-business-unit-account",
+          "max_rank": 2,
+          "reason": "An account-administration page sharing the word update is not publisher evidence for dataset formats, costs, licences or cadence."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/publications/geospatial-commission-data-catalogue-hm-land-registry"
+    },
+    {
+      "id": "LR-Q012",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "INSPIRE polygon indicative or legal boundary",
+      "intent": "Verify that spatial discovery polygons are not presented as exact legal title or charge boundaries.",
+      "persona_ids": [
+        "LR-P02",
+        "LR-P04",
+        "LR-P06"
+      ],
+      "story_ids": [
+        "LR-S03"
+      ],
+      "expected_terms": [
+        "INSPIRE",
+        "indicative",
+        "polygon",
+        "legal boundary"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/llc"
+        },
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/publications/hm-land-registry-plans-boundaries-pg40s3"
+        }
+      ],
+      "expected_propositions": [
+        "Local Land Charges INSPIRE data shows indicative locations.",
+        "Indicative geometry is a discovery aid and does not establish an exact legal title boundary."
+      ],
+      "near_miss_rule": "Displaying a polygon on a precise basemap does not upgrade its legal meaning.",
+      "hard_failure_ids": [
+        "HF-LEGAL-BOUNDARY"
+      ],
+      "tags": [
+        "gis",
+        "local-authority",
+        "boundaries"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDARY-NOT-CONCLUSION"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q012-NATIONAL-POLYGON-SERVICE",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/nps",
+          "max_rank": 3,
+          "reason": "Another polygon product cannot establish that INSPIRE geometry is an exact legal boundary."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/datasets/llc"
+    },
+    {
+      "id": "LR-Q013",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "which local authorities are in Local Land Charges INSPIRE data",
+      "intent": "Find the dated authority-level coverage statement and known migration limitation.",
+      "persona_ids": [
+        "LR-P04",
+        "LR-P06",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S07"
+      ],
+      "expected_terms": [
+        "local authority",
+        "migrated",
+        "coverage",
+        "monthly"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/llc"
+        },
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/publications/hm-land-registry-local-land-charges-programme/local-land-charges-programme"
+        }
+      ],
+      "expected_propositions": [
+        "Only migrated local-authority register data is available through the national Local Land Charges data or service; not every authority has migrated.",
+        "Coverage must be checked against a named authority list and as-of date; a planned transfer date is not evidence that migration has completed.",
+        "The monthly INSPIRE dataset is further limited to the publisher's stated theme groups."
+      ],
+      "near_miss_rule": "A headline denominator, an England-and-Wales label or a planned transfer date does not prove current migration or inclusion in the monthly INSPIRE file.",
+      "hard_failure_ids": [
+        "HF-COVERAGE",
+        "HF-DATE-CURRENCY"
+      ],
+      "tags": [
+        "gis",
+        "local-authority",
+        "coverage"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDED-COVERAGE",
+        "CAV-DATE-SEPARATION"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q013-MIGRATION-NEWS",
+          "canonical_url": "https://www.gov.uk/government/news/five-local-authorities-join-hm-land-registry-s-local-land-charges-register",
+          "max_rank": 3,
+          "reason": "A migration news item is not the current bounded authority list or monthly dataset denominator."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/datasets/llc"
+    },
+    {
+      "id": "LR-Q014",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "HM Land Registry INSPIRE GML British National Grid CRS Welsh place names language metadata",
+      "intent": "Test whether spatial records retain format, CRS or coordinate context, vintage, authority and language metadata where the source supplies them.",
+      "persona_ids": [
+        "LR-P04",
+        "LR-P06",
+        "LR-P09"
+      ],
+      "story_ids": [
+        "LR-S06"
+      ],
+      "expected_terms": [
+        "GML",
+        "British National Grid",
+        "EPSG:27700",
+        "Welsh place names",
+        "language metadata"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/inspire/tech-guidance"
+        },
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/accessibility-statement"
+        }
+      ],
+      "expected_propositions": [
+        "HMLR's INSPIRE GML is captured against British National Grid; reprojection may be required and can introduce positional error.",
+        "The accessibility statement says some Welsh place names in INSPIRE are not coded as a different language and may be mispronounced by screen readers; the bundle must preserve explicit language identity rather than silently normalise labels."
+      ],
+      "near_miss_rule": "A precise CRS or reprojected polygon does not make an indicative polygon an exact legal boundary, and an English-looking label does not justify deleting Welsh language identity.",
+      "hard_failure_ids": [
+        "HF-LEGAL-BOUNDARY",
+        "HF-WELSH-LANGUAGE",
+        "HF-ACCESSIBILITY"
+      ],
+      "tags": [
+        "gis",
+        "metadata",
+        "welsh"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-ACCESSIBLE-JOURNEY",
+        "CAV-BOUNDARY-NOT-CONCLUSION",
+        "CAV-LANGUAGE-DISTINCTION"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q014-INDEX-POLYGON-DATASET",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/inspire",
+          "max_rank": 3,
+          "reason": "The dataset landing page alone does not establish accessibility, language handling or exact-boundary meaning."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/accessibility-statement"
+    },
+    {
+      "id": "LR-Q015",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "Use land and property data API base URL version datasets",
+      "intent": "Retrieve the publisher-operated API contract, version and supported dataset scope.",
+      "persona_ids": [
+        "LR-P05"
+      ],
+      "story_ids": [
+        "LR-S08"
+      ],
+      "expected_terms": [
+        "REST",
+        "JSON",
+        "API v1",
+        "base URL"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD-API",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/api-documentation"
+        }
+      ],
+      "expected_propositions": [
+        "The service documents a RESTful JSON API under a versioned base URL.",
+        "The publisher documentation, not a central catalogue row, defines the operational contract."
+      ],
+      "near_miss_rule": "An API catalogue entry without the publisher contract cannot establish current operations or authentication.",
+      "hard_failure_ids": [
+        "HF-AUTHORITY",
+        "HF-RESTRICTED-AUTOMATION"
+      ],
+      "tags": [
+        "api",
+        "integration",
+        "contract"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-NO-RESTRICTED-AUTOMATION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q015-BUSINESS-GATEWAY-BANKRUPTCY",
+          "canonical_url": "https://businessgateway.landregistry.gov.uk/b2b/BGSoapEngine/BankruptcySearchV2_1WebService?wsdl=",
+          "max_rank": 10,
+          "reason": "A restricted Business Gateway endpoint is not the public ULPD API contract and must not enter its top ten results."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/api-documentation"
+    },
+    {
+      "id": "LR-Q016",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "what HMLR API data is public and what requires an account licence key",
+      "intent": "Distinguish public API documentation and example metadata from authenticated dataset access.",
+      "persona_ids": [
+        "LR-P05",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S08"
+      ],
+      "expected_terms": [
+        "account",
+        "licence",
+        "API key",
+        "example data"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD-API",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/api-documentation"
+        },
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/ocod"
+        }
+      ],
+      "expected_propositions": [
+        "Public documentation and some example data can be inspected without treating the underlying dataset as anonymous access.",
+        "Authenticated dataset access requires the documented account, licence acceptance and API key."
+      ],
+      "near_miss_rule": "A publicly visible API URL or example response does not authorise anonymous bulk download.",
+      "hard_failure_ids": [
+        "HF-LICENCE-ACCESS",
+        "HF-RESTRICTED-AUTOMATION"
+      ],
+      "tags": [
+        "api",
+        "access",
+        "licensing"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-NO-RESTRICTED-AUTOMATION",
+        "CAV-RIGHTS-AND-ACCESS"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q016-BUSINESS-GATEWAY-OFFICIAL-SEARCH",
+          "canonical_url": "https://businessgateway.landregistry.gov.uk/bg2/api/v1/official-searches-of-whole",
+          "max_rank": 10,
+          "reason": "A certificate-gated Business Gateway endpoint must not be presented among the top ten as public anonymous API data."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/api-documentation"
+    },
+    {
+      "id": "LR-Q017",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "anonymous automation permission credentials terms portal Business Gateway Local Land Charges",
+      "intent": "Ensure restricted portal, Business Gateway, local-search and authenticated data routes are discoverable without being invoked.",
+      "persona_ids": [
+        "LR-P02",
+        "LR-P05",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S08"
+      ],
+      "expected_terms": [
+        "portal",
+        "Business Gateway",
+        "Local Land Charges",
+        "credentials",
+        "terms",
+        "automation"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-PORTAL",
+          "canonical_url": "https://www.gov.uk/government/collections/how-to-use-the-land-registry-portal"
+        },
+        {
+          "source_id": "SRC-BG-TECHDOC",
+          "canonical_url": "https://landregistry.github.io/bg-dev-pack-redesign/"
+        },
+        {
+          "source_id": "SRC-LLC-SERVICE",
+          "canonical_url": "https://search-local-land-charges.service.gov.uk/terms-and-conditions"
+        }
+      ],
+      "expected_propositions": [
+        "Portal access is for approved professional customers; public guidance does not grant access or permission to automate.",
+        "Business Gateway documentation is public, but test and production calls require approved access and governing terms; documentation is not authorisation.",
+        "Local Land Charges terms prohibit automated software agents from searching, copying or monitoring the service.",
+        "The bundle indexes public metadata only and never invokes restricted services or stores credentials, session state or signed links."
+      ],
+      "near_miss_rule": "A publicly reachable landing page, robots access, sample contract or developer documentation is not authorisation for anonymous automation; permission must be established from service-specific access rules and terms.",
+      "hard_failure_ids": [
+        "HF-RESTRICTED-AUTOMATION",
+        "HF-LICENCE-ACCESS"
+      ],
+      "tags": [
+        "api",
+        "conveyancing",
+        "restricted-access",
+        "safety"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-NO-RESTRICTED-AUTOMATION",
+        "CAV-RIGHTS-AND-ACCESS"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q017-LOCAL-LAND-CHARGES-LANDING",
+          "canonical_url": "https://search-local-land-charges.service.gov.uk/",
+          "max_rank": 2,
+          "reason": "A publicly reachable service landing page is not permission for anonymous automation and must not outrank its terms."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/collections/how-to-use-the-land-registry-portal"
+    },
+    {
+      "id": "LR-Q018",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "OCOD monthly complete file change only update",
+      "intent": "Find the distribution and refresh contract needed for a reproducible monthly update.",
+      "persona_ids": [
+        "LR-P04",
+        "LR-P05",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S09"
+      ],
+      "expected_terms": [
+        "monthly",
+        "complete file",
+        "change only",
+        "title number"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/ocod"
+        }
+      ],
+      "expected_propositions": [
+        "OCOD publishes a complete monthly file and a change-only update.",
+        "A refresh must preserve file identity, release context and source observation rather than infer currency from the catalogue page."
+      ],
+      "near_miss_rule": "A page last-updated date is not a substitute for the file's release identity or covered month.",
+      "hard_failure_ids": [
+        "HF-DATE-CURRENCY",
+        "HF-AUTHORITY"
+      ],
+      "tags": [
+        "data",
+        "api",
+        "refresh",
+        "ocod"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-DATE-SEPARATION",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q018-PRICE-PAID-DATA",
+          "canonical_url": "https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads",
+          "max_rank": 1,
+          "reason": "Another monthly dataset cannot substitute for OCOD complete-file and change-only release identity."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/datasets/ocod"
+    },
+    {
+      "id": "LR-Q019",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "search local land charges coverage account official certificate",
+      "intent": "Find how public and official local-land-charge searches differ and whether an authority is covered.",
+      "persona_ids": [
+        "LR-P01",
+        "LR-P06",
+        "LR-P09"
+      ],
+      "story_ids": [
+        "LR-S07"
+      ],
+      "expected_terms": [
+        "local land charges",
+        "account",
+        "official search certificate",
+        "local authority"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-LLC-SERVICE",
+          "canonical_url": "https://search-local-land-charges.service.gov.uk/"
+        }
+      ],
+      "expected_propositions": [
+        "The service covers England and Wales but authority migration remains relevant.",
+        "A user account and an official certificate route have distinct access and fee implications."
+      ],
+      "near_miss_rule": "A free personal search is not automatically an official search certificate.",
+      "hard_failure_ids": [
+        "HF-LICENCE-ACCESS",
+        "HF-COVERAGE",
+        "HF-RESTRICTED-AUTOMATION"
+      ],
+      "tags": [
+        "local-authority",
+        "public",
+        "local-land-charges"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDED-COVERAGE",
+        "CAV-NO-RESTRICTED-AUTOMATION",
+        "CAV-RIGHTS-AND-ACCESS"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q019-BUSINESS-GATEWAY-LLC-SEARCH",
+          "canonical_url": "https://businessgateway.landregistry.gov.uk/b2b/ECLLC_SoapEngine/LLCSearchV2_0WebService?wsdl=",
+          "max_rank": 2,
+          "reason": "A restricted Business Gateway search must not outrank the public service route, coverage statement and terms."
+        }
+      ],
+      "runtime_expected_source_url": "https://search-local-land-charges.service.gov.uk/"
+    },
+    {
+      "id": "LR-Q020",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "local land charge planning condition title boundary differences",
+      "intent": "Prevent conflation of local land charges, planning information, title registration and mapped boundaries.",
+      "persona_ids": [
+        "LR-P02",
+        "LR-P04",
+        "LR-P06"
+      ],
+      "story_ids": [
+        "LR-S07"
+      ],
+      "expected_terms": [
+        "local land charge",
+        "planning condition",
+        "title",
+        "indicative location"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-LLC-SERVICE",
+          "canonical_url": "https://search-local-land-charges.service.gov.uk/"
+        },
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/llc"
+        }
+      ],
+      "expected_propositions": [
+        "Local land charges can include restrictions such as planning conditions but are not the complete planning record.",
+        "The search service, charge record, title record and indicative spatial dataset are distinct entities."
+      ],
+      "near_miss_rule": "A matching polygon or planning-related label does not prove the legal scope of a charge or registered title.",
+      "hard_failure_ids": [
+        "HF-LEGAL-BOUNDARY",
+        "HF-AUTHORITY",
+        "HF-COVERAGE"
+      ],
+      "tags": [
+        "local-authority",
+        "planning",
+        "semantic-boundary"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-BOUNDARY-NOT-CONCLUSION",
+        "CAV-BOUNDED-COVERAGE",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q020-EXACT-BOUNDARY-FORM",
+          "canonical_url": "https://www.gov.uk/government/publications/exact-line-of-boundary-registration-db",
+          "max_rank": 10,
+          "reason": "An exact-boundary application form does not establish the legal scope of a local land charge or title."
+        }
+      ],
+      "runtime_expected_source_url": "https://search-local-land-charges.service.gov.uk/"
+    },
+    {
+      "id": "LR-Q021",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "OCOD licence address data third party rights",
+      "intent": "Retrieve the dataset-specific licence and keep third-party address-data conditions visible.",
+      "persona_ids": [
+        "LR-P05",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S10"
+      ],
+      "expected_terms": [
+        "OCOD licence",
+        "AddressBase",
+        "PAF",
+        "third-party rights"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/datasets/ocod"
+        }
+      ],
+      "expected_propositions": [
+        "OCOD reuse is governed by a dataset-specific licence.",
+        "Property-address fields carry third-party intellectual-property conditions that must not be collapsed into a generic open-data statement."
+      ],
+      "near_miss_rule": "Public catalogue access or Crown ownership does not establish unrestricted redistribution of every field.",
+      "hard_failure_ids": [
+        "HF-LICENCE-ACCESS",
+        "HF-AUTHORITY"
+      ],
+      "tags": [
+        "licensing",
+        "provenance",
+        "ocod"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-RIGHTS-AND-ACCESS",
+        "CAV-SOURCE-AUTHORITY"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q021-ONLINE-OWNER-VERIFICATION",
+          "canonical_url": "https://businessgateway.landregistry.gov.uk/b2b/EOOV_SoapEngine/OnlineOwnershipVerificationV1_0WebService?wsdl=",
+          "max_rank": 9,
+          "reason": "A restricted ownership service cannot establish OCOD address-field reuse rights and must not enter the top nine."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/datasets/ocod"
+    },
+    {
+      "id": "LR-Q022",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "Price Paid Data OGL attribution Royal Mail Ordnance Survey",
+      "intent": "Find the required attribution and layered address-data reuse conditions for Price Paid Data.",
+      "persona_ids": [
+        "LR-P03",
+        "LR-P07"
+      ],
+      "story_ids": [
+        "LR-S10"
+      ],
+      "expected_terms": [
+        "Open Government Licence",
+        "attribution",
+        "Royal Mail",
+        "Ordnance Survey"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads"
+        }
+      ],
+      "expected_propositions": [
+        "Price Paid Data is published under OGL with a specified attribution.",
+        "Address fields include third-party rights and their reuse conditions must remain visible."
+      ],
+      "near_miss_rule": "Stating only OGL without the address-data conditions is incomplete.",
+      "hard_failure_ids": [
+        "HF-LICENCE-ACCESS"
+      ],
+      "tags": [
+        "licensing",
+        "lending",
+        "price-paid-data"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-RIGHTS-AND-ACCESS"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q022-HISTORIC-PRICE-PAID-NEWS",
+          "canonical_url": "https://www.gov.uk/government/news/additional-price-paid-data-to-be-released-in-october",
+          "max_rank": 2,
+          "reason": "A historic release announcement cannot replace current OGL and third-party address-data conditions."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/statistical-data-sets/price-paid-data-downloads"
+    },
+    {
+      "id": "LR-Q023",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "Use land and property data accessibility keyboard focus WCAG",
+      "intent": "Retrieve the applicable accessibility statement and test the bundle's equivalent critical journey.",
+      "persona_ids": [
+        "LR-P05",
+        "LR-P08"
+      ],
+      "story_ids": [
+        "LR-S11"
+      ],
+      "expected_terms": [
+        "WCAG 2.2 AA",
+        "keyboard",
+        "focus",
+        "screen reader"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-ULPD",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/accessibility-statement"
+        }
+      ],
+      "expected_propositions": [
+        "At the observation date the publisher statement reports partial WCAG 2.2 AA compliance and known focus, keyboard or map, language and screen-reader limitations.",
+        "The statement was last reviewed on 26 September 2024 and reports testing in September 2024; remediation dates that passed in January 2025 do not prove fixes, so current defect status is unknown until rechecked.",
+        "The OKF site must separately test its own search, filter, result and source-link journey rather than inherit the source service's claim."
+      ],
+      "near_miss_rule": "A planned remediation date, an old test result or a passing automated audit is not evidence that a defect is fixed or that the complete keyboard and screen-reader task works.",
+      "hard_failure_ids": [
+        "HF-ACCESSIBILITY",
+        "HF-DATE-CURRENCY"
+      ],
+      "tags": [
+        "accessibility",
+        "api",
+        "wcag"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-ACCESSIBLE-JOURNEY",
+        "CAV-DATE-SEPARATION"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q023-ULPD-LANDING",
+          "canonical_url": "https://use-land-property-data.service.gov.uk/",
+          "max_rank": 1,
+          "reason": "A general service landing page is not an accessibility statement or evidence of WCAG conformance."
+        }
+      ],
+      "runtime_expected_source_url": "https://use-land-property-data.service.gov.uk/accessibility-statement"
+    },
+    {
+      "id": "LR-Q024",
+      "status": "candidate-input-v0.3.0",
+      "verification_status": "version-scoped-digest-bound-external-evidence",
+      "question_type": "competency-and-retrieval",
+      "query": "HM Land Registry Welsh language services bilingual registers",
+      "intent": "Find the official Welsh-language commitment and preserve bilingual service and register context.",
+      "persona_ids": [
+        "LR-P01",
+        "LR-P08",
+        "LR-P09"
+      ],
+      "story_ids": [
+        "LR-S12"
+      ],
+      "expected_terms": [
+        "Welsh Language Scheme",
+        "Cymraeg",
+        "bilingual register",
+        "English and Welsh"
+      ],
+      "expected_min_results": 1,
+      "expected_sources": [
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/organisations/land-registry/about/welsh-language-scheme"
+        },
+        {
+          "source_id": "SRC-GOVUK-HMLR",
+          "canonical_url": "https://www.gov.uk/government/publications/hm-land-registry-welsh-language-scheme/hm-land-registry-welsh-language-scheme"
+        }
+      ],
+      "expected_propositions": [
+        "HMLR says Welsh and English are treated equally in Wales and identifies Welsh or bilingual contexts for public services, correspondence, publications and register or address information.",
+        "Welsh availability is service- and publication-specific; the bundle must label English and Welsh explicitly and must not infer that every linked item is bilingual."
+      ],
+      "near_miss_rule": "An English-only result is incomplete when the official source declares a Welsh route or bilingual context; conversely, the scheme is not proof that every service or document is bilingual.",
+      "hard_failure_ids": [
+        "HF-WELSH-LANGUAGE"
+      ],
+      "tags": [
+        "welsh",
+        "accessibility",
+        "public"
+      ],
+      "suite_partition": "calibration",
+      "required_caveat_ids": [
+        "CAV-LANGUAGE-DISTINCTION"
+      ],
+      "must_not_retrieve": [
+        {
+          "target_id": "NEG-LR-Q024-GENERAL-HMLR-PAGE",
+          "canonical_url": "https://www.gov.uk/government/organisations/land-registry",
+          "max_rank": 4,
+          "reason": "A general English organisational page must not outrank explicit Welsh-language routes for a Welsh-service query."
+        }
+      ],
+      "runtime_expected_source_url": "https://www.gov.uk/government/organisations/land-registry/about/welsh-language-scheme"
+    }
+  ],
+  "suite_partition": "calibration",
+  "caveat_registry": [
+    {
+      "id": "CAV-BOUNDARY-NOT-CONCLUSION",
+      "text": "Discovery geometry, title-plan lines and general boundaries are not exact legal boundary conclusions."
+    },
+    {
+      "id": "CAV-RIGHTS-AND-ACCESS",
+      "text": "Public discovery does not establish open, free or unrestricted access or reuse."
+    },
+    {
+      "id": "CAV-DATE-SEPARATION",
+      "text": "Observation, publication, catalogue, release and legal currency dates remain distinct."
+    },
+    {
+      "id": "CAV-SOURCE-AUTHORITY",
+      "text": "The bundle is a discovery aid; canonical official sources control authoritative claims."
+    },
+    {
+      "id": "CAV-NO-RESTRICTED-AUTOMATION",
+      "text": "Do not authenticate to or automate paid, portal, Business Gateway or terms-restricted services."
+    },
+    {
+      "id": "CAV-BOUNDED-COVERAGE",
+      "text": "Coverage is bounded to named source lanes and dated denominators."
+    },
+    {
+      "id": "CAV-ACCESSIBLE-JOURNEY",
+      "text": "Critical discovery and evidence inspection require an accessible non-visual journey."
+    },
+    {
+      "id": "CAV-LANGUAGE-DISTINCTION",
+      "text": "English and Welsh source identities and availability remain distinct."
+    }
+  ]
+}

--- a/providers/hmlr-open/README.md
+++ b/providers/hmlr-open/README.md
@@ -1,3 +1,12 @@
-# HMLR open-data provider placeholder
+# HM Land Registry public discovery metadata
 
-No HMLR integration is implemented or authorised in Stage 0.
+The public OKF bundle contains checksum-locked metadata for selected HM Land
+Registry datasets and three non-executing discovery journeys. It does not call an
+HM Land Registry service, authenticate, order or buy a record, or contain an
+address, transaction, title record, title plan or geometry.
+
+Rights and access remain attached to each described source. Public guidance
+metadata does not make a paid, authenticated or professional service open. INSPIRE
+polygons are indicative discovery aids and do not establish an exact legal title
+boundary. See the
+[source review](../../docs/source-ledger/reviewed-public-examples-2026-08-20.md).

--- a/providers/landis/README.md
+++ b/providers/landis/README.md
@@ -1,3 +1,10 @@
-# LandIS provider placeholder
+# LandIS public discovery metadata
 
-No LandIS integration is implemented or authorised in Stage 0.
+The public OKF bundle contains a non-executing capability description for the Land
+Information System at Cranfield University. It makes no LandIS request and contains
+no catalogue record, soil dataset, feature or geometry payload.
+
+LandIS access is mixed and rights must be established for each record. A public
+catalogue or OGC API description does not create blanket open-data or redistribution
+rights. See the
+[source review](../../docs/source-ledger/reviewed-public-examples-2026-08-20.md).

--- a/providers/ons/README.md
+++ b/providers/ons/README.md
@@ -1,3 +1,12 @@
-# ONS provider placeholder
+# Office for National Statistics public discovery metadata
 
-No ONS integration is implemented or authorised in Stage 0.
+The public OKF bundle describes two non-executing capability families: ONS data APIs
+and ONS geography products. The records are dated metadata from checksum-locked
+research inputs; they do not call an API or contain observations, postcode or UPRN
+rows, boundaries or other dataset payloads.
+
+The Open Government Licence applies only where the named product says it does.
+Ordnance Survey, Royal Mail and other third-party conditions remain
+product-specific. Release or product vintage must not be inferred from the GIS AI
+GO review or publication date. See the
+[source review](../../docs/source-ledger/reviewed-public-examples-2026-08-20.md).

--- a/scripts/build_okf.py
+++ b/scripts/build_okf.py
@@ -9,16 +9,51 @@ import json
 import re
 import shutil
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable
+from typing import Any
 from urllib.parse import urlparse
 
 from jsonschema import Draft202012Validator, FormatChecker
 
-BUILDER_VERSION = "1.0.0"
+BUILDER_VERSION = "1.1.1"
 GENERATED_MARKER = "gis-ai-go-okf-builder.v1\n"
 PUBLIC_BASE = "https://chris-page-gov.github.io/gis-ai-go/"
 HMLR_VENDOR = Path("okf/vendor/okf-landregistry/v0.3.0")
+HMLR_QUESTIONS = HMLR_VENDOR / "evaluation/questions.json"
+HMLR_RELEASE_SOURCE_ID = "S-OKF-HMLR-V0.3.0"
+HMLR_QUESTIONS_SHA256 = (
+    "c4423c70ed4207061d8cfea7d0956b87ddbc9e487fe3a512bc30ba2fbdba8fc0"
+)
+HMLR_APPROVED_INPUT_SHA256 = {
+    HMLR_VENDOR / "LICENSE.md": (
+        "cddac196d90d8b0d418c9af6d88ba9a3e169f720fb17e438886b74603fdcdf8c"
+    ),
+    HMLR_VENDOR / "evaluation/questions.json": HMLR_QUESTIONS_SHA256,
+    HMLR_VENDOR / "source/curated-records.json": (
+        "4e585751d2747281068f8f389ebdb791e3364c09c4dbb57347db810c39e83b4a"
+    ),
+    HMLR_VENDOR / "source/curated-rights-access.json": (
+        "a5c6dbfd97c3f5bbf462bb10cb1e3425b144a68f4c5fb462b55782936ad17136"
+    ),
+}
+HMLR_RELEASE_EXPECTED = {
+    "repository": "https://github.com/chris-page-gov/okf-LandRegistry",
+    "retrieved_on": "2026-08-19",
+    "tag": "v0.3.0",
+    "tagged_at": "2026-08-12T01:43:30+01:00",
+    "annotated_tag_object": "d4159f1076c090dd69260a08308f4162859e4165",
+    "commit": "1d708e39f2cde19610d43c5a7f5e36e4a2f947bc",
+    "tree": "aa60922cc25f73980d6480c1a7ffc85fb1fc59dd",
+    "approved_candidate": "751b6c1e80fbbad3c07f19798c74aebd603eb62c",
+    "release_root_sha256": "6a29e38e7bb805aafb7f36ba8d1fa4ce976875f45997049cd4808d6ede7f75e1",
+    "evaluation_questions_sha256": HMLR_QUESTIONS_SHA256,
+}
+HMLR_SUPERSEDED_EXPECTED = {
+    "recorded_commit_prefix": "4580c9e",
+    "status": "not-resolvable-in-local-clone-or-refs",
+    "decision": "Use the approved immutable v0.3.0 release identity above.",
+}
 MAX_INPUT_FILE_BYTES = 16 * 1024 * 1024
 MAX_INPUT_BYTES = 64 * 1024 * 1024
 MAX_RECORDS = 10_000
@@ -30,16 +65,21 @@ def load_json(path: Path) -> Any:
 
 
 def canonical_json_bytes(value: Any) -> bytes:
-    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    return (
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode()
 
 
 def canonical_record_sha256(value: Any) -> str:
-    payload = json.dumps(
-        value,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode() + b"\n"
+    payload = (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        + b"\n"
+    )
     return hashlib.sha256(payload).hexdigest()
 
 
@@ -49,6 +89,18 @@ def sha256_bytes(value: bytes) -> str:
 
 def sha256_file(path: Path) -> str:
     return sha256_bytes(path.read_bytes())
+
+
+def verify_approved_hmlr_inputs(root: Path) -> None:
+    """Bind every published upstream HMLR input to the approved v0.3.0 tag."""
+    for relative, expected in HMLR_APPROVED_INPUT_SHA256.items():
+        path = locked_path(root, relative.as_posix())
+        actual = sha256_file(path)
+        if actual != expected:
+            raise ValueError(
+                "HMLR approved v0.3.0 input hash mismatch for "
+                f"{relative}: expected {expected}, found {actual}"
+            )
 
 
 def normalise_datetime(value: str) -> str:
@@ -85,7 +137,9 @@ def verify_source_lock(root: Path, source_lock: dict[str, Any]) -> list[dict[str
     if not all(isinstance(path, str) for path in paths):
         raise ValueError("source lock paths must be strings")
     if paths != sorted(paths) or len(paths) != len(set(paths)):
-        raise ValueError("source lock paths must be unique and lexicographically sorted")
+        raise ValueError(
+            "source lock paths must be unique and lexicographically sorted"
+        )
 
     verified: list[dict[str, Any]] = []
     total_bytes = 0
@@ -129,7 +183,9 @@ def verify_source_lock(root: Path, source_lock: dict[str, Any]) -> list[dict[str
         actual_paths: set[str] = set()
         for path in input_root.rglob("*"):
             if path.is_symlink():
-                raise ValueError(f"controlled inputs must not contain symbolic links: {path}")
+                raise ValueError(
+                    f"controlled inputs must not contain symbolic links: {path}"
+                )
             if path.is_file():
                 actual_paths.add(path.relative_to(root).as_posix())
         locked_paths = {
@@ -195,7 +251,9 @@ def research_source_record(
 ) -> dict[str, Any]:
     url = source["url"]
     validate_url(url)
-    notes = source.get("notes") or "Citation metadata only; consult the source for scope."
+    notes = (
+        source.get("notes") or "Citation metadata only; consult the source for scope."
+    )
     return {
         "schema": "gis-ai-go-okf-concept.v1",
         "id": source["id"],
@@ -244,9 +302,34 @@ def research_source_record(
 
 
 def provider_record(
-    provider: dict[str, Any], publication: dict[str, Any]
+    provider: dict[str, Any], publication: dict[str, Any], snapshot_generated_at: str
 ) -> dict[str, Any]:
     source_refs = sorted(provider["source_ids"])
+    access_tiers = provider["access_tier"]
+    if not isinstance(access_tiers, list) or not access_tiers:
+        raise ValueError(f"provider {provider['id']} has no described access tiers")
+    mixed_access = len(access_tiers) > 1 or any(
+        "restricted" in tier.lower() or "commercial" in tier.lower()
+        for tier in access_tiers
+    )
+    licence = provider["licence"]
+    if mixed_access and not all(
+        phrase in licence.lower() for phrase in ("each record", "blanket licence")
+    ):
+        raise ValueError(
+            f"mixed-access provider {provider['id']} lacks per-record rights wording"
+        )
+
+    identifier_parts = provider["id"].lower().split("-")
+    family = identifier_parts[1] if len(identifier_parts) > 1 else "external"
+    tags = {"metadata-only", "provider", family}
+    tags.add("mixed-access" if mixed_access else "open")
+    if "geo" in identifier_parts:
+        tags.add("geography")
+    if "data" in identifier_parts:
+        tags.add("statistics")
+    if family == "landis":
+        tags.add("soil")
     return {
         "schema": "gis-ai-go-okf-concept.v1",
         "id": provider["id"],
@@ -267,18 +350,25 @@ def provider_record(
         "rights": {
             "state": "metadata-citation",
             "recordLicence": "MIT",
-            "describedResourceLicence": provider["licence"],
+            "describedResourceLicence": licence,
             "attribution": provider["attribution"],
         },
-        "freshness": freshness(publication, publication["reviewed_at"]),
+        "freshness": freshness(publication, snapshot_generated_at),
         "status": "candidate-metadata",
         "sourceRefs": source_refs,
         "limitations": [
             provider["known_changes"],
             provider["quality_limitations"],
+            provider["caching_redistribution"],
+            (
+                "The described provider has mixed, per-record access and rights; this "
+                "public metadata record is not a blanket open-data statement."
+                if mixed_access
+                else "Open access and reuse remain source- and product-specific."
+            ),
             "No live provider call, data distribution or service response is included.",
         ],
-        "tags": ["hmlr", "open", "provider"],
+        "tags": sorted(tags),
         "details": {
             "geographicScope": provider["geographic_scope"],
             "datasetsServices": provider["datasets_services"],
@@ -286,7 +376,15 @@ def provider_record(
             "updateFrequency": provider["update_frequency"],
             "mechanisms": provider["mechanisms"],
             "formats": provider["formats"],
+            "accessTiers": access_tiers,
+            "describedAccess": "mixed-per-record"
+            if mixed_access
+            else "open-source-specific",
+            "authentication": provider["authentication"],
             "cost": provider["cost"],
+            "cachingRedistribution": provider["caching_redistribution"],
+            "metadataSnapshotGeneratedAt": snapshot_generated_at,
+            "sourceRecordSha256": canonical_record_sha256(provider),
             "recommendedIntegration": provider["recommended_integration"],
         },
     }
@@ -336,6 +434,239 @@ def workflow_record(
     }
 
 
+def hmlr_release_source_record(
+    source_lock: dict[str, Any], publication: dict[str, Any]
+) -> dict[str, Any]:
+    release = source_lock.get("external_release")
+    if release != HMLR_RELEASE_EXPECTED:
+        raise ValueError(
+            "HMLR external release identity differs from the approved v0.3.0 pin"
+        )
+    release_url = f"{release['repository']}/releases/tag/{release['tag']}"
+    validate_url(release_url)
+    unresolved = source_lock.get("supersedes_unresolved_research_reference")
+    if unresolved != HMLR_SUPERSEDED_EXPECTED:
+        raise ValueError("HMLR superseded research reference is missing or has changed")
+    return {
+        "schema": "gis-ai-go-okf-concept.v1",
+        "id": HMLR_RELEASE_SOURCE_ID,
+        "type": "source",
+        "title": "Digest-locked okf-LandRegistry v0.3.0 release",
+        "description": (
+            "GIS AI GO provenance for the approved immutable HMLR public-estate "
+            "metadata release used by the selected datasets and discovery journeys."
+        ),
+        "authority": {
+            "class": "derived",
+            "statement": (
+                "GIS AI GO records the exact upstream release identity; HM Land "
+                "Registry and the cited official sources remain authoritative for "
+                "current services, records and terms."
+            ),
+            "source": release_url,
+        },
+        "publication": publication_envelope(),
+        "access": {
+            "tier": "open",
+            "state": "public-metadata",
+            "authentication": "None for the cited public release metadata.",
+        },
+        "rights": {
+            "state": "metadata-citation",
+            "recordLicence": (
+                "CC BY 4.0 for upstream metadata; GIS AI GO provenance additions are MIT."
+            ),
+            "describedResourceLicence": (
+                "Per record; consult the upstream rights evidence and each official source."
+            ),
+            "attribution": "HM Land Registry public-estate OKF Bundle contributors, v0.3.0.",
+        },
+        "freshness": freshness(publication, release["tagged_at"]),
+        "status": "external-source",
+        "sourceRefs": [HMLR_RELEASE_SOURCE_ID],
+        "limitations": [
+            "This release identity is provenance evidence, not proof of current service terms.",
+            (
+                "It supersedes the unresolved research-ledger commit prefix 4580c9e "
+                "without erasing that recorded discrepancy."
+            ),
+            "The release does not imply HM Land Registry endorsement of GIS AI GO.",
+        ],
+        "tags": ["hmlr", "okf", "release-provenance", "source"],
+        "details": {
+            "repository": release["repository"],
+            "releaseUrl": release_url,
+            "releaseTag": release["tag"],
+            "releaseTaggedAt": release["tagged_at"],
+            "retrievedOn": release["retrieved_on"],
+            "annotatedTagObject": release["annotated_tag_object"],
+            "commit": release["commit"],
+            "tree": release["tree"],
+            "approvedCandidate": release["approved_candidate"],
+            "releaseRootSha256": release["release_root_sha256"],
+            "evaluationQuestionsSha256": release["evaluation_questions_sha256"],
+            "supersededResearchCommitPrefix": unresolved["recorded_commit_prefix"],
+            "supersededResearchReferenceStatus": unresolved["status"],
+            "supersededResearchDecision": unresolved["decision"],
+        },
+    }
+
+
+def hmlr_question_record(
+    question: dict[str, Any],
+    source_refs: list[str],
+    caveat_text_by_id: dict[str, str],
+    known_hard_failure_ids: set[str],
+    research_cutoff: str,
+    expected_sha256: str,
+    publication: dict[str, Any],
+) -> dict[str, Any]:
+    actual_sha256 = canonical_record_sha256(question)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(f"selected HMLR question digest mismatch: {question['id']}")
+
+    required_caveat_ids = question.get("required_caveat_ids")
+    if not isinstance(required_caveat_ids, list) or not required_caveat_ids:
+        raise ValueError(
+            f"selected HMLR question lacks mandatory caveats: {question['id']}"
+        )
+    missing_caveats = sorted(set(required_caveat_ids) - set(caveat_text_by_id))
+    if missing_caveats:
+        raise ValueError(
+            f"selected HMLR question has unknown mandatory caveats: "
+            f"{question['id']} {missing_caveats}"
+        )
+    hard_failure_ids = question.get("hard_failure_ids")
+    if not isinstance(hard_failure_ids, list) or not hard_failure_ids:
+        raise ValueError(
+            f"selected HMLR question lacks hard-failure controls: {question['id']}"
+        )
+    missing_hard_failures = sorted(set(hard_failure_ids) - known_hard_failure_ids)
+    if missing_hard_failures:
+        raise ValueError(
+            f"selected HMLR question has unknown hard failures: "
+            f"{question['id']} {missing_hard_failures}"
+        )
+
+    positive_sources = question.get("expected_sources")
+    if not isinstance(positive_sources, list) or not positive_sources:
+        raise ValueError(
+            f"selected HMLR question lacks positive sources: {question['id']}"
+        )
+    positive_urls = []
+    expected_source_ids = []
+    for source in positive_sources:
+        if not isinstance(source, dict):
+            raise TypeError(
+                f"selected HMLR question has an invalid source: {question['id']}"
+            )
+        url = source.get("canonical_url")
+        source_id = source.get("source_id")
+        if not isinstance(url, str) or not isinstance(source_id, str):
+            raise TypeError(
+                f"selected HMLR question has an invalid source: {question['id']}"
+            )
+        validate_url(url)
+        positive_urls.append(url)
+        expected_source_ids.append(source_id)
+    if len(positive_urls) != len(set(positive_urls)):
+        raise ValueError(
+            f"selected HMLR question has duplicate sources: {question['id']}"
+        )
+    if question.get("runtime_expected_source_url") not in positive_urls:
+        raise ValueError(
+            f"selected HMLR question runtime source is outside its positive sources: "
+            f"{question['id']}"
+        )
+
+    forbidden_targets = []
+    forbidden_urls = set()
+    for target in question.get("must_not_retrieve", []):
+        if not isinstance(target, dict):
+            raise TypeError("selected HMLR question has an invalid forbidden target")
+        target_id = target.get("target_id")
+        reason = target.get("reason")
+        url = target.get("canonical_url")
+        if not all(
+            isinstance(value, str) and value for value in (target_id, reason, url)
+        ):
+            raise TypeError("selected HMLR question has an invalid forbidden target")
+        validate_url(url)
+        if url in positive_urls:
+            raise ValueError(
+                f"selected HMLR question target is both required and forbidden: "
+                f"{question['id']}"
+            )
+        forbidden_targets.append({"id": target_id, "reason": reason})
+        forbidden_urls.add(url)
+    if not forbidden_targets or len(forbidden_urls) != len(forbidden_targets):
+        raise ValueError(
+            f"selected HMLR question requires unique forbidden targets: {question['id']}"
+        )
+
+    limitations = [caveat_text_by_id[identifier] for identifier in required_caveat_ids]
+    limitations.append(
+        "Non-executing discovery journey only; no provider request, order or authentication occurs."
+    )
+    title_query = question["query"]
+    return {
+        "schema": "gis-ai-go-okf-concept.v1",
+        "id": question["id"],
+        "type": "workflow",
+        "title": f"{question['id']} — {title_query[0].upper()}{title_query[1:]}",
+        "description": question["intent"],
+        "authority": {
+            "class": "derived",
+            "statement": (
+                "Digest-bound projection of an upstream v0.3.0 calibration input; "
+                "the cited canonical official sources control authoritative claims."
+            ),
+            "source": HMLR_RELEASE_SOURCE_ID,
+        },
+        "publication": publication_envelope(),
+        "access": {
+            "tier": "open",
+            "state": "planned-non-executing",
+            "authentication": (
+                "Not applicable: this record does not call, order from or authenticate "
+                "to any provider service."
+            ),
+        },
+        "rights": {
+            "state": "metadata-citation",
+            "recordLicence": (
+                "CC BY 4.0 for upstream metadata; GIS AI GO projection additions are MIT."
+            ),
+            "describedResourceLicence": (
+                "Not applicable; cited guidance and services retain their own terms."
+            ),
+            "attribution": "HM Land Registry public-estate OKF Bundle contributors, v0.3.0.",
+        },
+        "freshness": freshness(publication, research_cutoff),
+        "status": "candidate-non-executing",
+        "sourceRefs": sorted(set(source_refs) | {HMLR_RELEASE_SOURCE_ID}),
+        "limitations": limitations,
+        "tags": sorted(set(question["tags"]) | {"hmlr", "metadata-only", "workflow"}),
+        "details": {
+            "questionId": question["id"],
+            "query": question["query"],
+            "intent": question["intent"],
+            "questionType": question["question_type"],
+            "suitePartition": question["suite_partition"],
+            "expectedTerms": question["expected_terms"],
+            "expectedMinResults": question["expected_min_results"],
+            "expectedSourceIds": expected_source_ids,
+            "expectedPropositions": question["expected_propositions"],
+            "nearMissRule": question["near_miss_rule"],
+            "hardFailureIds": hard_failure_ids,
+            "requiredCaveatIds": required_caveat_ids,
+            "forbiddenTargets": forbidden_targets,
+            "questionResearchCutoff": research_cutoff,
+            "sourceRecordSha256": actual_sha256,
+        },
+    }
+
+
 def source_record_id(url: str) -> str:
     return f"hmlr-source:{sha256_bytes(url.encode())[:16]}"
 
@@ -354,7 +685,10 @@ def hmlr_source_record(
         "id": source_id,
         "type": "source",
         "title": f"Official HMLR source: {label}",
-        "description": "Public evidence page cited by the selected upstream metadata record.",
+        "description": (
+            "Public evidence page cited by a selected upstream metadata record or "
+            "non-executing discovery journey."
+        ),
         "authority": {
             "class": "source-authoritative",
             "statement": (
@@ -381,8 +715,10 @@ def hmlr_source_record(
         "status": "external-source",
         "sourceRefs": [source_id],
         "limitations": [
-            "A public evidence page does not imply that linked data, services or "
-            "attachments are open."
+            (
+                "A public evidence page does not imply that linked data, services or "
+                "attachments are open."
+            )
         ],
         "tags": ["hmlr", "official-source", "source"],
         "details": {
@@ -398,20 +734,29 @@ def hmlr_dataset_record(
     source_refs: list[str],
     publication: dict[str, Any],
 ) -> dict[str, Any]:
-    if rights["access_state"] != "public" or rights["rights_state"] != "open-with-conditions":
-        raise ValueError(f"selected HMLR record does not have publishable rights: {record['id']}")
+    if (
+        rights["access_state"] != "public"
+        or rights["rights_state"] != "open-with-conditions"
+    ):
+        raise ValueError(
+            f"selected HMLR record does not have publishable rights: {record['id']}"
+        )
     actual = canonical_record_sha256(record)
     if actual != rights["curated_record_sha256"]:
         raise ValueError(f"selected HMLR record digest mismatch: {record['id']}")
     attribution = publication["attribution_by_record"].get(record["id"])
     if not attribution:
-        raise ValueError(f"selected HMLR record lacks explicit attribution: {record['id']}")
+        raise ValueError(
+            f"selected HMLR record lacks explicit attribution: {record['id']}"
+        )
     if "inspire" in record["id"].lower():
         caveats = " ".join(record["caveats"]).lower()
         if "indicative" not in caveats or not any(
             term in caveats for term in ("legal", "definitive")
         ):
-            raise ValueError(f"selected INSPIRE record lacks a non-legal caveat: {record['id']}")
+            raise ValueError(
+                f"selected INSPIRE record lacks a non-legal caveat: {record['id']}"
+            )
 
     return {
         "schema": "gis-ai-go-okf-concept.v1",
@@ -444,7 +789,9 @@ def hmlr_dataset_record(
         "sourceRefs": sorted(source_refs),
         "limitations": sorted(
             set(record["caveats"])
-            | {"Metadata only; no provider distribution or feature payload is included."}
+            | {
+                "Metadata only; no provider distribution or feature payload is included."
+            }
         ),
         "tags": sorted(set(record["topics"]) | {"hmlr", "metadata-only"}),
         "details": {
@@ -503,7 +850,9 @@ def product_record(publication: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def select_unique(rows: list[dict[str, Any]], ids: list[str], label: str) -> list[dict[str, Any]]:
+def select_unique(
+    rows: list[dict[str, Any]], ids: list[str], label: str
+) -> list[dict[str, Any]]:
     by_id = {row["id"]: row for row in rows}
     if len(by_id) != len(rows):
         raise ValueError(f"duplicate IDs in {label}")
@@ -521,27 +870,64 @@ def validate_reference_closure(records: list[dict[str, Any]]) -> None:
     for record in records:
         missing = sorted(set(record["sourceRefs"]) - known)
         if missing:
-            raise ValueError(f"unresolved source references for {record['id']}: {missing}")
+            raise ValueError(
+                f"unresolved source references for {record['id']}: {missing}"
+            )
 
 
-def build_records(root: Path, publication: dict[str, Any]) -> list[dict[str, Any]]:
+def build_records(
+    root: Path, publication: dict[str, Any], source_lock: dict[str, Any]
+) -> list[dict[str, Any]]:
+    verify_approved_hmlr_inputs(root)
     research_data = root / "docs/research/2026-08-19/research-pack/data"
     providers_doc = load_json(research_data / "providers.json")
     workflows_doc = load_json(research_data / "workflows.json")
     sources_doc = load_json(research_data / "sources.json")
     hmlr_records_doc = load_json(root / HMLR_VENDOR / "source/curated-records.json")
-    hmlr_rights_doc = load_json(root / HMLR_VENDOR / "source/curated-rights-access.json")
+    hmlr_rights_doc = load_json(
+        root / HMLR_VENDOR / "source/curated-rights-access.json"
+    )
+    hmlr_questions_doc = load_json(root / HMLR_QUESTIONS)
+
+    questions = hmlr_questions_doc.get("questions")
+    if (
+        hmlr_questions_doc.get("schema") != "okf-explorer-evaluation-suite.v1"
+        or hmlr_questions_doc.get("question_count") != 24
+        or not isinstance(questions, list)
+        or len(questions) != hmlr_questions_doc["question_count"]
+    ):
+        raise ValueError("HMLR evaluation question suite metadata is invalid")
 
     selected = publication["selected"]
     providers = select_unique(
         providers_doc["providers"], selected["research_provider_ids"], "providers"
     )
+    provider_sha256_by_id = selected.get("research_provider_sha256_by_id")
+    if not isinstance(provider_sha256_by_id, dict) or set(provider_sha256_by_id) != {
+        row["id"] for row in providers
+    }:
+        raise ValueError("selected provider digest inventory is incomplete")
+    for provider in providers:
+        expected = provider_sha256_by_id[provider["id"]]
+        if (
+            not isinstance(expected, str)
+            or canonical_record_sha256(provider) != expected
+        ):
+            raise ValueError(f"selected provider digest mismatch: {provider['id']}")
     workflows = select_unique(
         workflows_doc["workflows"], selected["research_workflow_ids"], "workflows"
     )
     hmlr_records = select_unique(
         hmlr_records_doc["records"], selected["hmlr_record_ids"], "HMLR records"
     )
+    hmlr_questions = select_unique(
+        questions, selected["hmlr_question_ids"], "HMLR questions"
+    )
+    question_sha256_by_id = selected.get("hmlr_question_sha256_by_id")
+    if not isinstance(question_sha256_by_id, dict) or set(question_sha256_by_id) != {
+        row["id"] for row in hmlr_questions
+    }:
+        raise ValueError("selected HMLR question digest inventory is incomplete")
     rights_rows = hmlr_rights_doc["classifications"]
     rights_by_id = {row["source_native_id"]: row for row in rights_rows}
     if len(rights_by_id) != len(rights_rows):
@@ -556,7 +942,9 @@ def build_records(root: Path, publication: dict[str, Any]) -> list[dict[str, Any
         sources_doc["sources"], sorted(referenced_research_sources), "sources"
     )
     research_source_ids_by_url = {
-        row["url"]: row["id"] for row in selected_sources if row["url"].startswith("https://")
+        row["url"]: row["id"]
+        for row in selected_sources
+        if row["url"].startswith("https://")
     }
 
     url_references: dict[str, set[str]] = {}
@@ -569,12 +957,57 @@ def build_records(root: Path, publication: dict[str, Any]) -> list[dict[str, Any
             refs.append(source_id)
             if source_id.startswith("hmlr-source:"):
                 url_references.setdefault(url, set()).add(row["id"])
-        hmlr_source_refs[row["id"]] = refs
+        hmlr_source_refs[row["id"]] = sorted(set(refs) | {HMLR_RELEASE_SOURCE_ID})
+
+    question_source_refs: dict[str, list[str]] = {}
+    for question in hmlr_questions:
+        refs = []
+        for source in question["expected_sources"]:
+            url = source["canonical_url"]
+            validate_url(url)
+            source_id = research_source_ids_by_url.get(url, source_record_id(url))
+            refs.append(source_id)
+            if source_id.startswith("hmlr-source:"):
+                url_references.setdefault(url, set()).add(question["id"])
+        question_source_refs[question["id"]] = refs
+
+    caveat_rows = hmlr_questions_doc.get("caveat_registry")
+    hard_failure_rows = hmlr_questions_doc.get("hard_failures")
+    if not isinstance(caveat_rows, list) or not isinstance(hard_failure_rows, list):
+        raise TypeError("HMLR evaluation controls are missing")
+    caveat_text_by_id = {row.get("id"): row.get("text") for row in caveat_rows}
+    known_hard_failure_ids = {row.get("id") for row in hard_failure_rows}
+    if (
+        None in caveat_text_by_id
+        or not all(
+            isinstance(text, str) and text for text in caveat_text_by_id.values()
+        )
+        or None in known_hard_failure_ids
+        or len(caveat_text_by_id) != len(caveat_rows)
+        or len(known_hard_failure_ids) != len(hard_failure_rows)
+    ):
+        raise ValueError("HMLR evaluation controls contain duplicate or invalid IDs")
 
     records: list[dict[str, Any]] = [product_record(publication)]
-    records.extend(provider_record(row, publication) for row in providers)
+    records.extend(
+        provider_record(row, publication, providers_doc["generated_at"])
+        for row in providers
+    )
     records.extend(workflow_record(row, publication) for row in workflows)
+    records.extend(
+        hmlr_question_record(
+            question,
+            question_source_refs[question["id"]],
+            caveat_text_by_id,
+            known_hard_failure_ids,
+            hmlr_questions_doc["research_cutoff"],
+            question_sha256_by_id[question["id"]],
+            publication,
+        )
+        for question in hmlr_questions
+    )
     records.extend(research_source_record(row, publication) for row in selected_sources)
+    records.append(hmlr_release_source_record(source_lock, publication))
     for row in hmlr_records:
         rights = rights_by_id.get(row["id"])
         if not rights:
@@ -598,6 +1031,11 @@ def build_records(root: Path, publication: dict[str, Any]) -> list[dict[str, Any
         )
 
     records.sort(key=lambda record: (record["type"], record["id"]))
+    if len(records) != publication["expected_record_count"]:
+        raise ValueError(
+            f"generated record count {len(records)} differs from expected "
+            f"{publication['expected_record_count']}"
+        )
     if len(records) > MAX_RECORDS:
         raise ValueError(f"generated record count exceeds {MAX_RECORDS}")
     validate_reference_closure(records)
@@ -622,13 +1060,17 @@ def validate_records(
         reject_forbidden_keys(record, forbidden)
         for value in walk_urls(record):
             validate_url(value)
-        errors = sorted(concept_validator.iter_errors(record), key=lambda error: list(error.path))
+        errors = sorted(
+            concept_validator.iter_errors(record), key=lambda error: list(error.path)
+        )
         if errors:
             detail = "; ".join(
                 f"{'/'.join(map(str, error.path)) or '<root>'}: {error.message}"
                 for error in errors
             )
-            raise ValueError(f"record {record['id']} failed schema validation: {detail}")
+            raise ValueError(
+                f"record {record['id']} failed schema validation: {detail}"
+            )
 
 
 def walk_urls(value: Any, key: str = "") -> Iterable[str]:
@@ -848,7 +1290,10 @@ def prepare_output(output: Path) -> None:
         raise ValueError(f"output directory must not be a symbolic link: {output}")
     if output.exists():
         marker = output / ".okf-generated"
-        if not marker.is_file() or marker.read_text(encoding="utf-8") != GENERATED_MARKER:
+        if (
+            not marker.is_file()
+            or marker.read_text(encoding="utf-8") != GENERATED_MARKER
+        ):
             raise ValueError(f"refusing to replace unmarked output directory: {output}")
         shutil.rmtree(output)
     output.mkdir(parents=True)
@@ -881,7 +1326,7 @@ def build(root: Path, output: Path, revision: str) -> dict[str, Any]:
     schema = load_json(root / "schemas/okf-publication-bundle.schema.json")
     version = (root / "VERSION").read_text(encoding="utf-8").strip()
 
-    records = build_records(root, publication)
+    records = build_records(root, publication, source_lock)
     validate_records(records, profile, schema)
     validate_output_paths(records)
     bundle = {
@@ -926,7 +1371,9 @@ def build(root: Path, output: Path, revision: str) -> dict[str, Any]:
         "records": records,
     }
     bundle_errors = sorted(
-        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(bundle),
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(
+            bundle
+        ),
         key=lambda error: list(error.path),
     )
     if bundle_errors:
@@ -946,7 +1393,9 @@ def build(root: Path, output: Path, revision: str) -> dict[str, Any]:
     write_file(output, "okf-bundle.json", canonical_json_bytes(bundle))
     jsonld = jsonld_document(bundle)
     write_file(output, "okf-bundle.jsonld", canonical_json_bytes(jsonld))
-    write_file(output, "context.jsonld", canonical_json_bytes({"@context": jsonld["@context"]}))
+    write_file(
+        output, "context.jsonld", canonical_json_bytes({"@context": jsonld["@context"]})
+    )
     write_file(output, "index.md", index_markdown(bundle))
     for record in records:
         write_file(output, record_output_path(record), record_markdown(record))
@@ -1001,7 +1450,9 @@ def build(root: Path, output: Path, revision: str) -> dict[str, Any]:
     }
     write_file(output, "manifest.json", canonical_json_bytes(manifest))
 
-    content_files = existing_payloads(output, {"CHECKSUMS.sha256", "build-receipt.json"})
+    content_files = existing_payloads(
+        output, {"CHECKSUMS.sha256", "build-receipt.json"}
+    )
     content_checksums = "".join(
         f"{sha256_file(output / path)}  {path}\n" for path in content_files
     ).encode()
@@ -1062,7 +1513,9 @@ def git_revision(root: Path) -> str:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--revision")
     return parser.parse_args()

--- a/tests/contract/test_okf_bundle.py
+++ b/tests/contract/test_okf_bundle.py
@@ -81,7 +81,10 @@ class OkfBundleTests(unittest.TestCase):
         cls.temporary_directory.cleanup()
 
     def test_build_is_byte_for_byte_deterministic(self) -> None:
-        with tempfile.TemporaryDirectory() as first, tempfile.TemporaryDirectory() as second:
+        with (
+            tempfile.TemporaryDirectory() as first,
+            tempfile.TemporaryDirectory() as second,
+        ):
             first_output = Path(first) / "different" / "first"
             second_output = Path(second) / "second"
             BUILDER.build(ROOT, first_output, FIXED_REVISION)
@@ -92,13 +95,23 @@ class OkfBundleTests(unittest.TestCase):
         schema = load_json(ROOT / "schemas" / "okf-publication-bundle.schema.json")
         Draft202012Validator.check_schema(schema)
         errors = list(
-            Draft202012Validator(
-                schema, format_checker=FormatChecker()
-            ).iter_errors(self.bundle)
+            Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(
+                self.bundle
+            )
         )
         self.assertEqual(errors, [])
-        self.assertEqual(self.bundle["recordCount"], 18)
+        self.assertEqual(self.bundle["recordCount"], 36)
         self.assertEqual(self.bundle["recordCount"], len(self.bundle["records"]))
+        counts = {
+            record_type: sum(
+                record["type"] == record_type for record in self.bundle["records"]
+            )
+            for record_type in {record["type"] for record in self.bundle["records"]}
+        }
+        self.assertEqual(
+            counts,
+            {"bundle": 1, "dataset": 3, "provider": 4, "source": 24, "workflow": 4},
+        )
         self.assertEqual(
             self.bundle["profile"],
             "https://chris-page-gov.github.io/gis-ai-go/profile/public-discovery/v1/",
@@ -112,10 +125,7 @@ class OkfBundleTests(unittest.TestCase):
         )
         self.assertEqual(
             (self.output / "third-party" / "okf-landregistry-LICENSE.md").read_bytes(),
-            (
-                ROOT
-                / "okf/vendor/okf-landregistry/v0.3.0/LICENSE.md"
-            ).read_bytes(),
+            (ROOT / "okf/vendor/okf-landregistry/v0.3.0/LICENSE.md").read_bytes(),
         )
         for record in self.bundle["records"]:
             with self.subTest(record=record["id"]):
@@ -132,13 +142,37 @@ class OkfBundleTests(unittest.TestCase):
         release = source_lock["external_release"]
         self.assertEqual(release["retrieved_on"], "2026-08-19")
         self.assertEqual(release["tag"], "v0.3.0")
-        self.assertEqual(
-            release["commit"], "1d708e39f2cde19610d43c5a7f5e36e4a2f947bc"
-        )
+        self.assertEqual(release["tagged_at"], "2026-08-12T01:43:30+01:00")
+        self.assertEqual(release["commit"], "1d708e39f2cde19610d43c5a7f5e36e4a2f947bc")
         self.assertEqual(
             release["release_root_sha256"],
             "6a29e38e7bb805aafb7f36ba8d1fa4ce976875f45997049cd4808d6ede7f75e1",
         )
+        self.assertEqual(
+            release["evaluation_questions_sha256"], BUILDER.HMLR_QUESTIONS_SHA256
+        )
+        questions = ROOT / BUILDER.HMLR_QUESTIONS
+        self.assertEqual(
+            hashlib.sha256(questions.read_bytes()).hexdigest(),
+            BUILDER.HMLR_QUESTIONS_SHA256,
+        )
+        question_lock = next(
+            item
+            for item in source_lock["inputs"]
+            if item["path"] == BUILDER.HMLR_QUESTIONS.as_posix()
+        )
+        self.assertEqual(question_lock["sha256"], BUILDER.HMLR_QUESTIONS_SHA256)
+        locked_sha256 = {Path(item["path"]): item["sha256"] for item in source_lock["inputs"]}
+        self.assertEqual(
+            {
+                path: hashlib.sha256((ROOT / path).read_bytes()).hexdigest()
+                for path in BUILDER.HMLR_APPROVED_INPUT_SHA256
+            },
+            BUILDER.HMLR_APPROVED_INPUT_SHA256,
+        )
+        for path, digest in BUILDER.HMLR_APPROVED_INPUT_SHA256.items():
+            with self.subTest(path=path):
+                self.assertEqual(locked_sha256[path], digest)
 
     def test_selected_hmlr_records_have_known_rights_and_legal_caveats(self) -> None:
         datasets = {
@@ -166,6 +200,232 @@ class OkfBundleTests(unittest.TestCase):
             caveats = " ".join(datasets[identifier]["limitations"]).lower()
             self.assertIn("indicative", caveats)
             self.assertTrue("legal" in caveats or "definitive" in caveats)
+
+    def test_selected_hmlr_journeys_are_exact_non_executing_projections(self) -> None:
+        workflows = {
+            record["id"]: record
+            for record in self.bundle["records"]
+            if record["type"] == "workflow"
+        }
+        expected = {
+            "LR-Q003": {
+                "sha256": "1ceea667a350027240418de79439ecbe83f77a7243290b7970e3847a19f84547",
+                "sources": {
+                    "S-OKF-HMLR-V0.3.0",
+                    "hmlr-source:7177c8b621ecfc42",
+                    "hmlr-source:b81206b053b276d5",
+                },
+                "target": "NEG-LR-Q003-BUSINESS-GATEWAY-OFFICIAL-COPY",
+            },
+            "LR-Q006": {
+                "sha256": "3d4980bd7f63ff5c65bd519584a42c85adab907bad17d216345467d07c507ab0",
+                "sources": {
+                    "S-OKF-HMLR-V0.3.0",
+                    "hmlr-source:7177c8b621ecfc42",
+                    "hmlr-source:b81206b053b276d5",
+                    "hmlr-source:c5984959cb2b5fa5",
+                },
+                "target": "NEG-LR-Q006-ADDRESS-SEARCH-CODE",
+            },
+            "LR-Q012": {
+                "sha256": "84269ab3c74e31517e7fb9a2c3eb7fba71b9e9757418be5674cfe778b88d452c",
+                "sources": {
+                    "S-OKF-HMLR-V0.3.0",
+                    "hmlr-source:638ecac167aaf6f0",
+                    "hmlr-source:951ac51b5d700a95",
+                },
+                "target": "NEG-LR-Q012-NATIONAL-POLYGON-SERVICE",
+            },
+        }
+        self.assertEqual(set(workflows), {"WF01", *expected})
+        for identifier, expectation in expected.items():
+            record = workflows[identifier]
+            with self.subTest(record=identifier):
+                self.assertEqual(record["access"]["state"], "planned-non-executing")
+                self.assertEqual(record["status"], "candidate-non-executing")
+                self.assertEqual(record["authority"]["class"], "derived")
+                self.assertEqual(record["authority"]["source"], "S-OKF-HMLR-V0.3.0")
+                self.assertEqual(record["rights"]["state"], "metadata-citation")
+                self.assertEqual(set(record["sourceRefs"]), expectation["sources"])
+                self.assertEqual(
+                    record["details"]["sourceRecordSha256"], expectation["sha256"]
+                )
+                self.assertEqual(
+                    [target["id"] for target in record["details"]["forbiddenTargets"]],
+                    [expectation["target"]],
+                )
+                self.assertEqual(
+                    set(record["details"]["forbiddenTargets"][0]), {"id", "reason"}
+                )
+                self.assertTrue(record["details"]["expectedPropositions"])
+                self.assertTrue(record["details"]["requiredCaveatIds"])
+
+        self.assertIn(
+            "not proof of ownership",
+            " ".join(workflows["LR-Q003"]["details"]["expectedPropositions"]).lower(),
+        )
+        self.assertIn(
+            "search of the index map",
+            " ".join(workflows["LR-Q006"]["details"]["expectedPropositions"]).lower(),
+        )
+        q12_text = " ".join(
+            workflows["LR-Q012"]["details"]["expectedPropositions"]
+            + workflows["LR-Q012"]["limitations"]
+        ).lower()
+        self.assertIn("indicative", q12_text)
+        self.assertIn("not exact legal boundary", q12_text)
+        source_urls = {
+            record["id"]: record["details"]["url"]
+            for record in self.bundle["records"]
+            if record["id"].startswith("hmlr-source:")
+        }
+        self.assertEqual(
+            {
+                identifier: source_urls[identifier]
+                for identifier in (
+                    "hmlr-source:638ecac167aaf6f0",
+                    "hmlr-source:7177c8b621ecfc42",
+                    "hmlr-source:951ac51b5d700a95",
+                    "hmlr-source:b81206b053b276d5",
+                    "hmlr-source:c5984959cb2b5fa5",
+                )
+            },
+            {
+                "hmlr-source:638ecac167aaf6f0": (
+                    "https://www.gov.uk/government/publications/"
+                    "hm-land-registry-plans-boundaries-pg40s3"
+                ),
+                "hmlr-source:7177c8b621ecfc42": (
+                    "https://www.gov.uk/guidance/"
+                    "land-registry-portal-how-to-request-official-copies"
+                ),
+                "hmlr-source:951ac51b5d700a95": (
+                    "https://use-land-property-data.service.gov.uk/datasets/llc"
+                ),
+                "hmlr-source:b81206b053b276d5": (
+                    "https://www.gov.uk/search-property-information-land-registry"
+                ),
+                "hmlr-source:c5984959cb2b5fa5": (
+                    "https://www.gov.uk/guidance/"
+                    "land-registry-portal-request-a-search-of-the-index-map"
+                ),
+            },
+        )
+
+    def test_provider_examples_preserve_mixed_rights_and_date_meanings(self) -> None:
+        providers = {
+            record["id"]: record
+            for record in self.bundle["records"]
+            if record["type"] == "provider"
+        }
+        expected_digests = {
+            "PV-HMLR-OPEN": "2c9b1712ad8995bd4e6bd37699bad6fc233462cf874f7fdba14e5e0bfb23f824",
+            "PV-LANDIS": "a735efba3e6d58d533f17d438e053246f7902705881186de542f5d26043e2c2a",
+            "PV-ONS-DATA": "535e6eb65fc9af4507e30700d425393a658a085a3a240689f4b37124dc8f8622",
+            "PV-ONS-GEO": "75f4313b278f360c0e60a8095ffdedca16aaabc7ce7ec91448ba1a1659203c1c",
+        }
+        self.assertEqual(set(providers), set(expected_digests))
+        for identifier, record in providers.items():
+            with self.subTest(record=identifier):
+                self.assertEqual(record["access"]["state"], "public-metadata")
+                self.assertEqual(record["rights"]["state"], "metadata-citation")
+                self.assertEqual(
+                    record["details"]["sourceRecordSha256"],
+                    expected_digests[identifier],
+                )
+                self.assertEqual(
+                    record["details"]["metadataSnapshotGeneratedAt"],
+                    "2026-08-19T13:30:00+01:00",
+                )
+                self.assertEqual(
+                    record["freshness"]["observedAt"],
+                    record["details"]["metadataSnapshotGeneratedAt"],
+                )
+                self.assertEqual(
+                    record["freshness"]["reviewedAt"], "2026-08-20T00:00:00Z"
+                )
+                if identifier != "PV-HMLR-OPEN":
+                    self.assertNotIn("hmlr", record["tags"])
+
+        landis = providers["PV-LANDIS"]
+        self.assertEqual(landis["details"]["describedAccess"], "mixed-per-record")
+        self.assertEqual(
+            landis["details"]["accessTiers"],
+            ["open", "commercial-or-restricted where record terms require"],
+        )
+        self.assertIn(
+            "each record", landis["rights"]["describedResourceLicence"].lower()
+        )
+        self.assertIn(
+            "blanket licence", landis["rights"]["describedResourceLicence"].lower()
+        )
+        self.assertIn("mixed-access", landis["tags"])
+
+        ons_data = providers["PV-ONS-DATA"]
+        ons_geo = providers["PV-ONS-GEO"]
+        self.assertEqual(set(ons_data["sourceRefs"]), {"S-ONS-API", "S-ONS-LICENCE"})
+        self.assertEqual(
+            set(ons_geo["sourceRefs"]),
+            {"S-ONS-GEOGRAPHY", "S-ONS-LICENCE", "S-ONS-OPG"},
+        )
+        self.assertIn("where stated", ons_data["rights"]["describedResourceLicence"])
+        self.assertIn(
+            "product-specific", ons_geo["rights"]["describedResourceLicence"].lower()
+        )
+
+        records = {record["id"]: record for record in self.bundle["records"]}
+        ons_source = records["S-ONS-API"]
+        self.assertIsNone(ons_source["details"]["published"])
+        self.assertEqual(ons_source["details"]["retrieved"], "2026-08-19")
+        self.assertEqual(ons_source["freshness"]["observedAt"], "2026-08-19T00:00:00Z")
+        price_paid = records["hmlr:dataset:price-paid-data"]
+        self.assertEqual(price_paid["details"]["publisherLastUpdated"], "2026-07-28")
+        self.assertEqual(price_paid["freshness"]["observedAt"], "2026-07-29T07:53:38Z")
+
+    def test_hmlr_release_provenance_is_visible_and_exact(self) -> None:
+        release = next(
+            record
+            for record in self.bundle["records"]
+            if record["id"] == "S-OKF-HMLR-V0.3.0"
+        )
+        details = release["details"]
+        self.assertEqual(release["authority"]["class"], "derived")
+        self.assertEqual(details["releaseTag"], "v0.3.0")
+        self.assertEqual(details["releaseTaggedAt"], "2026-08-12T01:43:30+01:00")
+        self.assertEqual(details["retrievedOn"], "2026-08-19")
+        self.assertEqual(details["commit"], "1d708e39f2cde19610d43c5a7f5e36e4a2f947bc")
+        self.assertEqual(
+            details["releaseRootSha256"],
+            "6a29e38e7bb805aafb7f36ba8d1fa4ce976875f45997049cd4808d6ede7f75e1",
+        )
+        self.assertEqual(
+            details["evaluationQuestionsSha256"], BUILDER.HMLR_QUESTIONS_SHA256
+        )
+        self.assertEqual(details["supersededResearchCommitPrefix"], "4580c9e")
+        self.assertEqual(
+            details["supersededResearchReferenceStatus"],
+            "not-resolvable-in-local-clone-or-refs",
+        )
+        self.assertEqual(
+            details["supersededResearchDecision"],
+            "Use the approved immutable v0.3.0 release identity above.",
+        )
+
+    def test_hmlr_superseded_reference_identity_fails_closed(self) -> None:
+        publication = load_json(ROOT / "okf" / "source" / "publication.json")
+        source_lock = load_json(ROOT / "okf" / "source-lock.json")
+        for field, value in (
+            ("recorded_commit_prefix", "different"),
+            ("status", "resolved"),
+            ("status", None),
+            ("decision", "Use mutable main."),
+        ):
+            changed = copy.deepcopy(source_lock)
+            changed["supersedes_unresolved_research_reference"][field] = value
+            with self.subTest(field=field, value=value), self.assertRaisesRegex(
+                ValueError, "superseded research reference"
+            ):
+                BUILDER.hmlr_release_source_record(changed, publication)
 
     def test_json_and_jsonld_project_the_same_identifiers(self) -> None:
         jsonld = load_json(self.output / "okf-bundle.jsonld")
@@ -212,7 +472,9 @@ class OkfBundleTests(unittest.TestCase):
             path = self.output / entry["path"]
             self.assertTrue(path.is_file())
             self.assertEqual(path.stat().st_size, entry["bytes"])
-            self.assertEqual(hashlib.sha256(path.read_bytes()).hexdigest(), entry["sha256"])
+            self.assertEqual(
+                hashlib.sha256(path.read_bytes()).hexdigest(), entry["sha256"]
+            )
 
         checksum_bytes = (self.output / "CHECKSUMS.sha256").read_bytes()
         checksum_rows = []
@@ -220,7 +482,8 @@ class OkfBundleTests(unittest.TestCase):
             digest, relative = line.split("  ", 1)
             self.assertNotIn("..", Path(relative).parts)
             self.assertEqual(
-                hashlib.sha256((self.output / relative).read_bytes()).hexdigest(), digest
+                hashlib.sha256((self.output / relative).read_bytes()).hexdigest(),
+                digest,
             )
             checksum_rows.append(relative)
         self.assertEqual(checksum_rows, sorted(checksum_rows))
@@ -259,30 +522,179 @@ class OkfBundleTests(unittest.TestCase):
 
     def test_bad_rights_for_selected_record_fail_closed(self) -> None:
         records = load_json(
-            ROOT
-            / "okf/vendor/okf-landregistry/v0.3.0/source/curated-records.json"
+            ROOT / "okf/vendor/okf-landregistry/v0.3.0/source/curated-records.json"
         )["records"]
         rights = load_json(
             ROOT
             / "okf/vendor/okf-landregistry/v0.3.0/source/curated-rights-access.json"
         )["classifications"]
-        record = next(row for row in records if row["id"] == "hmlr:dataset:price-paid-data")
+        record = next(
+            row for row in records if row["id"] == "hmlr:dataset:price-paid-data"
+        )
         classification = copy.deepcopy(
             next(row for row in rights if row["source_native_id"] == record["id"])
         )
         classification["rights_state"] = "unknown"
         publication = load_json(ROOT / "okf" / "source" / "publication.json")
         with self.assertRaisesRegex(ValueError, "publishable rights"):
-            BUILDER.hmlr_dataset_record(record, classification, ["S-HMLR-PPD"], publication)
+            BUILDER.hmlr_dataset_record(
+                record, classification, ["S-HMLR-PPD"], publication
+            )
+        classification["rights_state"] = "open-with-conditions"
+        classification["access_state"] = "unknown"
+        with self.assertRaisesRegex(ValueError, "publishable rights"):
+            BUILDER.hmlr_dataset_record(
+                record, classification, ["S-HMLR-PPD"], publication
+            )
+
+        missing_attribution = copy.deepcopy(publication)
+        missing_attribution["attribution_by_record"].pop(record["id"])
+        classification["access_state"] = "public"
+        with self.assertRaisesRegex(ValueError, "explicit attribution"):
+            BUILDER.hmlr_dataset_record(
+                record, classification, ["S-HMLR-PPD"], missing_attribution
+            )
+
+    def test_selected_provider_digests_and_mixed_rights_fail_closed(self) -> None:
+        publication = load_json(ROOT / "okf" / "source" / "publication.json")
+        source_lock = load_json(ROOT / "okf" / "source-lock.json")
+        changed_digest = copy.deepcopy(publication)
+        changed_digest["selected"]["research_provider_sha256_by_id"]["PV-ONS-DATA"] = (
+            "0" * 64
+        )
+        with self.assertRaisesRegex(ValueError, "selected provider digest mismatch"):
+            BUILDER.build_records(ROOT, changed_digest, source_lock)
+
+        changed_question_digest = copy.deepcopy(publication)
+        changed_question_digest["selected"]["hmlr_question_sha256_by_id"]["LR-Q012"] = (
+            "0" * 64
+        )
+        with self.assertRaisesRegex(
+            ValueError, "selected HMLR question digest mismatch"
+        ):
+            BUILDER.build_records(ROOT, changed_question_digest, source_lock)
+
+        changed_release = copy.deepcopy(source_lock)
+        changed_release["external_release"]["commit"] = "0" * 40
+        with self.assertRaisesRegex(ValueError, "approved v0.3.0 pin"):
+            BUILDER.hmlr_release_source_record(changed_release, publication)
+
+        providers_doc = load_json(
+            ROOT / "docs/research/2026-08-19/research-pack/data/providers.json"
+        )
+        landis = copy.deepcopy(
+            next(row for row in providers_doc["providers"] if row["id"] == "PV-LANDIS")
+        )
+        landis["licence"] = "Open Government Licence"
+        with self.assertRaisesRegex(ValueError, "per-record rights wording"):
+            BUILDER.provider_record(landis, publication, providers_doc["generated_at"])
+        landis["access_tier"] = []
+        with self.assertRaisesRegex(ValueError, "no described access tiers"):
+            BUILDER.provider_record(landis, publication, providers_doc["generated_at"])
+
+    def test_hmlr_question_controls_fail_closed(self) -> None:
+        suite = load_json(ROOT / BUILDER.HMLR_QUESTIONS)
+        publication = load_json(ROOT / "okf" / "source" / "publication.json")
+        caveats = {row["id"]: row["text"] for row in suite["caveat_registry"]}
+        hard_failures = {row["id"] for row in suite["hard_failures"]}
+        original = next(row for row in suite["questions"] if row["id"] == "LR-Q003")
+        source_refs = [
+            BUILDER.source_record_id(source["canonical_url"])
+            for source in original["expected_sources"]
+        ]
+
+        def project(question: dict[str, Any]) -> dict[str, Any]:
+            return BUILDER.hmlr_question_record(
+                question,
+                source_refs,
+                caveats,
+                hard_failures,
+                suite["research_cutoff"],
+                BUILDER.canonical_record_sha256(question),
+                publication,
+            )
+
+        missing_caveat = copy.deepcopy(original)
+        missing_caveat["required_caveat_ids"] = []
+        with self.assertRaisesRegex(ValueError, "lacks mandatory caveats"):
+            project(missing_caveat)
+
+        unknown_caveat = copy.deepcopy(original)
+        unknown_caveat["required_caveat_ids"] = ["CAV-NOT-REGISTERED"]
+        with self.assertRaisesRegex(ValueError, "unknown mandatory caveats"):
+            project(unknown_caveat)
+
+        missing_hard_failure = copy.deepcopy(original)
+        missing_hard_failure["hard_failure_ids"] = []
+        with self.assertRaisesRegex(ValueError, "lacks hard-failure controls"):
+            project(missing_hard_failure)
+
+        source_mismatch = copy.deepcopy(original)
+        source_mismatch["runtime_expected_source_url"] = "https://example.invalid/"
+        with self.assertRaisesRegex(ValueError, "outside its positive sources"):
+            project(source_mismatch)
+
+        target_overlap = copy.deepcopy(original)
+        target_overlap["must_not_retrieve"][0]["canonical_url"] = original[
+            "expected_sources"
+        ][0]["canonical_url"]
+        with self.assertRaisesRegex(ValueError, "both required and forbidden"):
+            project(target_overlap)
+
+        no_forbidden_target = copy.deepcopy(original)
+        no_forbidden_target["must_not_retrieve"] = []
+        with self.assertRaisesRegex(ValueError, "requires unique forbidden targets"):
+            project(no_forbidden_target)
+
+        wrong_digest = copy.deepcopy(original)
+        with self.assertRaisesRegex(ValueError, "question digest mismatch"):
+            BUILDER.hmlr_question_record(
+                wrong_digest,
+                source_refs,
+                caveats,
+                hard_failures,
+                suite["research_cutoff"],
+                "0" * 64,
+                publication,
+            )
 
     def test_forbidden_payload_keys_and_unsafe_urls_fail_closed(self) -> None:
         profile = load_json(ROOT / "okf" / "profile" / "public-discovery-v1.json")
-        forbidden = {BUILDER.canonical_key(key) for key in profile["forbidden_payload_keys"]}
-        with self.assertRaisesRegex(ValueError, "forbidden payload key"):
-            BUILDER.reject_forbidden_keys({"nested": {"geometry": {}}}, forbidden)
+        forbidden = {
+            BUILDER.canonical_key(key) for key in profile["forbidden_payload_keys"]
+        }
+        for key in (
+            "address",
+            "apiKey",
+            "certificate",
+            "cookie",
+            "feature",
+            "geometry",
+            "logo",
+            "ownership",
+            "serviceResponse",
+            "signedUrl",
+            "titleNumber",
+            "uprn",
+        ):
+            with (
+                self.subTest(key=key),
+                self.assertRaisesRegex(ValueError, "forbidden payload key"),
+            ):
+                BUILDER.reject_forbidden_keys({"nested": {key: "blocked"}}, forbidden)
+        BUILDER.reject_forbidden_keys(self.bundle, forbidden)
         for value in ("javascript:alert(1)", "file:///tmp/data", "../escape"):
             with self.subTest(value=value), self.assertRaises(ValueError):
                 BUILDER.validate_url(value)
+
+        output_text = b"\n".join(file_bytes(self.output).values()).decode("utf-8")
+        for forbidden_url in (
+            "https://businessgateway.landregistry.gov.uk/bg2/s1/v1",
+            "https://github.com/LandRegistry/address-search-api",
+            "https://use-land-property-data.service.gov.uk/datasets/nps",
+        ):
+            with self.subTest(url=forbidden_url):
+                self.assertNotIn(forbidden_url, output_text)
 
     def test_unknown_access_and_unresolved_references_fail_closed(self) -> None:
         records = copy.deepcopy(self.bundle["records"])
@@ -306,6 +718,65 @@ class OkfBundleTests(unittest.TestCase):
             target.write_bytes(target.read_bytes() + b"\n")
             with self.assertRaisesRegex(ValueError, "hash mismatch"):
                 BUILDER.verify_source_lock(root, source_lock)
+
+    def test_coordinated_hmlr_source_and_lock_mutation_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_lock = copy_locked_inputs(root)
+            records_path = root / BUILDER.HMLR_VENDOR / "source/curated-records.json"
+            rights_path = (
+                root / BUILDER.HMLR_VENDOR / "source/curated-rights-access.json"
+            )
+            records_doc = load_json(records_path)
+            rights_doc = load_json(rights_path)
+            record = next(
+                row
+                for row in records_doc["records"]
+                if row["id"] == "hmlr:dataset:price-paid-data"
+            )
+            record["description"] = (
+                "Validation mutation not present in the approved upstream release."
+            )
+            rights = next(
+                row
+                for row in rights_doc["classifications"]
+                if row["source_native_id"] == record["id"]
+            )
+            rights["curated_record_sha256"] = BUILDER.canonical_record_sha256(record)
+            records_path.write_bytes(BUILDER.canonical_json_bytes(records_doc))
+            rights_path.write_bytes(BUILDER.canonical_json_bytes(rights_doc))
+
+            lock_by_path = {item["path"]: item for item in source_lock["inputs"]}
+            for path in (records_path, rights_path):
+                relative = path.relative_to(root).as_posix()
+                lock_by_path[relative]["sha256"] = hashlib.sha256(
+                    path.read_bytes()
+                ).hexdigest()
+
+            BUILDER.verify_source_lock(root, source_lock)
+            publication = load_json(root / "okf/source/publication.json")
+            with self.assertRaisesRegex(
+                ValueError, "approved v0.3.0 input hash mismatch"
+            ):
+                BUILDER.build_records(root, publication, source_lock)
+
+    def test_coordinated_hmlr_licence_and_lock_mutation_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_lock = copy_locked_inputs(root)
+            licence_path = root / BUILDER.HMLR_VENDOR / "LICENSE.md"
+            licence_path.write_bytes(licence_path.read_bytes() + b"\nAltered terms.\n")
+            relative = licence_path.relative_to(root).as_posix()
+            lock_entry = next(
+                item for item in source_lock["inputs"] if item["path"] == relative
+            )
+            lock_entry["sha256"] = hashlib.sha256(licence_path.read_bytes()).hexdigest()
+
+            BUILDER.verify_source_lock(root, source_lock)
+            with self.assertRaisesRegex(
+                ValueError, "approved v0.3.0 input hash mismatch"
+            ):
+                BUILDER.verify_approved_hmlr_inputs(root)
 
     def test_vendored_input_inventory_is_exact(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Outcome

- Work item: DISC-103
- Release target: v0.1.0 public discovery product
- User-visible outcome: adds reviewed HMLR discovery journeys, Price Paid metadata,
  two ONS capability records and a mixed-rights LandIS capability record to the
  canonical OKF bundle and accessible Explorer.

## Scope

- Included: 36-record deterministic public metadata bundle; immutable HMLR v0.3.0
  source and licence binding; source, rights, date and attribution evidence;
  non-executing Explorer journeys for LR-Q003, LR-Q006, LR-Q012, Price Paid, ONS
  and LandIS.
- Not included: title registers or plans, ownership, addresses, transaction rows,
  real geometry, credentials, live provider calls, authenticated or paid services,
  deployment or release.

## Evidence

- [x] Relevant tests added or updated
- [x] `pnpm run check` passes
- [x] Source, data, rights and licence provenance reviewed
- [x] Security and privacy boundary reviewed
- [x] Accessibility impact tested
- [x] Changelog fragment added
- [x] Deployment boundary and rollback recorded

The final security diff scan covered all six changed runtime and source surfaces.
It dynamically identified one low-severity release-binding gap. The fix now binds
the four published upstream HMLR files to builder-owned v0.3.0 digests and proves
that coordinated source, rights, licence and editable-lock changes fail closed.

## Verification

Local macOS candidate based on protected `main`
`6984f3097cff578f0d22088ca8582ebe55725115`:

- `pnpm run check`: passed;
- 4 gateway tests;
- 16 Explorer build-policy tests;
- 39 Explorer unit and component tests;
- 31 repository Python tests and 2 execution-boundary tests;
- 25 Chrome journeys, including 7 reviewed-example journeys, axe WCAG A/AA,
  keyboard, touch, forced-colour, reduced-motion, clean-console and exact-origin
  checks;
- 8 schemas and 53 evaluation records;
- 286 local links, 183 immutable research hashes, 2 ledger snapshots and 71 source
  identifiers;
- 429 text files scanned without a baseline secret or machine-path match;
- 9 diagrams and a 145-component CycloneDX SBOM.

The fixed-revision 36-record build has content root
`b47c97efdb8efe9b3782244406eba32a8b0b765b0df7aef943b0e6fc1c2a305d`.
The immutable research tree has no diff.

## Deployment and rollback

Deployment target: not deployed. GitHub Pages remains disabled until DISC-104.

Rollback: revert this squash commit. That removes the reviewed overlay and derived
journeys while preserving the earlier immutable research evidence.

Closes #5
