### PR TITLE
feat(publication): add immutable Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   assurance:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,6 +46,39 @@ jobs:
       - name: Run assurance
         run: pnpm run check
 
+      - name: Package immutable Pages source
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && success() }}
+        run: |
+          uv run --locked --cache-dir .uv-cache python scripts/package_pages.py \
+            --dist apps/public-explorer/dist \
+            --output-dir artifacts/pages \
+            --source-commit "$GITHUB_SHA" \
+            --repository "$GITHUB_REPOSITORY" \
+            --version "$(tr -d '\n' < VERSION)" \
+            --base-path /gis-ai-go/
+
+      - name: Verify immutable Pages source
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && success() }}
+        run: |
+          uv run --locked --cache-dir .uv-cache python scripts/verify_pages_archive.py \
+            --archive artifacts/pages/artifact.tar \
+            --checksum artifacts/pages/artifact.tar.sha256 \
+            --receipt artifacts/pages/archive-receipt.json \
+            --expected-source-commit "$GITHUB_SHA" \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-version "$(tr -d '\n' < VERSION)" \
+            --expected-base-path /gis-ai-go/
+
+      - name: Upload immutable Pages source
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && success() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pages-source-${{ github.sha }}
+          path: artifacts/pages/
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
       - name: Upload generated evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -52,5 +86,62 @@ jobs:
           name: assurance-evidence
           path: |
             artifacts/
+            !artifacts/pages/**
             apps/public-explorer/test-results/
           if-no-files-found: warn
+
+  provenance:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: assurance
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out attested source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: 0.12.2
+          enable-cache: true
+
+      - name: Download immutable Pages source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pages-source-${{ github.sha }}
+          path: artifacts/pages
+
+      - name: Verify archive before attestation
+        run: |
+          uv run --locked --cache-dir .uv-cache python scripts/verify_pages_archive.py \
+            --archive artifacts/pages/artifact.tar \
+            --checksum artifacts/pages/artifact.tar.sha256 \
+            --receipt artifacts/pages/archive-receipt.json \
+            --expected-source-commit "$GITHUB_SHA" \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-version "$(tr -d '\n' < VERSION)" \
+            --expected-base-path /gis-ai-go/
+
+      - name: Attest immutable Pages source
+        id: attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: artifacts/pages/artifact.tar
+
+      - name: Record provenance
+        env:
+          ATTESTATION_URL: ${{ steps.attestation.outputs.attestation-url }}
+        run: |
+          {
+            printf '### Immutable Pages source\n\n'
+            printf -- '- Source commit: `%s`\n' "$GITHUB_SHA"
+            printf -- '- Artefact: `pages-source-%s`\n' "$GITHUB_SHA"
+            printf -- '- Attestation: %s\n' "$ATTESTATION_URL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,419 @@
+name: Deploy Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful CI run ID for a protected-main push
+        required: true
+        type: string
+      source_commit:
+        description: Exact 40-character commit SHA produced by the CI run
+        required: true
+        type: string
+      archive_sha256:
+        description: Expected SHA-256 of artifact.tar from the accepted CI run
+        required: true
+        type: string
+      mode:
+        description: Deployment purpose
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - rollback
+          - restore
+      reason:
+        description: Public audit reason; do not include secrets or personal data
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Validate immutable source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      attestations: read
+      contents: read
+    outputs:
+      artifact_digest: ${{ steps.source.outputs.artifact_digest }}
+      artifact_id: ${{ steps.source.outputs.artifact_id }}
+      okf_content_root: ${{ steps.product.outputs.okf_content_root }}
+      payload_root: ${{ steps.product.outputs.payload_root }}
+      public_checksums_sha256: ${{ steps.product.outputs.public_checksums_sha256 }}
+      product_version: ${{ steps.product.outputs.version }}
+    steps:
+      - name: Validate dispatch inputs and CI run
+        id: source
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          GH_TOKEN: ${{ github.token }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/pages.yml@refs/heads/main"
+          if [[ "$GITHUB_REF" != 'refs/heads/main' ]] || \
+             [[ "$GITHUB_WORKFLOW_REF" != "$expected_workflow_ref" ]] || \
+             [[ "$GITHUB_REF_PROTECTED" != 'true' ]]; then
+            echo 'Deployments must run from this workflow on protected main' >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo 'source_run_id must contain digits only' >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'source_commit must be a lower-case, full 40-character commit SHA' >&2
+            exit 1
+          fi
+          if [[ ! "$ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo 'archive_sha256 must be a lower-case, 64-character SHA-256' >&2
+            exit 1
+          fi
+          if [[ ! "$REASON" =~ [^[:space:]] ]] || (( ${#REASON} > 500 )); then
+            echo 'reason must contain 1 to 500 meaningful characters' >&2
+            exit 1
+          fi
+          if [[ "$REASON" =~ [[:cntrl:]] ]]; then
+            echo 'reason must not contain control characters' >&2
+            exit 1
+          fi
+
+          run_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}")"
+          if ! jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_commit "$SOURCE_COMMIT" \
+            '
+              .event == "push" and
+              .status == "completed" and
+              .conclusion == "success" and
+              .head_branch == "main" and
+              .head_sha == $source_commit and
+              .path == ".github/workflows/ci.yml" and
+              .repository.full_name == $repository and
+              .head_repository.full_name == $repository
+            ' <<<"$run_json" >/dev/null; then
+            echo 'The source run is not a successful CI push run for the exact main commit' >&2
+            exit 1
+          fi
+
+          artifact_name="pages-source-${SOURCE_COMMIT}"
+          artifacts_json="$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100")"
+          total_count="$(jq -r '.total_count' <<<"$artifacts_json")"
+          if (( total_count > 100 )); then
+            echo 'The source run has more artefacts than this validator will enumerate' >&2
+            exit 1
+          fi
+          artifact_count="$(jq \
+            --arg artifact_name "$artifact_name" \
+            '[.artifacts[] | select(.name == $artifact_name and .expired == false)] | length' \
+            <<<"$artifacts_json")"
+          if [[ "$artifact_count" != '1' ]]; then
+            echo 'The source run must contain exactly one unexpired, exact-name Pages source artefact' >&2
+            exit 1
+          fi
+
+          artifact_id="$(jq -r \
+            --arg artifact_name "$artifact_name" \
+            '.artifacts[] | select(.name == $artifact_name and .expired == false) | .id' \
+            <<<"$artifacts_json")"
+          artifact_digest="$(jq -r \
+            --arg artifact_name "$artifact_name" \
+            '.artifacts[] | select(.name == $artifact_name and .expired == false) | .digest' \
+            <<<"$artifacts_json")"
+          if [[ ! "$artifact_id" =~ ^[0-9]+$ ]] || \
+             [[ ! "$artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo 'The source artefact has no valid GitHub ID or transport digest' >&2
+            exit 1
+          fi
+
+          {
+            printf 'artifact_id=%s\n' "$artifact_id"
+            printf 'artifact_digest=%s\n' "$artifact_digest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out the exact source commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: 0.12.2
+          enable-cache: true
+
+      - name: Download exact CI artefact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          name: pages-source-${{ inputs.source_commit }}
+          path: artifacts/pages
+          github-token: ${{ github.token }}
+
+      - name: Verify archive structure and receipt
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          uv run --locked --cache-dir .uv-cache python scripts/verify_pages_archive.py \
+            --archive artifacts/pages/artifact.tar \
+            --checksum artifacts/pages/artifact.tar.sha256 \
+            --receipt artifacts/pages/archive-receipt.json \
+            --expected-source-commit "$SOURCE_COMMIT" \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-version "$(tr -d '\n' < VERSION)" \
+            --expected-base-path /gis-ai-go/ \
+            --expected-archive-sha256 "$ARCHIVE_SHA256"
+
+      - name: Verify GitHub build provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          mkdir -p deployment-evidence
+          signer_workflow="${GITHUB_SERVER_URL#https://}/${GITHUB_REPOSITORY}/.github/workflows/ci.yml"
+          gh attestation verify artifacts/pages/artifact.tar \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$signer_workflow" \
+            --signer-digest "$SOURCE_COMMIT" \
+            --source-ref refs/heads/main \
+            --source-digest "$SOURCE_COMMIT" \
+            --deny-self-hosted-runners \
+            --format json > deployment-evidence/attestation-verification.json
+
+      - name: Record accepted product version
+        id: product
+        run: |
+          version="$(tr -d '\r\n' < VERSION)"
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo 'VERSION is not a stable semantic version' >&2
+            exit 1
+          fi
+          okf_content_root="$(jq -r '.okfContentRootSha256' \
+            artifacts/pages/archive-receipt.json)"
+          payload_root="$(jq -r '.payloadRootSha256' \
+            artifacts/pages/archive-receipt.json)"
+          public_checksums_sha256="$(jq -r '.publication.checksumsSha256' \
+            artifacts/pages/archive-receipt.json)"
+          if [[ ! "$okf_content_root" =~ ^[0-9a-f]{64}$ ]]; then
+            echo 'The archive receipt has no valid OKF content root' >&2
+            exit 1
+          fi
+          if [[ ! "$payload_root" =~ ^[0-9a-f]{64}$ ]]; then
+            echo 'The archive receipt has no valid publication payload root' >&2
+            exit 1
+          fi
+          if [[ ! "$public_checksums_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo 'The archive receipt has no valid public checksum-ledger digest' >&2
+            exit 1
+          fi
+          {
+            printf 'version=%s\n' "$version"
+            printf 'okf_content_root=%s\n' "$okf_content_root"
+            printf 'payload_root=%s\n' "$payload_root"
+            printf 'public_checksums_sha256=%s\n' "$public_checksums_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write pre-deployment receipt
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          ARTIFACT_DIGEST: ${{ steps.source.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ steps.source.outputs.artifact_id }}
+          DEPLOYMENT_MODE: ${{ inputs.mode }}
+          OKF_CONTENT_ROOT: ${{ steps.product.outputs.okf_content_root }}
+          PAYLOAD_ROOT: ${{ steps.product.outputs.payload_root }}
+          PUBLIC_CHECKSUMS_SHA256: ${{ steps.product.outputs.public_checksums_sha256 }}
+          PRODUCT_VERSION: ${{ steps.product.outputs.version }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          jq -n \
+            --arg schemaVersion 'gis-ai-go.pages-pre-deployment-receipt.v1' \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sourceRunId "$SOURCE_RUN_ID" \
+            --arg sourceCommit "$SOURCE_COMMIT" \
+            --arg productVersion "$PRODUCT_VERSION" \
+            --arg okfContentRoot "$OKF_CONTENT_ROOT" \
+            --arg payloadRoot "$PAYLOAD_ROOT" \
+            --arg publicChecksumsSha256 "$PUBLIC_CHECKSUMS_SHA256" \
+            --arg archiveSha256 "$ARCHIVE_SHA256" \
+            --arg artifactId "$ARTIFACT_ID" \
+            --arg artifactDigest "$ARTIFACT_DIGEST" \
+            --arg mode "$DEPLOYMENT_MODE" \
+            --arg reason "$REASON" \
+            --arg workflowRun "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --arg validatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            '{
+              schemaVersion: $schemaVersion,
+              repository: $repository,
+              sourceRunId: $sourceRunId,
+              sourceCommit: $sourceCommit,
+              productVersion: $productVersion,
+              okfContentRootSha256: $okfContentRoot,
+              payloadRootSha256: $payloadRoot,
+              publicChecksumsSha256: $publicChecksumsSha256,
+              archiveSha256: $archiveSha256,
+              sourceArtifact: {id: $artifactId, digest: $artifactDigest},
+              mode: $mode,
+              reason: $reason,
+              workflowRun: $workflowRun,
+              validatedAt: $validatedAt
+            }' > deployment-evidence/pre-deployment-receipt.json
+
+      - name: Upload validation evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pages-validation-${{ inputs.source_commit }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            deployment-evidence/
+            artifacts/pages/archive-receipt.json
+            artifacts/pages/artifact.tar.sha256
+          if-no-files-found: error
+          retention-days: 90
+
+  deploy:
+    name: Deploy preserved archive
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      actions: read
+      id-token: write
+      pages: write
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download exact CI artefact again
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          name: pages-source-${{ inputs.source_commit }}
+          path: artifacts/pages
+          github-token: ${{ github.token }}
+
+      - name: Recheck preserved archive digest
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+        run: |
+          actual_sha256="$(sha256sum artifacts/pages/artifact.tar | cut -d ' ' -f 1)"
+          if [[ "$actual_sha256" != "$ARCHIVE_SHA256" ]]; then
+            echo 'The redeployed archive digest differs from the accepted digest' >&2
+            exit 1
+          fi
+          (
+            cd artifacts/pages
+            sha256sum --check --strict artifact.tar.sha256
+          )
+
+      - name: Confirm Pages configuration
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Stage unchanged Pages archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-pages
+          path: artifacts/pages/artifact.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: Deploy unchanged Pages archive
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          artifact_name: github-pages
+
+  public-verification:
+    name: Verify public deployment
+    needs:
+      - prepare
+      - deploy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out deployed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.33.2
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.19.0
+          cache: pnpm
+
+      - name: Install locked test dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run public browser acceptance
+        env:
+          CI: 'true'
+          EXPECTED_ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          EXPECTED_OKF_CONTENT_ROOT: ${{ needs.prepare.outputs.okf_content_root }}
+          EXPECTED_PAYLOAD_ROOT: ${{ needs.prepare.outputs.payload_root }}
+          EXPECTED_PUBLIC_CHECKSUMS_SHA256: ${{ needs.prepare.outputs.public_checksums_sha256 }}
+          EXPECTED_SOURCE_COMMIT: ${{ inputs.source_commit }}
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.product_version }}
+          PUBLIC_BASE_URL: ${{ needs.deploy.outputs.page_url }}
+        run: pnpm --filter @gis-ai-go/public-explorer run test:public
+
+      - name: Upload public verification evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-verification-${{ inputs.source_commit }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: apps/public-explorer/test-results/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Record accepted deployment
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          DEPLOYMENT_MODE: ${{ inputs.mode }}
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+          PRODUCT_VERSION: ${{ needs.prepare.outputs.product_version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          {
+            printf '### Accepted Pages deployment\n\n'
+            printf -- '- URL: %s\n' "$PAGE_URL"
+            printf -- '- Mode: `%s`\n' "$DEPLOYMENT_MODE"
+            printf -- '- Product version: `%s`\n' "$PRODUCT_VERSION"
+            printf -- '- Source commit: `%s`\n' "$SOURCE_COMMIT"
+            printf -- '- Source CI run: `%s`\n' "$SOURCE_RUN_ID"
+            printf -- '- Archive SHA-256: `%s`\n' "$ARCHIVE_SHA256"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -146,10 +146,10 @@ jobs:
             printf 'artifact_digest=%s\n' "$artifact_digest"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Check out the exact source commit
+      - name: Check out the protected-main deployment verifier
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.source_commit }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -356,10 +356,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check out deployed source
+      - name: Check out the protected-main public verifier
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.source_commit }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,9 +34,9 @@ Start every implementation task by reading, in order:
 ## Current implementation state
 
 Stage 0 is complete at commit `983b1a102aa8038c9f50ae1b1894315c3ae0b89f`.
-The canonical OKF build and accessible static Explorer are merged through
-`DISC-101` and `DISC-102`; protected `main` is at
-`6984f3097cff578f0d22088ca8582ebe55725115`. The Explorer is a functional static
+The canonical OKF build, accessible static Explorer and reviewed public examples
+are merged through `DISC-101`, `DISC-102` and `DISC-103`; protected `main` is at
+`e5a522ee17f3a0a6f5857245c5ae3acd767efc25`. The Explorer is a functional static
 candidate in repository and CI, but it is not deployed. There is no MCP listener,
 live provider adapter, policy engine, identity integration or evidence store.
 
@@ -44,8 +44,9 @@ The owner has authorised autonomous implementation in the open under
 [`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The active
 outcome is the `v0.1.0` public discovery product. The repository is public under the
 owner's personal `chris-page-gov` account. Pull-request assurance, security controls
-and branch protection govern development on `main`. The active outcome is DISC-103:
-reviewed, metadata-only public geospatial examples before the DISC-104 Pages gate.
+and branch protection govern development on `main`. The active outcome is
+`DISC-104`: package the validated static product as an immutable artefact, deploy it
+through GitHub Pages, verify it publicly and prove rollback without rebuilding.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,14 +10,15 @@ reproducible GitHub Pages deployment.
 
 ## Active workstream
 
-`DISC-103 — Add reviewed public geospatial examples`
+`DISC-104 — Publish immutable GitHub Pages artefacts`
 
-- add digest-locked HM Land Registry journeys LR-Q003, LR-Q006 and LR-Q012;
-- add non-executing ONS data, ONS geography and LandIS capability records;
-- preserve exact source, release, retrieval, review, rights and access semantics;
-- fail closed on forbidden fields, unresolved evidence or mixed rights presented as
-  open;
-- prove the new journeys through contract, Explorer and real-browser assurance.
+- package only the checked Explorer distribution as a deterministic publication
+  artefact with checksums, provenance, receipt and SBOM;
+- deploy the exact artefact from a successful protected-`main` assurance run;
+- verify the public product, catalogue journeys, CSP, network boundary,
+  accessibility and source identity in a real browser;
+- rehearse rollback to a previous accepted artefact and restore the current one
+  without rebuilding either artefact.
 
 ## Completed
 
@@ -45,37 +46,47 @@ reproducible GitHub Pages deployment.
   graph, timeline, non-legal schematic map, durable URLs and machine-readable
   downloads;
 - full local `pnpm run check` passed on 20 August 2026.
+- `DISC-103` merged through [pull request 10](https://github.com/chris-page-gov/gis-ai-go/pull/10)
+  at `e5a522ee17f3a0a6f5857245c5ae3acd767efc25` with passing assurance and
+  CodeQL;
+- the canonical public bundle now contains 36 records covering reviewed HMLR
+  discovery journeys, HMLR datasets and non-executing ONS and LandIS provider
+  capabilities with exact rights and provenance boundaries.
 
 ## Next
 
-1. Complete and merge the reviewed examples through `DISC-103`.
-2. Publish the immutable static product through `DISC-104` after the final gate.
+1. Publish and verify the immutable static product through `DISC-104`.
+2. Prove artefact-only rollback and restore the current accepted deployment.
 3. Assemble, tag and verify the first supported `v0.1.0` release.
 
 ## Current blockers
 
-- GitHub Pages stays disabled until the hardened Explorer, attribution review and
-  browser/accessibility gates pass.
+- GitHub Pages stays disabled until the immutable publication workflow and
+  protected-main artefact pass their local and remote gates.
 - Protected PSGA and commercial deployments require separate rights, credentials
   and isolated infrastructure; they do not block the open product.
 
 ## Latest evidence
 
-- canonical OKF content and Explorer: merged on protected `main` at `6984f30`;
-- main assurance and CodeQL: passing at `6984f30` on 20 August 2026;
+- canonical OKF content, Explorer and reviewed public examples: merged on protected
+  `main` at `e5a522e`;
+- main assurance and CodeQL: passing at `e5a522e` on 20 August 2026;
 - Explorer assurance includes
-  16 build-policy tests, 36 unit and component tests, 18 browser journeys and
+  16 build-policy tests, 42 unit and component tests, 25 browser journeys and
   production integrity checks;
 - bounded security diff review: all changed runtime, interface and build-assurance
   files covered; the confirmed Low CSP/origin assurance gap, exact HTML-attribute
   parsing, fresh preview-server enforcement, and defensive symlink and lock-strict
   hardening are remediated with passing regressions;
 - DISC-103 source review: exact provider snapshots and HMLR `v0.3.0` inputs are
-  selected; the 36-record local candidate passes the complete repository gate,
-  including 25 browser journeys, and independent review is complete;
+  selected; the merged 36-record product passed the complete repository gate,
+  including 25 browser journeys, and independent review;
 - DISC-103 security review: the selected HMLR inputs and copied licence are
   independently bound to approved v0.3.0 digests, and coordinated source, rights,
   licence and lock mutations now fail closed;
+- DISC-104 local candidate: 17 archive and 10 workflow contract tests, the complete
+  repository gate and 4 public-artefact browser tests pass; protected-main build,
+  attestation, deployment and rollback evidence remain to be produced;
 - public repository: verified with personal `noreply` commit identity;
 - deployed product: none;
 - latest supported release: none.

--- a/apps/public-explorer/README.md
+++ b/apps/public-explorer/README.md
@@ -11,10 +11,11 @@ copied into the static application:
 pnpm run build:explorer
 ```
 
-Generated catalogue files and browser reports are ignored. The eventual GitHub Pages
-workflow publishes only `dist/`, never the repository root or immutable research
-viewer. Deployment remains outside DISC-103 and is controlled by the separate
-DISC-104 publication gate.
+Generated catalogue files and browser reports are ignored. The GitHub Pages
+publication gate packages only the checked `dist/` tree with deterministic
+provenance, receipt, checksums and SBOM. It never publishes the repository root or
+immutable research viewer, and deployment verifies and reuses that exact artefact
+without rebuilding it.
 
 Before Vite runs, the build rejects symlinked or special-file public and distribution
 trees and requires the exact checksum-derived public inventory. The finished
@@ -42,4 +43,18 @@ Run the focused checks with:
 pnpm --filter @gis-ai-go/public-explorer run typecheck
 pnpm --filter @gis-ai-go/public-explorer run test:unit
 pnpm run test:browser
+```
+
+After an accepted Pages deployment, the separate live suite uses explicit expected
+publication identities:
+
+```bash
+PUBLIC_BASE_URL=https://chris-page-gov.github.io/gis-ai-go/ \
+EXPECTED_SOURCE_COMMIT=SOURCE_COMMIT \
+EXPECTED_ARCHIVE_SHA256=ARCHIVE_SHA256 \
+EXPECTED_OKF_CONTENT_ROOT=OKF_CONTENT_ROOT \
+EXPECTED_PAYLOAD_ROOT=PAYLOAD_ROOT \
+EXPECTED_PUBLIC_CHECKSUMS_SHA256=PUBLIC_CHECKSUMS_SHA256 \
+EXPECTED_VERSION=VERSION \
+pnpm --filter @gis-ai-go/public-explorer run test:public
 ```

--- a/apps/public-explorer/package.json
+++ b/apps/public-explorer/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test:build": "node --test test/build/*.test.mjs",
     "test:unit": "pnpm run test:build && vitest run",
-    "test:browser": "playwright test"
+    "test:browser": "playwright test",
+    "test:public": "playwright test --config playwright.public.config.ts"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.13.0",

--- a/apps/public-explorer/playwright.config.ts
+++ b/apps/public-explorer/playwright.config.ts
@@ -5,6 +5,7 @@ const origin = `http://127.0.0.1:${port}`;
 
 export default defineConfig({
   testDir: "./test/browser",
+  testIgnore: "public-deployment.spec.ts",
   outputDir: "./test-results",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),

--- a/apps/public-explorer/playwright.public.config.ts
+++ b/apps/public-explorer/playwright.public.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig } from "@playwright/test";
+
+function requireEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for public deployment assurance`);
+  return value;
+}
+
+const publicBaseUrl = new URL(requireEnvironment("PUBLIC_BASE_URL"));
+if (publicBaseUrl.username || publicBaseUrl.password || publicBaseUrl.search || publicBaseUrl.hash) {
+  throw new Error("PUBLIC_BASE_URL must not contain credentials, a query or a fragment");
+}
+if (!publicBaseUrl.pathname.endsWith("/")) {
+  throw new Error("PUBLIC_BASE_URL must end with a slash");
+}
+const loopback = publicBaseUrl.hostname === "127.0.0.1" || publicBaseUrl.hostname === "localhost";
+if (publicBaseUrl.protocol !== "https:" && !(loopback && publicBaseUrl.protocol === "http:")) {
+  throw new Error("PUBLIC_BASE_URL must use HTTPS except for a loopback validation server");
+}
+
+for (const [name, length] of [
+  ["EXPECTED_SOURCE_COMMIT", 40],
+  ["EXPECTED_ARCHIVE_SHA256", 64],
+  ["EXPECTED_OKF_CONTENT_ROOT", 64],
+  ["EXPECTED_PAYLOAD_ROOT", 64],
+  ["EXPECTED_PUBLIC_CHECKSUMS_SHA256", 64],
+] as const) {
+  if (!new RegExp(`^[0-9a-f]{${length}}$`, "u").test(requireEnvironment(name))) {
+    throw new Error(`${name} must be a lower-case ${length}-character hexadecimal value`);
+  }
+}
+requireEnvironment("EXPECTED_VERSION");
+
+export default defineConfig({
+  testDir: "./test/browser",
+  testMatch: "public-deployment.spec.ts",
+  outputDir: "./test-results/public",
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 1,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 45_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: publicBaseUrl.href,
+    channel: "chrome",
+    locale: "en-GB",
+    timezoneId: "Europe/London",
+    colorScheme: "light",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "off",
+  },
+});

--- a/apps/public-explorer/test/browser/public-deployment.spec.ts
+++ b/apps/public-explorer/test/browser/public-deployment.spec.ts
@@ -1,0 +1,313 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test as base, type Page } from "@playwright/test";
+
+import {
+  encodedPublicationPath,
+  verifyPayloadBytes,
+  verifyPayloadManifest,
+} from "../fixtures/publication";
+
+const PUBLIC_BASE_URL = requireEnvironment("PUBLIC_BASE_URL");
+const EXPECTED_SOURCE_COMMIT = requireHex("EXPECTED_SOURCE_COMMIT", 40);
+const EXPECTED_ARCHIVE_SHA256 = requireHex("EXPECTED_ARCHIVE_SHA256", 64);
+const EXPECTED_OKF_CONTENT_ROOT = requireHex("EXPECTED_OKF_CONTENT_ROOT", 64);
+const EXPECTED_PAYLOAD_ROOT = requireHex("EXPECTED_PAYLOAD_ROOT", 64);
+const EXPECTED_PUBLIC_CHECKSUMS_SHA256 = requireHex("EXPECTED_PUBLIC_CHECKSUMS_SHA256", 64);
+const EXPECTED_VERSION = requireEnvironment("EXPECTED_VERSION");
+const EXPECTED_REPOSITORY = "chris-page-gov/gis-ai-go";
+const REQUIRED_CSP =
+  "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; " +
+  "font-src 'self'; connect-src 'self'; media-src 'none'; object-src 'none'; " +
+  "frame-src 'none'; worker-src 'none'; manifest-src 'self'; base-uri 'none'; " +
+  "form-action 'none'";
+const baseUrl = new URL(PUBLIC_BASE_URL);
+const expectedCanonicalUrl = new URL(
+  process.env.EXPECTED_CANONICAL_URL?.trim() || PUBLIC_BASE_URL,
+).href;
+
+function requireEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for public deployment assurance`);
+  return value;
+}
+
+function requireHex(name: string, length: number): string {
+  const value = requireEnvironment(name);
+  if (!new RegExp(`^[0-9a-f]{${length}}$`, "u").test(value)) {
+    throw new Error(`${name} must be a lower-case ${length}-character hexadecimal value`);
+  }
+  return value;
+}
+
+function publicUrl(relative = ""): string {
+  return new URL(relative, baseUrl).href;
+}
+
+function isPublicationRequest(requestUrl: string): boolean {
+  const candidate = new URL(requestUrl);
+  return candidate.origin === baseUrl.origin && candidate.pathname.startsWith(baseUrl.pathname);
+}
+
+function asObject(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectIdentity(
+  value: unknown,
+  schema: string,
+  label: string,
+): Record<string, unknown> {
+  const document = asObject(value, label);
+  expect(document.schema).toBe(schema);
+  expect(document.repository).toBe(EXPECTED_REPOSITORY);
+  expect(document.sourceCommit).toBe(EXPECTED_SOURCE_COMMIT);
+  expect(document.version).toBe(EXPECTED_VERSION);
+  expect(document.basePath).toBe(baseUrl.pathname);
+  expect(document.canonicalUrl).toBe(expectedCanonicalUrl);
+  expect(document.okfContentRootSha256).toBe(EXPECTED_OKF_CONTENT_ROOT);
+  return document;
+}
+
+type PublicAssurance = { publicAssurance: void };
+const test = base.extend<PublicAssurance>({
+  publicAssurance: [
+    async ({ page }, use, testInfo) => {
+      const failures: string[] = [];
+      const unexpectedRequests: string[] = [];
+      page.on("console", (message) => {
+        if (message.type() === "error") failures.push(`console: ${message.text()}`);
+      });
+      page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
+      page.on("requestfailed", (request) => {
+        failures.push(`requestfailed: ${request.method()} ${request.url()}`);
+      });
+      page.on("response", (response) => {
+        if (response.status() >= 400) failures.push(`response ${response.status()}: ${response.url()}`);
+      });
+      page.on("request", (request) => {
+        if (!isPublicationRequest(request.url())) {
+          unexpectedRequests.push(`${request.method()} ${request.url()}`);
+        }
+      });
+      await use();
+      if (failures.length || unexpectedRequests.length) {
+        await testInfo.attach("public-deployment-errors", {
+          body: [...failures, ...unexpectedRequests.map((item) => `unexpected: ${item}`)].join("\n"),
+          contentType: "text/plain",
+        });
+      }
+      expect(unexpectedRequests, "the public Explorer must request only its publication path").toEqual([]);
+      expect(failures, "the public Explorer console and request lifecycle must stay clean").toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+test.beforeAll(async ({ request }) => {
+  test.setTimeout(120_000);
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(
+          publicUrl(`publication/site-receipt.json?source=${EXPECTED_SOURCE_COMMIT}`),
+          { headers: { "cache-control": "no-cache" } },
+        );
+        if (!response.ok()) return { status: response.status() };
+        const receipt = asObject(await response.json(), "site receipt");
+        return {
+          status: response.status(),
+          sourceCommit: receipt.sourceCommit,
+          version: receipt.version,
+          okfContentRootSha256: receipt.okfContentRootSha256,
+          payloadRootSha256: receipt.payloadRootSha256,
+        };
+      },
+      { message: "wait for the exact deployed publication", timeout: 110_000 },
+    )
+    .toEqual({
+      status: 200,
+      sourceCommit: EXPECTED_SOURCE_COMMIT,
+      version: EXPECTED_VERSION,
+      okfContentRootSha256: EXPECTED_OKF_CONTENT_ROOT,
+      payloadRootSha256: EXPECTED_PAYLOAD_ROOT,
+    });
+});
+
+test("publishes the exact identity, policy and checksum-bound files", async ({ page, request }) => {
+  const response = await page.goto(publicUrl(`?publication=${EXPECTED_SOURCE_COMMIT}`), {
+    waitUntil: "networkidle",
+  });
+  expect(response?.status()).toBe(200);
+  await expect(page).toHaveTitle("Catalogue – GIS AI GO");
+
+  const csp = await page.locator('meta[http-equiv="Content-Security-Policy"]').getAttribute("content");
+  expect(csp).toBe(REQUIRED_CSP);
+
+  const publication = await page.evaluate(async () => {
+    const readJson = async (path: string): Promise<unknown> => {
+      const response = await fetch(path, { cache: "no-store" });
+      if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+      return response.json();
+    };
+    return Promise.all([
+      readJson("./publication/site-receipt.json"),
+      readJson("./publication/provenance.json"),
+      readJson("./publication/manifest.json"),
+    ]);
+  });
+
+  const receipt = expectIdentity(publication[0], "gis-ai-go.pages-site-receipt.v1", "site receipt");
+  const provenance = asObject(publication[1], "provenance");
+  expect(provenance.schema).toBe("gis-ai-go.pages-provenance.v1");
+  expect(provenance.repository).toBe(EXPECTED_REPOSITORY);
+  expect(provenance.sourceCommit).toBe(EXPECTED_SOURCE_COMMIT);
+  expect(provenance.version).toBe(EXPECTED_VERSION);
+  expect(provenance.basePath).toBe(baseUrl.pathname);
+  expect(provenance.canonicalUrl).toBe(expectedCanonicalUrl);
+  expect(asObject(provenance.okf, "provenance.okf").contentRootSha256).toBe(
+    EXPECTED_OKF_CONTENT_ROOT,
+  );
+  const manifest = expectIdentity(publication[2], "gis-ai-go.pages-manifest.v1", "manifest");
+  const manifestPayload = asObject(manifest.payload, "manifest.payload");
+  expect(receipt.payloadRootSha256).toBe(EXPECTED_PAYLOAD_ROOT);
+  expect(manifestPayload.rootSha256).toBe(EXPECTED_PAYLOAD_ROOT);
+  const payloadEntries = verifyPayloadManifest(manifestPayload, EXPECTED_PAYLOAD_ROOT);
+  for (const entry of payloadEntries) {
+    if (entry.path === ".nojekyll") {
+      verifyPayloadBytes(entry, new Uint8Array());
+      continue;
+    }
+    const payloadResponse = await request.get(publicUrl(encodedPublicationPath(entry.path)), {
+      headers: { "cache-control": "no-cache" },
+    });
+    expect(payloadResponse.ok(), `${entry.path} must be publicly fetchable`).toBe(true);
+    verifyPayloadBytes(entry, new Uint8Array(await payloadResponse.body()));
+  }
+
+  const checksumReport = await page.evaluate(async () => {
+    const ledgerResponse = await fetch("./publication/CHECKSUMS.sha256", { cache: "no-store" });
+    if (!ledgerResponse.ok) throw new Error(`checksum ledger returned ${ledgerResponse.status}`);
+    const ledgerBytes = await ledgerResponse.arrayBuffer();
+    const ledgerSha256 = [...new Uint8Array(await crypto.subtle.digest("SHA-256", ledgerBytes))]
+      .map((value) => value.toString(16).padStart(2, "0"))
+      .join("");
+    const rows = new TextDecoder().decode(ledgerBytes).trimEnd().split("\n");
+    const failures: string[] = [];
+    let entries = 0;
+    for (const row of rows) {
+      const match = /^([0-9a-f]{64}) {2}([^\\\0]+)$/u.exec(row);
+      if (!match?.[1] || !match[2] || match[2].startsWith("/") || match[2].split("/").includes("..")) {
+        failures.push(`invalid row: ${row}`);
+        continue;
+      }
+      const fileResponse = await fetch(`./${match[2]}`, { cache: "no-store" });
+      if (!fileResponse.ok) {
+        failures.push(`${match[2]} returned ${fileResponse.status}`);
+        continue;
+      }
+      const digest = [...new Uint8Array(await crypto.subtle.digest("SHA-256", await fileResponse.arrayBuffer()))]
+        .map((value) => value.toString(16).padStart(2, "0"))
+        .join("");
+      if (digest !== match[1]) failures.push(`${match[2]} checksum mismatch`);
+      entries += 1;
+    }
+    return { entries, failures, ledgerSha256 };
+  });
+  expect(checksumReport.entries).toBeGreaterThan(0);
+  expect(checksumReport.failures).toEqual([]);
+  expect(checksumReport.ledgerSha256).toBe(EXPECTED_PUBLIC_CHECKSUMS_SHA256);
+  expect(EXPECTED_ARCHIVE_SHA256).toMatch(/^[0-9a-f]{64}$/u);
+});
+
+async function search(page: Page, query: string): Promise<void> {
+  await page.goto(publicUrl("?view=cards"));
+  const box = page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i });
+  await box.fill(query);
+  await page.getByRole("button", { name: /^Search$/i }).click();
+}
+
+test("answers the legal-boundary question and exposes reviewed examples", async ({ page }) => {
+  await page.goto(publicUrl());
+  await expect(
+    page.getByRole("heading", { level: 1, name: "INSPIRE polygon: indicative or legal boundary?" }),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText(
+        "Polygons are indicative and do not establish the exact legal extent of a title.",
+        { exact: true },
+      )
+      .first(),
+  ).toBeVisible();
+
+  for (const [query, recordId, marker] of [
+    ["Price Paid", "hmlr:dataset:price-paid-data", "Price Paid Data"],
+    ["PV-ONS-DATA", "PV-ONS-DATA", "ONS Data API"],
+    ["PV-ONS-GEO", "PV-ONS-GEO", "ONS Geography and Open Geography Portal"],
+    ["PV-LANDIS", "PV-LANDIS", "LandIS"],
+  ] as const) {
+    await search(page, query);
+    const link = page.locator(
+      `article.record-card a[href*="#record=${encodeURIComponent(recordId)}"]`,
+    );
+    await expect(link).toHaveCount(1);
+    await expect(link).toContainText(marker);
+  }
+});
+
+test("preserves direct state, browser history and projection parity", async ({ page }) => {
+  const recordId = "hmlr:dataset:price-paid-data";
+  await page.goto(
+    publicUrl(`?view=cards&q=Price%20Paid&type=dataset#record=${encodeURIComponent(recordId)}`),
+  );
+  await expect(page.getByRole("heading", { level: 2, name: "Price Paid Data" })).toBeVisible();
+  await page.getByRole("link", { name: "Back to catalogue", exact: true }).click();
+  await expect(page.getByRole("link", { name: "Price Paid Data", exact: true })).toBeVisible();
+  await page.goBack();
+  await expect(page.getByRole("heading", { level: 2, name: "Price Paid Data" })).toBeVisible();
+  await page.goForward();
+  await expect(page.getByRole("link", { name: "Price Paid Data", exact: true })).toBeVisible();
+
+  const identifiers = await page.evaluate(async () => {
+    const [jsonResponse, jsonLdResponse] = await Promise.all([
+      fetch("./catalogue/okf-bundle.json"),
+      fetch("./catalogue/okf-bundle.jsonld"),
+    ]);
+    if (!jsonResponse.ok || !jsonLdResponse.ok) {
+      throw new Error(`projection response ${jsonResponse.status}/${jsonLdResponse.status}`);
+    }
+    const json = (await jsonResponse.json()) as { records: Array<{ id: string }> };
+    const jsonLd = (await jsonLdResponse.json()) as { "@graph": Array<{ identifier: string }> };
+    return {
+      json: json.records.map((record) => record.id).sort(),
+      jsonLd: jsonLd["@graph"].map((record) => record.identifier).sort(),
+    };
+  });
+  expect(identifiers.json.length).toBe(36);
+  expect(identifiers.jsonLd).toEqual(identifiers.json);
+});
+
+test("passes public keyboard, WCAG and 320-pixel reflow acceptance", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.goto(publicUrl("?view=cards"));
+  await page.keyboard.press("Tab");
+  const skipLink = page.getByRole("link", { name: "Skip to main content" });
+  await expect(skipLink).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#main-content")).toBeFocused();
+
+  const violations = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+    .analyze();
+  expect(violations.violations, JSON.stringify(violations.violations, null, 2)).toEqual([]);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    ),
+  ).toBeLessThanOrEqual(1);
+});
+
+export { expect, test };

--- a/apps/public-explorer/test/fixtures/publication.ts
+++ b/apps/public-explorer/test/fixtures/publication.ts
@@ -1,0 +1,103 @@
+import { createHash } from "node:crypto";
+
+export type PublicationPayloadEntry = {
+  path: string;
+  bytes: number;
+  sha256: string;
+};
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const ENTRY_KEYS = ["bytes", "path", "sha256"];
+const PAYLOAD_KEYS = ["fileCount", "files", "rootSha256"];
+
+function sha256(value: Uint8Array | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  if (actual.join("\n") !== expected.join("\n")) {
+    throw new Error(`${label} has unexpected fields`);
+  }
+}
+
+function safePath(value: unknown): string {
+  if (typeof value !== "string" || !value || value.startsWith("/") || value.includes("\\")) {
+    throw new Error("publication payload path is unsafe");
+  }
+  const parts = value.split("/");
+  if (parts.some((part) => !part || part === "." || part === ".." || part.includes("\0"))) {
+    throw new Error("publication payload path is unsafe");
+  }
+  return value;
+}
+
+function utf8Compare(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+export function encodedPublicationPath(path: string): string {
+  return path.split("/").map((part) => encodeURIComponent(part)).join("/");
+}
+
+export function verifyPayloadManifest(
+  value: unknown,
+  expectedRootSha256: string,
+): PublicationPayloadEntry[] {
+  if (!SHA256.test(expectedRootSha256)) throw new Error("expected payload root is invalid");
+  const payload = object(value, "manifest payload");
+  exactKeys(payload, PAYLOAD_KEYS, "manifest payload");
+  if (!Array.isArray(payload.files) || payload.files.length === 0) {
+    throw new Error("manifest payload files must be a non-empty array");
+  }
+
+  const entries = payload.files.map((raw, index) => {
+    const entry = object(raw, `manifest payload file ${index}`);
+    exactKeys(entry, ENTRY_KEYS, `manifest payload file ${index}`);
+    const path = safePath(entry.path);
+    if (!Number.isSafeInteger(entry.bytes) || Number(entry.bytes) < 0) {
+      throw new Error(`manifest payload byte count is invalid: ${path}`);
+    }
+    if (typeof entry.sha256 !== "string" || !SHA256.test(entry.sha256)) {
+      throw new Error(`manifest payload digest is invalid: ${path}`);
+    }
+    return { path, bytes: Number(entry.bytes), sha256: entry.sha256 };
+  });
+
+  const sorted = [...entries].sort((left, right) => utf8Compare(left.path, right.path));
+  if (entries.map((entry) => entry.path).join("\n") !== sorted.map((entry) => entry.path).join("\n")) {
+    throw new Error("manifest payload paths must use canonical UTF-8 order");
+  }
+  if (new Set(entries.map((entry) => entry.path)).size !== entries.length) {
+    throw new Error("manifest payload paths must be unique");
+  }
+  if (payload.fileCount !== entries.length) {
+    throw new Error("manifest payload file count does not match its inventory");
+  }
+
+  const noJekyll = entries.find((entry) => entry.path === ".nojekyll");
+  if (!noJekyll || noJekyll.bytes !== 0 || noJekyll.sha256 !== sha256(new Uint8Array())) {
+    throw new Error("manifest payload must bind the empty .nojekyll control file");
+  }
+  const ledger = entries
+    .map((entry) => `${entry.sha256}  ${entry.path}\n`)
+    .join("");
+  const actualRoot = sha256(ledger);
+  if (payload.rootSha256 !== expectedRootSha256 || actualRoot !== expectedRootSha256) {
+    throw new Error("manifest payload inventory does not reproduce the accepted payload root");
+  }
+  return entries;
+}
+
+export function verifyPayloadBytes(entry: PublicationPayloadEntry, value: Uint8Array): void {
+  if (value.byteLength !== entry.bytes || sha256(value) !== entry.sha256) {
+    throw new Error(`public payload differs from the accepted manifest: ${entry.path}`);
+  }
+}

--- a/apps/public-explorer/test/unit/publication.test.ts
+++ b/apps/public-explorer/test/unit/publication.test.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { verifyPayloadBytes, verifyPayloadManifest } from "../fixtures/publication";
+
+function digest(value: Uint8Array | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fixture(): { payload: Record<string, unknown>; script: Uint8Array } {
+  const script = new TextEncoder().encode("console.log('accepted');\n");
+  const files = [
+    { path: ".nojekyll", bytes: 0, sha256: digest(new Uint8Array()) },
+    { path: "assets/app.js", bytes: script.byteLength, sha256: digest(script) },
+  ];
+  const ledger = files.map((entry) => `${entry.sha256}  ${entry.path}\n`).join("");
+  return {
+    payload: { fileCount: files.length, files, rootSha256: digest(ledger) },
+    script,
+  };
+}
+
+describe("public payload verification", () => {
+  it("accepts the exact checksum-rooted manifest and payload bytes", () => {
+    const { payload, script } = fixture();
+    const entries = verifyPayloadManifest(payload, String(payload.rootSha256));
+    verifyPayloadBytes(entries[0]!, new Uint8Array());
+    verifyPayloadBytes(entries[1]!, script);
+  });
+
+  it("rejects changed public bytes even when the accepted manifest is unchanged", () => {
+    const { payload } = fixture();
+    const entries = verifyPayloadManifest(payload, String(payload.rootSha256));
+    const altered = new TextEncoder().encode("console.log('altered');\n");
+    expect(() => verifyPayloadBytes(entries[1]!, altered)).toThrow(/differs from the accepted manifest/u);
+  });
+
+  it("rejects a rewritten manifest inventory that retains the accepted root", () => {
+    const { payload } = fixture();
+    const altered = structuredClone(payload);
+    const files = altered.files as Array<Record<string, unknown>>;
+    files[1]!.sha256 = digest("altered");
+    expect(() => verifyPayloadManifest(altered, String(payload.rootSha256))).toThrow(
+      /does not reproduce the accepted payload root/u,
+    );
+  });
+});

--- a/changelog.d/DISC-104.added.md
+++ b/changelog.d/DISC-104.added.md
@@ -1,0 +1,2 @@
+- Added checksum-bound, provenance-attested GitHub Pages publication with
+  least-privilege deployment, live browser assurance and artefact-only rollback.

--- a/docs/decisions/ADR-0007-immutable-pages-publication.md
+++ b/docs/decisions/ADR-0007-immutable-pages-publication.md
@@ -43,6 +43,12 @@ previously accepted source CI run and digest. A restore selects the later accept
 artefact. Neither action rebuilds source. Deployment reasons and selected identities
 remain in the workflow record.
 
+All executable deployment and public-verification code is checked out from the
+current protected `main` workflow commit. The selected source commit is handled only
+as an attested archive identity and never as executable workflow input. A retained
+archive that is no longer compatible with the protected-main verifier must stop for
+a reviewed compatibility change; the workflow must not execute its older source.
+
 The deployed application continues to use its exact meta Content Security Policy.
 GitHub Pages does not provide repository-controlled response headers, so this
 decision does not claim `frame-ancestors` or other header-only controls.

--- a/docs/decisions/ADR-0007-immutable-pages-publication.md
+++ b/docs/decisions/ADR-0007-immutable-pages-publication.md
@@ -1,0 +1,63 @@
+# ADR-0007: Immutable GitHub Pages publication
+
+- status: accepted
+- decided on: 20 August 2026
+- work item: DISC-104
+
+## Context
+
+The public Explorer is a static product whose source, catalogue, rights and browser
+behaviour already pass repository assurance. Building it again during deployment
+would create a second, weaker path between reviewed source and the public site.
+Automatic deployment after every push would also make rollback depend on rebuilding
+old source rather than retaining an accepted artefact.
+
+GitHub Pages needs a tar archive delivered by a workflow with `pages: write` and
+`id-token: write`. The repository's ordinary CI token is read-only and `main` is
+protected by a no-bypass pull-request ruleset.
+
+## Decision
+
+Build the deployable Pages archive once, at the end of the complete assurance job
+for a successful push to protected `main`. The deterministic archive contains only
+the checked Explorer distribution, `.nojekyll` and publication metadata. It records
+the source commit, product version, `/gis-ai-go/` base path, canonical URL, OKF
+content root, complete file manifest, checksums, provenance, site receipt and
+CycloneDX SBOM. Tar paths, ownership, modes and modification times are normalised;
+wall-clock time is excluded.
+
+Attest the exact tar archive in a separate successful-main job. Retain the tar,
+checksum and outer receipt together as `pages-source-<source-commit>`. Deployment is
+a manually dispatched workflow on `main` that must:
+
+1. identify a successful `push` CI run for `main` and the exact source commit;
+2. download the named retained artefact rather than check out and rebuild the site;
+3. verify its declared SHA-256 digest, deterministic receipt and GitHub build
+   provenance;
+4. upload that unchanged tar as the current `github-pages` artefact;
+5. deploy through the branch-restricted `github-pages` environment; and
+6. run the public-browser suite against the returned Pages URL.
+
+Use the same workflow for `deploy`, `rollback` and `restore`. A rollback selects a
+previously accepted source CI run and digest. A restore selects the later accepted
+artefact. Neither action rebuilds source. Deployment reasons and selected identities
+remain in the workflow record.
+
+The deployed application continues to use its exact meta Content Security Policy.
+GitHub Pages does not provide repository-controlled response headers, so this
+decision does not claim `frame-ancestors` or other header-only controls.
+
+## Consequences
+
+- ordinary pull requests cannot publish a site;
+- CI and deployment permissions remain separate and least privilege;
+- the public URL can be traced to one source commit, content root, archive digest,
+  attestation and deployment run;
+- rollback is evidence that retained bytes can be redeployed, not merely that old
+  source still compiles;
+- GitHub Actions artefact retention is not permanent, so supported release archives,
+  checksums and receipts must also be attached to the corresponding GitHub release;
+  accepting a release asset for deployment requires a separately reviewed ingestion
+  path and is not authorised by this workflow;
+- a change to archive format or publication identity requires a new ADR version or
+  superseding decision and new rollback evidence.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,6 +10,7 @@ research recommendations remain unchanged in the preserved pack at
 - [ADR-0004: Public autonomous delivery](ADR-0004-public-autonomous-delivery.md)
 - [ADR-0005: Static public Explorer](ADR-0005-static-public-explorer.md)
 - [ADR-0006: Reviewed public geospatial examples](ADR-0006-reviewed-public-geospatial-examples.md)
+- [ADR-0007: Immutable GitHub Pages publication](ADR-0007-immutable-pages-publication.md)
 
 Research decisions D01–D19 are accepted as constraints for building and evaluating
 Stage 0, not as blanket authority for later production stages. Research decision D20

--- a/docs/operations/DISC-103_VERIFICATION.md
+++ b/docs/operations/DISC-103_VERIFICATION.md
@@ -1,6 +1,6 @@
 # DISC-103 verification record
 
-- status: implementation candidate
+- status: verified on protected main
 - reviewed on: 20 August 2026
 - work item: DISC-103
 - publication: none; GitHub Pages remains disabled
@@ -69,8 +69,16 @@ The release content root is intentionally not claimed here: the build receipt bi
 the Git revision, so DISC-104 and the release gate must record the exact merged
 revision and its corresponding artefact root.
 
-The pull-request head, remote assurance and CodeQL evidence must be added before
-merge. This candidate has not been deployed or released.
+The implementation merged through
+[pull request 10](https://github.com/chris-page-gov/gis-ai-go/pull/10) at
+`e5a522ee17f3a0a6f5857245c5ae3acd767efc25`. The pull-request
+[assurance run](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32316389446)
+and [CodeQL run](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32316387958)
+passed, followed by the protected-main
+[assurance run](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32316482090).
+The merged revision reproducibly builds OKF content root
+`c3fdadf975194580d1f659e7f3f3b609099b720129b9d8149801115f659c4040`.
+This product has not yet been deployed or released.
 
 ## Rollback
 

--- a/docs/operations/DISC-104_RUNBOOK.md
+++ b/docs/operations/DISC-104_RUNBOOK.md
@@ -1,0 +1,128 @@
+# DISC-104 GitHub Pages runbook
+
+This runbook publishes or restores an already built GIS AI GO Pages artefact. It
+must never build the Explorer during deployment.
+
+## Publication identities
+
+Record all of these before dispatch:
+
+- the successful `CI` push run ID for protected `main`;
+- its full 40-character source commit;
+- artefact name `pages-source-<source-commit>`;
+- SHA-256 of `artifact.tar` from `artifact.tar.sha256`;
+- product version, publication payload root, public checksum-ledger digest and OKF
+  content root from `archive-receipt.json`;
+- the successful GitHub provenance attestation for that tar.
+
+The retained artefact contains exactly:
+
+```text
+artifact.tar
+artifact.tar.sha256
+archive-receipt.json
+```
+
+The tar contains only the generated site plus `.nojekyll` and the
+`publication/` manifest, checksums, provenance, site receipt and SBOM.
+
+## First-time repository configuration
+
+The repository owner performs this once after the publication workflow has merged
+and a successful protected-`main` source artefact exists:
+
+1. set the Pages build type to GitHub Actions and enforce HTTPS;
+2. leave the custom domain unset;
+3. configure the `github-pages` environment to accept only the exact `main` branch;
+4. retain the existing no-bypass `main` ruleset and required `assurance` check;
+5. require complete commit-SHA pins for Actions; and
+6. confirm workflow token permissions remain read-only by default.
+
+Record the API responses in the verification record. Do not enable branch-folder
+publication, publish `docs/`, or upload the repository root.
+
+## Inspect and verify a source artefact
+
+Replace the examples with the exact run and commit being considered:
+
+```bash
+gh run view SOURCE_RUN_ID --repo chris-page-gov/gis-ai-go
+gh run download SOURCE_RUN_ID \
+  --repo chris-page-gov/gis-ai-go \
+  --name pages-source-SOURCE_COMMIT \
+  --dir /tmp/gis-ai-go-pages-source
+shasum -a 256 /tmp/gis-ai-go-pages-source/artifact.tar
+gh attestation verify /tmp/gis-ai-go-pages-source/artifact.tar \
+  --repo chris-page-gov/gis-ai-go
+```
+
+The digest must equal both `artifact.tar.sha256` and
+`archive-receipt.json.archive.sha256`. The receipt source commit must equal the CI
+run head. Stop on any mismatch.
+
+## Deploy
+
+Dispatch only the workflow stored on protected `main`:
+
+```bash
+gh workflow run pages.yml \
+  --repo chris-page-gov/gis-ai-go \
+  --ref main \
+  -f source_run_id=SOURCE_RUN_ID \
+  -f source_commit=SOURCE_COMMIT \
+  -f archive_sha256=ARCHIVE_SHA256 \
+  -f mode=deploy \
+  -f reason='Initial v0.1.0 public discovery deployment'
+```
+
+The workflow validates the source run, archive and attestation before the
+`github-pages` environment is entered. It then deploys the unchanged tar and runs
+the public Playwright suite against the URL returned by GitHub Pages. A failed
+public check is a failed deployment gate even if Pages accepted the bytes.
+
+Record the workflow run, deployment ID, public URL, source run and commit, archive
+digest, attestation URL, version, OKF root and public-test result.
+
+## Roll back and restore
+
+Rollback requires two previously accepted artefacts, A and B. B is the current
+site; A is its accepted predecessor.
+
+1. Reverify A's source run, digest, outer receipt and GitHub attestation.
+2. Dispatch the same workflow with A's identities, `mode=rollback` and a clear
+   reason.
+3. Confirm the public receipt now identifies A and the complete public suite passes.
+4. Reverify B without rebuilding it.
+5. Dispatch B with `mode=restore` and a clear reason.
+6. Confirm the public receipt identifies B and the complete public suite passes.
+
+Example mode-specific fields are:
+
+```text
+-f mode=rollback -f reason='DISC-104 rollback rehearsal to accepted artefact A'
+-f mode=restore  -f reason='DISC-104 restore rehearsal to accepted artefact B'
+```
+
+Never substitute a local rebuild, a workflow artefact from a pull request, a failed
+run or a mutable branch archive. The current workflow accepts only an unexpired
+Actions source artefact. A release asset preserves evidence but is not an accepted
+deployment input; if the Actions artefact has expired, stop until a separately
+reviewed release-asset ingestion path exists.
+
+## Public acceptance
+
+The workflow's public suite must verify:
+
+- receipt, provenance, source commit, version, publication payload root, trusted
+  public checksum-ledger digest and OKF content root;
+- every trusted-ledger checksum, every accepted-manifest payload byte and
+  JSON/JSON-LD identifier parity;
+- the default HMLR legal-boundary caveat and the Price Paid, ONS and LandIS
+  discovery journeys;
+- direct query/fragment routes and browser history;
+- the exact Content Security Policy, clean console and publication-path-only
+  network traffic; and
+- keyboard skip navigation, WCAG A/AA checks and 320 CSS-pixel reflow.
+
+Do not mark DISC-104 complete until deploy, rollback and restore each have a public
+receipt and passing public-browser evidence.

--- a/docs/operations/DISC-104_RUNBOOK.md
+++ b/docs/operations/DISC-104_RUNBOOK.md
@@ -3,6 +3,9 @@
 This runbook publishes or restores an already built GIS AI GO Pages artefact. It
 must never build the Explorer during deployment.
 
+The workflow runs verifier and browser-test code only from its current
+protected-`main` commit. It treats the selected source commit and archive as data.
+
 ## Publication identities
 
 Record all of these before dispatch:
@@ -108,6 +111,9 @@ run or a mutable branch archive. The current workflow accepts only an unexpired
 Actions source artefact. A release asset preserves evidence but is not an accepted
 deployment input; if the Actions artefact has expired, stop until a separately
 reviewed release-asset ingestion path exists.
+
+Also stop if an older retained archive is incompatible with the current
+protected-main verifier. Do not execute verifier code from the selected old commit.
 
 ## Public acceptance
 

--- a/docs/operations/DISC-104_VERIFICATION.md
+++ b/docs/operations/DISC-104_VERIFICATION.md
@@ -1,0 +1,101 @@
+# DISC-104 GitHub Pages verification record
+
+- status: implementation candidate
+- reviewed on: 20 August 2026
+- work item: DISC-104
+- public URL: not deployed
+
+## Outcome
+
+DISC-104 packages the checked Explorer distribution once and separates build,
+attestation and deployment. The deployment workflow can publish, roll back or
+restore only a successful protected-`main` artefact whose source run, commit,
+SHA-256 digest, deterministic receipt and GitHub provenance all agree.
+
+No workflow publishes the repository root, immutable research viewer, source tree,
+provider payload, credential or protected data. Deployment performs no build.
+
+## Candidate gates
+
+Before merge, record:
+
+- deterministic archive tests, including repeated byte-for-byte output;
+- malicious path, symlink, hard-link, special-file, inventory and checksum
+  rejection;
+- workflow event, source-run, branch, commit, artefact-name, digest, attestation and
+  least-privilege contract tests;
+- complete repository assurance and CodeQL at the pull-request head; and
+- independent review of the archive, workflow and public-browser boundaries.
+
+The complete local candidate gate passed on 20 August 2026 against the uncommitted
+DISC-104 candidate based on protected `main` at
+`e5a522ee17f3a0a6f5857245c5ae3acd767efc25`:
+
+- 17 deterministic archive and hostile-input contract tests;
+- 10 workflow event, identity, provenance, permission and no-build deployment
+  contract tests;
+- 4 gateway tests, 16 Explorer build-policy tests, 42 Explorer unit and component
+  tests, 58 repository Python tests and 2 execution-boundary tests;
+- 25 existing local real-browser journeys;
+- 8 schemas and 53 evaluation records, 289 local links, 183 immutable research
+  hashes, 2 source-ledger snapshots and 71 source identifiers;
+- 442 text files scanned without a baseline secret or machine-path match;
+- 9 rendered diagrams and a 145-component repository CycloneDX SBOM.
+
+The candidate packager and verifier reproduced uncompressed canonical POSIX ustar
+archive SHA-256
+`aca0decf3637e836e0818619456deec75601b0a99475ca6d71b17a23c8fc0f31`
+and payload root
+`9b0f95f52bc77f45924a767cf774f70e9806b5b10b0ccbe0e460701e3e05ee55`
+from merged source commit `e5a522e` and OKF content root
+`c3fdadf975194580d1f659e7f3f3b609099b720129b9d8149801115f659c4040`.
+This is a local rehearsal identity, not the future protected-main publication
+artefact. The archive was extracted under the `/gis-ai-go/` mount and the separate
+public suite passed all 4 identity, accepted-manifest payload, trusted-ledger checksum,
+reviewed-journey, history, network, CSP, accessibility and 320 CSS-pixel tests.
+
+All nine external Action pins were independently resolved against their official
+GitHub tag refs; the annotated pnpm tag was dereferenced to its exact commit.
+
+## Protected-main source evidence
+
+Complete after the implementation pull request merges:
+
+- source commit: pending;
+- successful CI push run and `assurance` job: pending;
+- source artefact name and ID: pending;
+- `artifact.tar` SHA-256 and outer receipt: pending;
+- GitHub build-provenance attestation: pending;
+- product version and OKF content root: pending.
+
+## Repository configuration evidence
+
+Complete before first deployment:
+
+- Pages build type `workflow`, HTTPS enforced and no custom domain: pending;
+- `github-pages` environment restricted to exact branch `main`: pending;
+- complete-SHA Action pin enforcement: pending;
+- existing protected-main ruleset and read-only default workflow token reverified:
+  pending.
+
+## Deployment and public evidence
+
+Complete after first deployment:
+
+- deployment workflow run, Pages deployment ID and public URL: pending;
+- live receipt identity equals selected source artefact: pending;
+- checksum and JSON/JSON-LD parity: pending;
+- default, Price Paid, ONS, LandIS, direct-route and history journeys: pending;
+- exact CSP, clean console and publication-path-only requests: pending;
+- keyboard, axe A/AA and 320 CSS-pixel acceptance: pending.
+
+## Rollback rehearsal
+
+Complete with two accepted protected-main artefacts:
+
+- artefact A identities and original deployment: pending;
+- artefact B identities and original deployment: pending;
+- rollback run redeploying A without a build and its public evidence: pending;
+- restore run redeploying B without a build and its public evidence: pending.
+
+DISC-104 remains incomplete while any item in this record is pending.

--- a/docs/operations/DISC-104_VERIFICATION.md
+++ b/docs/operations/DISC-104_VERIFICATION.md
@@ -15,6 +15,10 @@ SHA-256 digest, deterministic receipt and GitHub provenance all agree.
 No workflow publishes the repository root, immutable research viewer, source tree,
 provider payload, credential or protected data. Deployment performs no build.
 
+Deployment-time verifier and browser-test code always comes from the current
+protected-main workflow commit. A dispatch-selected source commit remains
+non-executable archive identity data.
+
 ## Candidate gates
 
 Before merge, record:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -10,3 +10,5 @@ pause. There is no deployed product yet.
 - [Stage 0 verification record](STAGE_0_VERIFICATION.md)
 - [DISC-102 Explorer verification record](DISC-102_VERIFICATION.md)
 - [DISC-103 reviewed examples verification record](DISC-103_VERIFICATION.md)
+- [DISC-104 GitHub Pages runbook](DISC-104_RUNBOOK.md)
+- [DISC-104 GitHub Pages verification record](DISC-104_VERIFICATION.md)

--- a/scripts/package_pages.py
+++ b/scripts/package_pages.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Build the deterministic, immutable GIS AI GO GitHub Pages archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import stat
+import subprocess
+import tarfile
+from html.parser import HTMLParser
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_REPOSITORY = "chris-page-gov/gis-ai-go"
+EXPECTED_BASE_PATH = "/gis-ai-go/"
+CANONICAL_URL = "https://chris-page-gov.github.io/gis-ai-go/"
+BUILDER_VERSION = "1.0.0"
+MAX_FILE_BYTES = 32 * 1024 * 1024
+MAX_TOTAL_BYTES = 128 * 1024 * 1024
+MAX_FILES = 10_000
+OUTPUT_NAMES = {"artifact.tar", "artifact.tar.sha256", "archive-receipt.json"}
+PUBLICATION_PATHS = {
+    "publication/CHECKSUMS.sha256",
+    "publication/manifest.json",
+    "publication/provenance.json",
+    "publication/site-receipt.json",
+    "publication/sbom.cdx.json",
+}
+REQUIRED_CATALOGUE_PATHS = {
+    "build-receipt.json",
+    "manifest.json",
+    "okf-bundle.json",
+    "okf-bundle.jsonld",
+    "okf-explorer.json",
+}
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+VERSION_RE = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z"
+)
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_entry(path: str, value: bytes) -> dict[str, Any]:
+    return {"path": path, "bytes": len(value), "sha256": sha256_bytes(value)}
+
+
+def safe_relative_path(value: str) -> str:
+    logical = PurePosixPath(value)
+    if (
+        not value
+        or value.startswith("/")
+        or "\\" in value
+        or "\0" in value
+        or logical.is_absolute()
+        or any(part in {"", ".", ".."} for part in logical.parts)
+    ):
+        raise ValueError(f"unsafe publication path: {value!r}")
+    lowered = value.casefold()
+    forbidden_parts = {".git", "docs", "node_modules", "publication", "research"}
+    if (
+        any(part.casefold() in forbidden_parts for part in logical.parts)
+        or "research-pack" in lowered
+        or lowered.endswith(".map")
+    ):
+        raise ValueError(f"forbidden or non-public distribution path: {value}")
+    hidden = [part for part in logical.parts if part.startswith(".")]
+    if hidden and value != "catalogue/.explorer-generated":
+        raise ValueError(f"unexpected hidden distribution path: {value}")
+    return value
+
+
+def inventory_regular_files(root: Path) -> dict[str, bytes]:
+    try:
+        root_metadata = root.lstat()
+    except FileNotFoundError as error:
+        raise ValueError(f"distribution does not exist: {root}") from error
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError("distribution root must be a real directory")
+
+    files: dict[str, bytes] = {}
+    total_bytes = 0
+
+    def visit(directory: Path, prefix: PurePosixPath | None = None) -> None:
+        nonlocal total_bytes
+        with os.scandir(directory) as entries:
+            ordered = sorted(entries, key=lambda entry: entry.name)
+        for entry in ordered:
+            relative = entry.name if prefix is None else f"{prefix.as_posix()}/{entry.name}"
+            safe_relative_path(relative)
+            metadata = entry.stat(follow_symlinks=False)
+            if stat.S_ISLNK(metadata.st_mode):
+                raise ValueError(f"distribution must not contain symbolic links: {relative}")
+            if stat.S_ISDIR(metadata.st_mode):
+                visit(Path(entry.path), PurePosixPath(relative))
+                continue
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ValueError(f"distribution must contain regular files only: {relative}")
+            if metadata.st_nlink != 1:
+                raise ValueError(f"distribution must not contain hard-linked files: {relative}")
+            if metadata.st_size > MAX_FILE_BYTES:
+                raise ValueError(f"distribution file exceeds {MAX_FILE_BYTES} bytes: {relative}")
+            total_bytes += metadata.st_size
+            if total_bytes > MAX_TOTAL_BYTES:
+                raise ValueError(f"distribution exceeds {MAX_TOTAL_BYTES} bytes")
+            if len(files) >= MAX_FILES:
+                raise ValueError(f"distribution exceeds {MAX_FILES} files")
+            files[relative] = Path(entry.path).read_bytes()
+
+    visit(root)
+    if not files:
+        raise ValueError("distribution must not be empty")
+    return files
+
+
+def parse_checksum_ledger(value: bytes, label: str) -> list[dict[str, str]]:
+    try:
+        text = value.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{label} must be UTF-8") from error
+    if not text.endswith("\n"):
+        raise ValueError(f"{label} must end with a newline")
+    rows: list[dict[str, str]] = []
+    for line in text[:-1].split("\n"):
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+        if not match:
+            raise ValueError(f"invalid {label} row: {line!r}")
+        rows.append({"sha256": match.group(1), "path": safe_relative_path(match.group(2))})
+    paths = [row["path"] for row in rows]
+    if not rows or paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise ValueError(f"{label} paths must be non-empty, unique and sorted")
+    return rows
+
+
+class _References(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.values: list[str] = []
+
+    def handle_starttag(self, _tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if name.casefold() in {"href", "src"} and value and not value.startswith("#"):
+                self.values.append(value)
+
+
+def html_references(value: bytes) -> set[str]:
+    try:
+        text = value.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError("Explorer index must be UTF-8") from error
+    parser = _References()
+    parser.feed(text)
+    references: set[str] = set()
+    for raw in parser.values:
+        split = urlsplit(raw)
+        if split.scheme or split.netloc or raw.startswith("/") or raw.startswith("//"):
+            raise ValueError(f"Explorer index contains a non-relative reference: {raw}")
+        path = unquote(split.path)
+        if path.startswith("./"):
+            path = path[2:]
+        if not path:
+            continue
+        references.add(safe_relative_path(path))
+    return references
+
+
+def require_checked_distribution(
+    files: dict[str, bytes], version: str, source_commit: str
+) -> dict[str, Any]:
+    for required in {
+        "index.html",
+        "favicon.svg",
+        "catalogue/.explorer-generated",
+        "catalogue/CHECKSUMS.sha256",
+    }:
+        if required not in files:
+            raise ValueError(f"checked distribution is missing {required}")
+    if files["catalogue/.explorer-generated"] != b"gis-ai-go-public-explorer-data.v1\n":
+        raise ValueError("Explorer catalogue marker is not recognised")
+
+    catalogue_rows = parse_checksum_ledger(
+        files["catalogue/CHECKSUMS.sha256"], "catalogue checksum ledger"
+    )
+    catalogue_paths = {
+        path.removeprefix("catalogue/")
+        for path in files
+        if path.startswith("catalogue/")
+    }
+    expected_catalogue = {
+        ".explorer-generated",
+        "CHECKSUMS.sha256",
+        *(row["path"] for row in catalogue_rows),
+    }
+    if catalogue_paths != expected_catalogue:
+        raise ValueError("distributed catalogue inventory differs from its checksum ledger")
+    for row in catalogue_rows:
+        path = f"catalogue/{row['path']}"
+        if sha256_bytes(files[path]) != row["sha256"]:
+            raise ValueError(f"distributed catalogue checksum mismatch: {row['path']}")
+    if not REQUIRED_CATALOGUE_PATHS.issubset({row["path"] for row in catalogue_rows}):
+        missing = sorted(REQUIRED_CATALOGUE_PATHS - {row["path"] for row in catalogue_rows})
+        raise ValueError(f"distributed catalogue is missing required files: {missing}")
+
+    references = html_references(files["index.html"])
+    expected_files = {
+        "index.html",
+        *(path for path in files if path.startswith("catalogue/")),
+        *references,
+    }
+    if "favicon.svg" not in references:
+        raise ValueError("Explorer index must reference favicon.svg")
+    if set(files) != expected_files:
+        missing = sorted(expected_files - set(files))
+        extra = sorted(set(files) - expected_files)
+        raise ValueError(f"distribution inventory is not exact; missing={missing}; extra={extra}")
+
+    try:
+        receipt = json.loads(files["catalogue/build-receipt.json"])
+        catalogue_manifest = json.loads(files["catalogue/manifest.json"])
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("catalogue receipt and manifest must be valid UTF-8 JSON") from error
+    if not isinstance(receipt, dict) or not isinstance(catalogue_manifest, dict):
+        raise ValueError("catalogue receipt and manifest must be JSON objects")
+    for field in (
+        "builder",
+        "builderVersion",
+        "revision",
+        "contentRootSha256",
+        "manifestSha256",
+        "version",
+    ):
+        if not isinstance(receipt.get(field), str) or not receipt[field]:
+            raise ValueError(f"catalogue build receipt requires string field {field}")
+    if not COMMIT_RE.fullmatch(receipt["revision"]):
+        raise ValueError("catalogue build receipt revision must be a full commit")
+    if receipt["revision"] != source_commit:
+        raise ValueError(
+            "catalogue build receipt revision differs from the publication source commit"
+        )
+    if not SHA256_RE.fullmatch(receipt["contentRootSha256"]):
+        raise ValueError("catalogue build receipt content root is invalid")
+    actual_manifest_sha = sha256_bytes(files["catalogue/manifest.json"])
+    if receipt["manifestSha256"] != actual_manifest_sha:
+        raise ValueError("catalogue build receipt does not bind catalogue/manifest.json")
+    if receipt["version"] != version:
+        raise ValueError("catalogue build receipt version differs from the publication version")
+    return {
+        "builder": receipt["builder"],
+        "builderVersion": receipt["builderVersion"],
+        "revision": receipt["revision"],
+        "contentRootSha256": receipt["contentRootSha256"],
+        "manifestSha256": actual_manifest_sha,
+    }
+
+
+def validate_identity(repository: str, source_commit: str, version: str, base_path: str) -> None:
+    if repository != EXPECTED_REPOSITORY:
+        raise ValueError(f"repository must be exactly {EXPECTED_REPOSITORY}")
+    if base_path != EXPECTED_BASE_PATH:
+        raise ValueError(f"base path must be exactly {EXPECTED_BASE_PATH}")
+    if not COMMIT_RE.fullmatch(source_commit):
+        raise ValueError("source commit must be a 40-character lowercase hexadecimal commit")
+    if not VERSION_RE.fullmatch(version):
+        raise ValueError("version must be a semantic version")
+    expected_version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+    if version != expected_version:
+        raise ValueError(
+            f"version differs from VERSION: expected {expected_version}, found {version}"
+        )
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, check=True, capture_output=True, text=True
+    )
+    if result.stdout.strip() != source_commit:
+        raise ValueError("source commit must equal the checked-out HEAD")
+
+
+def checksum_ledger(entries: list[dict[str, Any]]) -> bytes:
+    ordered = sorted(entries, key=lambda item: item["path"])
+    return "".join(f"{item['sha256']}  {item['path']}\n" for item in ordered).encode()
+
+
+def payload_root(entries: list[dict[str, Any]]) -> str:
+    return sha256_bytes(checksum_ledger(entries))
+
+
+def publication_sbom(
+    identity: dict[str, str], payload_entries: list[dict[str, Any]], root_sha256: str
+) -> bytes:
+    components = []
+    for item in sorted(payload_entries, key=lambda entry: entry["path"]):
+        components.append(
+            {
+                "bom-ref": f"file:{item['path']}@sha256:{item['sha256']}",
+                "type": "file",
+                "name": item["path"],
+                "hashes": [{"alg": "SHA-256", "content": item["sha256"]}],
+                "properties": [
+                    {"name": "gis-ai-go:bytes", "value": str(item["bytes"])},
+                    {"name": "gis-ai-go:publication-path", "value": item["path"]},
+                ],
+            }
+        )
+    return canonical_json(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "metadata": {
+                "component": {
+                    "bom-ref": f"git:{identity['repository']}@{identity['sourceCommit']}",
+                    "type": "application",
+                    "name": "GIS AI GO public Explorer",
+                    "version": identity["version"],
+                    "hashes": [{"alg": "SHA-256", "content": root_sha256}],
+                    "licenses": [{"license": {"id": "MIT"}}],
+                },
+                "properties": [
+                    {"name": "gis-ai-go:base-path", "value": identity["basePath"]},
+                    {"name": "gis-ai-go:repository", "value": identity["repository"]},
+                    {"name": "gis-ai-go:source-commit", "value": identity["sourceCommit"]},
+                ],
+            },
+            "components": components,
+        }
+    )
+
+
+def deterministic_tar(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for path in sorted(files):
+            if path != ".nojekyll" and not path.startswith("publication/"):
+                safe_relative_path(path)
+            value = files[path]
+            member = tarfile.TarInfo(path)
+            member.size = len(value)
+            member.mode = 0o644
+            member.uid = 0
+            member.gid = 0
+            member.uname = ""
+            member.gname = ""
+            member.mtime = 0
+            member.type = tarfile.REGTYPE
+            archive.addfile(member, io.BytesIO(value))
+    return buffer.getvalue()
+
+
+def build_archive(
+    *,
+    dist: Path,
+    output_dir: Path,
+    source_commit: str,
+    repository: str,
+    version: str,
+    base_path: str,
+) -> dict[str, Any]:
+    validate_identity(repository, source_commit, version, base_path)
+    dist_resolved = dist.resolve()
+    output_resolved = output_dir.resolve()
+    if output_resolved == dist_resolved or output_resolved.is_relative_to(dist_resolved):
+        raise ValueError("output directory must not be inside the checked distribution")
+
+    dist_files = inventory_regular_files(dist)
+    okf = require_checked_distribution(dist_files, version, source_commit)
+    identity = {
+        "repository": repository,
+        "sourceCommit": source_commit,
+        "version": version,
+        "basePath": base_path,
+        "canonicalUrl": CANONICAL_URL,
+    }
+    payload_files = {**dist_files, ".nojekyll": b""}
+    payload_entries = [file_entry(path, value) for path, value in sorted(payload_files.items())]
+    root_sha256 = payload_root(payload_entries)
+
+    sbom = publication_sbom(identity, payload_entries, root_sha256)
+    provenance = canonical_json(
+        {
+            "schema": "gis-ai-go.pages-provenance.v1",
+            **identity,
+            "builder": {"name": "scripts/package_pages.py", "version": BUILDER_VERSION},
+            "source": {
+                "path": "apps/public-explorer/dist",
+                "fileCount": len(payload_entries),
+                "payloadRootSha256": root_sha256,
+            },
+            "okf": {
+                "buildReceiptPath": "catalogue/build-receipt.json",
+                **okf,
+            },
+            "determinism": {
+                "archiveFormat": "POSIX ustar",
+                "pathOrder": "lexicographic UTF-8 publication path",
+                "uid": 0,
+                "gid": 0,
+                "userName": "",
+                "groupName": "",
+                "fileMode": "0644",
+                "modificationTime": 0,
+                "wallClockIncluded": False,
+            },
+        }
+    )
+    site_receipt = canonical_json(
+        {
+            "schema": "gis-ai-go.pages-site-receipt.v1",
+            **identity,
+            "fileCount": len(payload_entries),
+            "payloadRootSha256": root_sha256,
+            "okfContentRootSha256": okf["contentRootSha256"],
+            "okfManifestSha256": okf["manifestSha256"],
+            "provenanceSha256": sha256_bytes(provenance),
+            "sbomSha256": sha256_bytes(sbom),
+        }
+    )
+    supporting = {
+        "publication/provenance.json": provenance,
+        "publication/site-receipt.json": site_receipt,
+        "publication/sbom.cdx.json": sbom,
+    }
+    supporting_entries = [file_entry(path, value) for path, value in sorted(supporting.items())]
+    manifest = canonical_json(
+        {
+            "schema": "gis-ai-go.pages-manifest.v1",
+            **identity,
+            "okfContentRootSha256": okf["contentRootSha256"],
+            "payload": {
+                "fileCount": len(payload_entries),
+                "rootSha256": root_sha256,
+                "files": payload_entries,
+            },
+            "publicationFiles": supporting_entries,
+        }
+    )
+    archive_files = {
+        **payload_files,
+        **supporting,
+        "publication/manifest.json": manifest,
+    }
+    publicly_fetchable = [
+        file_entry(path, value)
+        for path, value in sorted(archive_files.items())
+        if path != ".nojekyll"
+    ]
+    checksums = checksum_ledger(publicly_fetchable)
+    archive_files["publication/CHECKSUMS.sha256"] = checksums
+    if set(archive_files) != set(payload_files) | PUBLICATION_PATHS:
+        raise AssertionError("internal publication inventory differs from the fixed contract")
+
+    archive_bytes = deterministic_tar(archive_files)
+    archive_sha256 = sha256_bytes(archive_bytes)
+    archive_checksum = f"{archive_sha256}  artifact.tar\n".encode()
+    receipt = {
+        "schema": "gis-ai-go.pages-archive-receipt.v1",
+        **identity,
+        "payloadRootSha256": root_sha256,
+        "okfContentRootSha256": okf["contentRootSha256"],
+        "archive": {
+            "path": "artifact.tar",
+            "format": "POSIX ustar",
+            "bytes": len(archive_bytes),
+            "sha256": archive_sha256,
+        },
+        "checksum": {
+            "path": "artifact.tar.sha256",
+            "sha256": sha256_bytes(archive_checksum),
+        },
+        "publication": {
+            "checksumsSha256": sha256_bytes(checksums),
+            "manifestSha256": sha256_bytes(manifest),
+            "provenanceSha256": sha256_bytes(provenance),
+            "siteReceiptSha256": sha256_bytes(site_receipt),
+            "sbomSha256": sha256_bytes(sbom),
+        },
+    }
+
+    if output_dir.exists() or output_dir.is_symlink():
+        output_metadata = output_dir.lstat()
+        if stat.S_ISLNK(output_metadata.st_mode) or not stat.S_ISDIR(output_metadata.st_mode):
+            raise ValueError("output directory must be a real directory")
+    else:
+        output_dir.mkdir(parents=True, exist_ok=False)
+    unexpected = {path.name for path in output_dir.iterdir()} - OUTPUT_NAMES
+    if unexpected:
+        raise ValueError(f"output directory contains unexpected entries: {sorted(unexpected)}")
+    for name in sorted(OUTPUT_NAMES):
+        candidate = output_dir / name
+        if not candidate.exists() and not candidate.is_symlink():
+            continue
+        metadata = candidate.lstat()
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            raise ValueError(f"existing output must be an ordinary single-link file: {name}")
+    (output_dir / "artifact.tar").write_bytes(archive_bytes)
+    (output_dir / "artifact.tar.sha256").write_bytes(archive_checksum)
+    (output_dir / "archive-receipt.json").write_bytes(canonical_json(receipt))
+    return receipt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--base-path", required=True)
+    args = parser.parse_args()
+    receipt = build_archive(
+        dist=args.dist,
+        output_dir=args.output_dir,
+        source_commit=args.source_commit,
+        repository=args.repository,
+        version=args.version,
+        base_path=args.base_path,
+    )
+    print(
+        "Built deterministic Pages archive "
+        f"sha256={receipt['archive']['sha256']} bytes={receipt['archive']['bytes']} "
+        f"source={receipt['sourceCommit']}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_pages_archive.py
+++ b/scripts/verify_pages_archive.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""Verify a GIS AI GO Pages archive without extracting or rebuilding the site."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import stat
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+EXPECTED_REPOSITORY = "chris-page-gov/gis-ai-go"
+EXPECTED_BASE_PATH = "/gis-ai-go/"
+EXPECTED_CANONICAL_URL = "https://chris-page-gov.github.io/gis-ai-go/"
+PUBLICATION_PATHS = {
+    "publication/CHECKSUMS.sha256",
+    "publication/manifest.json",
+    "publication/provenance.json",
+    "publication/site-receipt.json",
+    "publication/sbom.cdx.json",
+}
+MAX_ARCHIVE_BYTES = 160 * 1024 * 1024
+MAX_FILE_BYTES = 32 * 1024 * 1024
+MAX_FILES = 10_010
+MAX_METADATA_BYTES = 2 * 1024 * 1024
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def require_keys(value: Any, expected: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(
+            f"{label} fields differ from the contract; "
+            f"missing={sorted(expected - actual)}; extra={sorted(actual - expected)}"
+        )
+    return value
+
+
+def require_sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def safe_archive_path(value: str) -> str:
+    logical = PurePosixPath(value)
+    if (
+        not value
+        or value.startswith("/")
+        or "\\" in value
+        or "\0" in value
+        or logical.is_absolute()
+        or any(part in {"", ".", ".."} for part in logical.parts)
+    ):
+        raise ValueError(f"unsafe archive path: {value!r}")
+    lowered = value.casefold()
+    if (
+        any(
+            part.casefold() in {".git", "docs", "node_modules", "research"}
+            for part in logical.parts
+        )
+        or ("publication" in logical.parts and logical.parts[0] != "publication")
+        or "research-pack" in lowered
+        or lowered.endswith(".map")
+    ):
+        raise ValueError(f"forbidden archive path: {value}")
+    hidden = [part for part in logical.parts if part.startswith(".")]
+    if hidden and value not in {".nojekyll", "catalogue/.explorer-generated"}:
+        raise ValueError(f"unexpected hidden archive path: {value}")
+    return value
+
+
+def parse_checksum_ledger(value: bytes, label: str) -> list[dict[str, str]]:
+    try:
+        text = value.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{label} must be UTF-8") from error
+    if not text.endswith("\n"):
+        raise ValueError(f"{label} must end with a newline")
+    rows: list[dict[str, str]] = []
+    for line in text[:-1].split("\n"):
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+        if not match:
+            raise ValueError(f"invalid {label} row: {line!r}")
+        rows.append({"sha256": match.group(1), "path": safe_archive_path(match.group(2))})
+    paths = [row["path"] for row in rows]
+    if not rows or paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise ValueError(f"{label} paths must be non-empty, unique and sorted")
+    return rows
+
+
+def checksum_ledger(entries: list[dict[str, Any]]) -> bytes:
+    ordered = sorted(entries, key=lambda item: item["path"])
+    return "".join(f"{item['sha256']}  {item['path']}\n" for item in ordered).encode()
+
+
+def file_entry(path: str, value: bytes) -> dict[str, Any]:
+    return {"path": path, "bytes": len(value), "sha256": sha256_bytes(value)}
+
+
+def read_outer_file(path: Path, label: str, maximum_bytes: int) -> bytes:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise ValueError(f"{label} does not exist") from error
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+    ):
+        raise ValueError(f"{label} must be an ordinary single-link regular file")
+    if metadata.st_size > maximum_bytes:
+        raise ValueError(f"{label} exceeds {maximum_bytes} bytes")
+    return path.read_bytes()
+
+
+def deterministic_tar(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for path in sorted(files):
+            value = files[path]
+            member = tarfile.TarInfo(path)
+            member.size = len(value)
+            member.mode = 0o644
+            member.uid = 0
+            member.gid = 0
+            member.uname = ""
+            member.gname = ""
+            member.mtime = 0
+            member.type = tarfile.REGTYPE
+            archive.addfile(member, io.BytesIO(value))
+    return buffer.getvalue()
+
+
+def read_archive(value: bytes) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(value), mode="r:") as archive:
+            members = archive.getmembers()
+            if len(members) > MAX_FILES:
+                raise ValueError(f"archive exceeds {MAX_FILES} members")
+            paths = [member.name for member in members]
+            if paths != sorted(paths) or len(paths) != len(set(paths)):
+                raise ValueError("archive paths must be unique and sorted")
+            for member in members:
+                path = safe_archive_path(member.name)
+                if member.type != tarfile.REGTYPE or not member.isfile():
+                    raise ValueError(f"archive must contain regular files only: {path}")
+                if member.linkname:
+                    raise ValueError(f"archive member must not link elsewhere: {path}")
+                if member.pax_headers:
+                    raise ValueError(f"archive must not contain PAX metadata: {path}")
+                if (
+                    member.uid != 0
+                    or member.gid != 0
+                    or member.uname != ""
+                    or member.gname != ""
+                    or member.mode != 0o644
+                    or member.mtime != 0
+                ):
+                    raise ValueError(f"archive member metadata is not normalised: {path}")
+                if member.size > MAX_FILE_BYTES:
+                    raise ValueError(f"archive member exceeds {MAX_FILE_BYTES} bytes: {path}")
+                handle = archive.extractfile(member)
+                if handle is None:
+                    raise ValueError(f"archive member cannot be read: {path}")
+                files[path] = handle.read()
+    except tarfile.TarError as error:
+        raise ValueError("artifact.tar is not a valid uncompressed POSIX tar archive") from error
+    if deterministic_tar(files) != value:
+        raise ValueError("archive bytes are not the canonical deterministic POSIX ustar encoding")
+    return files
+
+
+def parse_json_file(files: dict[str, bytes], path: str) -> Any:
+    try:
+        value = json.loads(files[path])
+    except (KeyError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{path} must be valid UTF-8 JSON") from error
+    if canonical_json(value) != files[path]:
+        raise ValueError(f"{path} must use canonical sorted two-space JSON with a final newline")
+    return value
+
+
+def require_identity(
+    value: dict[str, Any],
+    *,
+    repository: str,
+    source_commit: str,
+    version: str,
+    base_path: str,
+    label: str,
+) -> None:
+    expected = {
+        "repository": repository,
+        "sourceCommit": source_commit,
+        "version": version,
+        "basePath": base_path,
+        "canonicalUrl": EXPECTED_CANONICAL_URL,
+    }
+    for key, expected_value in expected.items():
+        if value.get(key) != expected_value:
+            raise ValueError(f"{label} {key} differs from the expected identity")
+
+
+def require_file_entries(value: Any, label: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{label} must be a non-empty array")
+    paths: list[str] = []
+    for index, raw in enumerate(value):
+        item = require_keys(raw, {"path", "bytes", "sha256"}, f"{label}[{index}]")
+        if not isinstance(item["path"], str):
+            raise ValueError(f"{label}[{index}].path must be a string")
+        safe_archive_path(item["path"])
+        if (
+            not isinstance(item["bytes"], int)
+            or isinstance(item["bytes"], bool)
+            or item["bytes"] < 0
+        ):
+            raise ValueError(f"{label}[{index}].bytes must be a non-negative integer")
+        require_sha256(item["sha256"], f"{label}[{index}].sha256")
+        paths.append(item["path"])
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise ValueError(f"{label} paths must be unique and sorted")
+    return value
+
+
+def verify_catalogue(files: dict[str, bytes], manifest: dict[str, Any], version: str) -> None:
+    catalogue_rows = parse_checksum_ledger(
+        files["catalogue/CHECKSUMS.sha256"], "catalogue checksums"
+    )
+    catalogue_paths = {
+        path.removeprefix("catalogue/")
+        for path in files
+        if path.startswith("catalogue/")
+    }
+    expected_paths = {
+        ".explorer-generated",
+        "CHECKSUMS.sha256",
+        *(row["path"] for row in catalogue_rows),
+    }
+    if catalogue_paths != expected_paths:
+        raise ValueError("archived catalogue inventory differs from catalogue checksums")
+    for row in catalogue_rows:
+        if sha256_bytes(files[f"catalogue/{row['path']}"]) != row["sha256"]:
+            raise ValueError(f"archived catalogue checksum mismatch: {row['path']}")
+    receipt = parse_json_file(files, "catalogue/build-receipt.json")
+    if not isinstance(receipt, dict):
+        raise ValueError("catalogue build receipt must be an object")
+    if receipt.get("version") != version:
+        raise ValueError("catalogue build receipt version differs from publication version")
+    okf = manifest["okf"]
+    expected = {
+        "builder": receipt.get("builder"),
+        "builderVersion": receipt.get("builderVersion"),
+        "revision": receipt.get("revision"),
+        "contentRootSha256": receipt.get("contentRootSha256"),
+        "manifestSha256": sha256_bytes(files["catalogue/manifest.json"]),
+    }
+    for key, expected_value in expected.items():
+        if okf[key] != expected_value:
+            raise ValueError(f"publication provenance differs from catalogue receipt: {key}")
+    if receipt.get("manifestSha256") != expected["manifestSha256"]:
+        raise ValueError("catalogue receipt does not bind catalogue/manifest.json")
+
+
+def verify_sbom(
+    sbom: Any,
+    *,
+    payload_entries: list[dict[str, Any]],
+    payload_root: str,
+    repository: str,
+    source_commit: str,
+    version: str,
+    base_path: str,
+) -> None:
+    document = require_keys(
+        sbom,
+        {"bomFormat", "specVersion", "version", "metadata", "components"},
+        "SBOM",
+    )
+    if (
+        document["bomFormat"] != "CycloneDX"
+        or document["specVersion"] != "1.6"
+        or document["version"] != 1
+    ):
+        raise ValueError("SBOM must be CycloneDX 1.6 document version 1")
+    metadata = require_keys(document["metadata"], {"component", "properties"}, "SBOM metadata")
+    component = require_keys(
+        metadata["component"],
+        {"bom-ref", "type", "name", "version", "hashes", "licenses"},
+        "SBOM product",
+    )
+    if (
+        component["bom-ref"] != f"git:{repository}@{source_commit}"
+        or component["type"] != "application"
+        or component["name"] != "GIS AI GO public Explorer"
+        or component["version"] != version
+        or component["hashes"] != [{"alg": "SHA-256", "content": payload_root}]
+        or component["licenses"] != [{"license": {"id": "MIT"}}]
+    ):
+        raise ValueError("SBOM product identity differs from the publication")
+    expected_properties = [
+        {"name": "gis-ai-go:base-path", "value": base_path},
+        {"name": "gis-ai-go:repository", "value": repository},
+        {"name": "gis-ai-go:source-commit", "value": source_commit},
+    ]
+    if metadata["properties"] != expected_properties:
+        raise ValueError("SBOM publication properties differ from the publication")
+    expected_components = []
+    for item in payload_entries:
+        expected_components.append(
+            {
+                "bom-ref": f"file:{item['path']}@sha256:{item['sha256']}",
+                "type": "file",
+                "name": item["path"],
+                "hashes": [{"alg": "SHA-256", "content": item["sha256"]}],
+                "properties": [
+                    {"name": "gis-ai-go:bytes", "value": str(item["bytes"])},
+                    {"name": "gis-ai-go:publication-path", "value": item["path"]},
+                ],
+            }
+        )
+    if document["components"] != expected_components:
+        raise ValueError("SBOM file components differ from the complete payload inventory")
+
+
+def verify_archive(
+    *,
+    archive_path: Path,
+    checksum_path: Path,
+    receipt_path: Path,
+    expected_source_commit: str,
+    expected_repository: str,
+    expected_version: str,
+    expected_base_path: str,
+    expected_archive_sha256: str | None = None,
+) -> dict[str, Any]:
+    if expected_repository != EXPECTED_REPOSITORY or expected_base_path != EXPECTED_BASE_PATH:
+        raise ValueError(
+            "expected repository and base path must name the GIS AI GO Pages publication"
+        )
+    if not COMMIT_RE.fullmatch(expected_source_commit):
+        raise ValueError("expected source commit must be a full lowercase commit")
+    if expected_archive_sha256 is not None:
+        require_sha256(expected_archive_sha256, "expected archive digest")
+
+    archive_bytes = read_outer_file(archive_path, "Pages archive", MAX_ARCHIVE_BYTES)
+    digest = sha256_bytes(archive_bytes)
+    expected_checksum = f"{digest}  artifact.tar\n".encode()
+    checksum_bytes = read_outer_file(checksum_path, "Pages archive checksum", MAX_METADATA_BYTES)
+    if checksum_bytes != expected_checksum:
+        raise ValueError("artifact.tar.sha256 does not exactly bind artifact.tar")
+    if expected_archive_sha256 is not None and digest != expected_archive_sha256:
+        raise ValueError("archive digest differs from the expected accepted artefact")
+
+    try:
+        receipt_bytes = read_outer_file(receipt_path, "Pages archive receipt", MAX_METADATA_BYTES)
+        receipt_value = json.loads(receipt_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("archive receipt must be valid UTF-8 JSON") from error
+    if canonical_json(receipt_value) != receipt_bytes:
+        raise ValueError("archive receipt must use canonical JSON")
+    receipt = require_keys(
+        receipt_value,
+        {
+            "schema", "repository", "sourceCommit", "version", "basePath", "canonicalUrl",
+            "payloadRootSha256", "okfContentRootSha256", "archive", "checksum", "publication",
+        },
+        "archive receipt",
+    )
+    if receipt["schema"] != "gis-ai-go.pages-archive-receipt.v1":
+        raise ValueError("archive receipt schema is not recognised")
+    require_identity(
+        receipt,
+        repository=expected_repository,
+        source_commit=expected_source_commit,
+        version=expected_version,
+        base_path=expected_base_path,
+        label="archive receipt",
+    )
+    require_sha256(receipt["payloadRootSha256"], "archive receipt payload root")
+    require_sha256(receipt["okfContentRootSha256"], "archive receipt OKF root")
+    archive = require_keys(
+        receipt["archive"],
+        {"path", "format", "bytes", "sha256"},
+        "archive receipt archive",
+    )
+    expected_archive = {
+        "path": "artifact.tar",
+        "format": "POSIX ustar",
+        "bytes": len(archive_bytes),
+        "sha256": digest,
+    }
+    if archive != expected_archive:
+        raise ValueError("archive receipt archive identity differs from artifact.tar")
+    checksum = require_keys(receipt["checksum"], {"path", "sha256"}, "archive receipt checksum")
+    if checksum != {"path": "artifact.tar.sha256", "sha256": sha256_bytes(checksum_bytes)}:
+        raise ValueError("archive receipt checksum identity differs from artifact.tar.sha256")
+    publication = require_keys(
+        receipt["publication"],
+        {
+            "checksumsSha256",
+            "manifestSha256",
+            "provenanceSha256",
+            "siteReceiptSha256",
+            "sbomSha256",
+        },
+        "archive receipt publication",
+    )
+    for key, value in publication.items():
+        require_sha256(value, f"archive receipt publication {key}")
+
+    files = read_archive(archive_bytes)
+    if not PUBLICATION_PATHS.issubset(files) or ".nojekyll" not in files:
+        raise ValueError("archive is missing the fixed Pages publication files")
+    if files[".nojekyll"] != b"":
+        raise ValueError(".nojekyll must be an empty regular file")
+    if any(path.startswith("publication/") and path not in PUBLICATION_PATHS for path in files):
+        raise ValueError("archive contains an unexpected publication metadata file")
+
+    public_rows = parse_checksum_ledger(
+        files["publication/CHECKSUMS.sha256"], "publication checksums"
+    )
+    expected_public_paths = sorted(set(files) - {".nojekyll", "publication/CHECKSUMS.sha256"})
+    if [row["path"] for row in public_rows] != expected_public_paths:
+        raise ValueError("publication checksums must cover every publicly fetchable archive file")
+    for row in public_rows:
+        if sha256_bytes(files[row["path"]]) != row["sha256"]:
+            raise ValueError(f"publication checksum mismatch: {row['path']}")
+
+    manifest = require_keys(
+        parse_json_file(files, "publication/manifest.json"),
+        {
+            "schema", "repository", "sourceCommit", "version", "basePath", "canonicalUrl",
+            "okfContentRootSha256", "payload", "publicationFiles",
+        },
+        "publication manifest",
+    )
+    if manifest["schema"] != "gis-ai-go.pages-manifest.v1":
+        raise ValueError("publication manifest schema is not recognised")
+    require_identity(
+        manifest,
+        repository=expected_repository,
+        source_commit=expected_source_commit,
+        version=expected_version,
+        base_path=expected_base_path,
+        label="publication manifest",
+    )
+    payload = require_keys(
+        manifest["payload"],
+        {"fileCount", "rootSha256", "files"},
+        "manifest payload",
+    )
+    payload_entries = require_file_entries(payload["files"], "manifest payload files")
+    expected_payload_paths = sorted(path for path in files if not path.startswith("publication/"))
+    if [item["path"] for item in payload_entries] != expected_payload_paths:
+        raise ValueError("manifest payload inventory differs from archived site files")
+    for item in payload_entries:
+        if item != file_entry(item["path"], files[item["path"]]):
+            raise ValueError(f"manifest payload metadata differs from bytes: {item['path']}")
+    root_sha256 = sha256_bytes(checksum_ledger(payload_entries))
+    if payload["fileCount"] != len(payload_entries) or payload["rootSha256"] != root_sha256:
+        raise ValueError("manifest payload count or content root differs from the inventory")
+    supporting_entries = require_file_entries(
+        manifest["publicationFiles"], "manifest publication files"
+    )
+    expected_supporting_paths = [
+        "publication/provenance.json", "publication/sbom.cdx.json", "publication/site-receipt.json"
+    ]
+    if [item["path"] for item in supporting_entries] != expected_supporting_paths:
+        raise ValueError("manifest publication files differ from the acyclic supporting set")
+    for item in supporting_entries:
+        if item != file_entry(item["path"], files[item["path"]]):
+            raise ValueError(f"manifest supporting metadata differs from bytes: {item['path']}")
+
+    provenance = require_keys(
+        parse_json_file(files, "publication/provenance.json"),
+        {
+            "schema", "repository", "sourceCommit", "version", "basePath", "canonicalUrl",
+            "builder", "source", "okf", "determinism",
+        },
+        "publication provenance",
+    )
+    if provenance["schema"] != "gis-ai-go.pages-provenance.v1":
+        raise ValueError("publication provenance schema is not recognised")
+    require_identity(
+        provenance,
+        repository=expected_repository,
+        source_commit=expected_source_commit,
+        version=expected_version,
+        base_path=expected_base_path,
+        label="publication provenance",
+    )
+    if require_keys(provenance["builder"], {"name", "version"}, "provenance builder") != {
+        "name": "scripts/package_pages.py", "version": "1.0.0"
+    }:
+        raise ValueError("publication provenance builder is not recognised")
+    source = require_keys(
+        provenance["source"],
+        {"path", "fileCount", "payloadRootSha256"},
+        "provenance source",
+    )
+    expected_source = {
+        "path": "apps/public-explorer/dist",
+        "fileCount": len(payload_entries),
+        "payloadRootSha256": root_sha256,
+    }
+    if source != expected_source:
+        raise ValueError("publication provenance source differs from the payload")
+    okf = require_keys(
+        provenance["okf"],
+        {
+            "buildReceiptPath",
+            "builder",
+            "builderVersion",
+            "revision",
+            "contentRootSha256",
+            "manifestSha256",
+        },
+        "provenance OKF",
+    )
+    if (
+        okf["buildReceiptPath"] != "catalogue/build-receipt.json"
+        or not COMMIT_RE.fullmatch(okf["revision"])
+        or okf["revision"] != expected_source_commit
+    ):
+        raise ValueError("publication provenance OKF identity is invalid")
+    require_sha256(okf["contentRootSha256"], "provenance OKF content root")
+    require_sha256(okf["manifestSha256"], "provenance OKF manifest")
+    determinism = require_keys(
+        provenance["determinism"],
+        {
+            "archiveFormat",
+            "pathOrder",
+            "uid",
+            "gid",
+            "userName",
+            "groupName",
+            "fileMode",
+            "modificationTime",
+            "wallClockIncluded",
+        },
+        "provenance determinism",
+    )
+    if determinism != {
+        "archiveFormat": "POSIX ustar", "pathOrder": "lexicographic UTF-8 publication path",
+        "uid": 0, "gid": 0, "userName": "", "groupName": "", "fileMode": "0644",
+        "modificationTime": 0, "wallClockIncluded": False,
+    }:
+        raise ValueError("publication provenance determinism contract differs")
+
+    site_receipt = require_keys(
+        parse_json_file(files, "publication/site-receipt.json"),
+        {
+            "schema", "repository", "sourceCommit", "version", "basePath", "canonicalUrl",
+            "fileCount", "payloadRootSha256", "okfContentRootSha256", "okfManifestSha256",
+            "provenanceSha256", "sbomSha256",
+        },
+        "site receipt",
+    )
+    if site_receipt["schema"] != "gis-ai-go.pages-site-receipt.v1":
+        raise ValueError("site receipt schema is not recognised")
+    require_identity(
+        site_receipt,
+        repository=expected_repository,
+        source_commit=expected_source_commit,
+        version=expected_version,
+        base_path=expected_base_path,
+        label="site receipt",
+    )
+    expected_site_values = {
+        "fileCount": len(payload_entries),
+        "payloadRootSha256": root_sha256,
+        "okfContentRootSha256": okf["contentRootSha256"],
+        "okfManifestSha256": okf["manifestSha256"],
+        "provenanceSha256": sha256_bytes(files["publication/provenance.json"]),
+        "sbomSha256": sha256_bytes(files["publication/sbom.cdx.json"]),
+    }
+    for key, value in expected_site_values.items():
+        if site_receipt[key] != value:
+            raise ValueError(f"site receipt differs from the archived publication: {key}")
+
+    verify_sbom(
+        parse_json_file(files, "publication/sbom.cdx.json"),
+        payload_entries=payload_entries,
+        payload_root=root_sha256,
+        repository=expected_repository,
+        source_commit=expected_source_commit,
+        version=expected_version,
+        base_path=expected_base_path,
+    )
+    verify_catalogue(files, provenance, expected_version)
+
+    if manifest["okfContentRootSha256"] != okf["contentRootSha256"]:
+        raise ValueError("publication manifest OKF root differs from provenance")
+    expected_outer = {
+        "payloadRootSha256": root_sha256,
+        "okfContentRootSha256": okf["contentRootSha256"],
+    }
+    for key, value in expected_outer.items():
+        if receipt[key] != value:
+            raise ValueError(f"archive receipt differs from the publication: {key}")
+    expected_publication_digests = {
+        "checksumsSha256": sha256_bytes(files["publication/CHECKSUMS.sha256"]),
+        "manifestSha256": sha256_bytes(files["publication/manifest.json"]),
+        "provenanceSha256": sha256_bytes(files["publication/provenance.json"]),
+        "siteReceiptSha256": sha256_bytes(files["publication/site-receipt.json"]),
+        "sbomSha256": sha256_bytes(files["publication/sbom.cdx.json"]),
+    }
+    if publication != expected_publication_digests:
+        raise ValueError("archive receipt publication digests differ from artifact.tar")
+    return receipt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--checksum", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--expected-source-commit", required=True)
+    parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-base-path", required=True)
+    parser.add_argument("--expected-archive-sha256")
+    args = parser.parse_args()
+    receipt = verify_archive(
+        archive_path=args.archive,
+        checksum_path=args.checksum,
+        receipt_path=args.receipt,
+        expected_source_commit=args.expected_source_commit,
+        expected_repository=args.expected_repository,
+        expected_version=args.expected_version,
+        expected_base_path=args.expected_base_path,
+        expected_archive_sha256=args.expected_archive_sha256,
+    )
+    print(
+        "Verified Pages archive "
+        f"sha256={receipt['archive']['sha256']} files-bound={receipt['payloadRootSha256']} "
+        f"source={receipt['sourceCommit']}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/contract/test_pages_publication.py
+++ b/tests/contract/test_pages_publication.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script(name: str) -> ModuleType:
+    specification = importlib.util.spec_from_file_location(name, ROOT / "scripts" / f"{name}.py")
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"cannot load {name}")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+PACKAGE = load_script("package_pages")
+VERIFY = load_script("verify_pages_archive")
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+class PagesPublicationContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.dist = self.root / "dist"
+        self.output = self.root / "output"
+        self.head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+        self.content_root = "a" * 64
+        self._make_checked_distribution()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _write(self, relative: str, value: bytes) -> None:
+        path = self.dist / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(value)
+
+    def _make_checked_distribution(self) -> None:
+        self._write(
+            "index.html",
+            (
+                '<!doctype html><html lang="en-GB"><head>'
+                '<link rel="icon" href="./favicon.svg">'
+                '<link rel="stylesheet" href="./assets/app.css">'
+                '<script type="module" src="./assets/app.js"></script>'
+                "</head><body>GIS AI GO</body></html>\n"
+            ).encode(),
+        )
+        self._write("favicon.svg", b"<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>\n")
+        self._write("assets/app.css", b"body { color: #111; }\n")
+        self._write("assets/app.js", b"document.documentElement.className = 'js';\n")
+        self._write("catalogue/.explorer-generated", b"gis-ai-go-public-explorer-data.v1\n")
+
+        catalogue_manifest = canonical_json({"files": [], "recordCount": 0, "recordIds": []})
+        catalogue_files = {
+            "manifest.json": catalogue_manifest,
+            "okf-bundle.json": canonical_json({"recordCount": 0, "records": []}),
+            "okf-bundle.jsonld": canonical_json({"@graph": []}),
+            "okf-explorer.json": canonical_json({"recordCount": 0, "records": []}),
+        }
+        catalogue_files["build-receipt.json"] = canonical_json(
+            {
+                "builder": "tests/fixture",
+                "builderVersion": "1.0.0",
+                "contentRootSha256": self.content_root,
+                "manifestSha256": sha256(catalogue_manifest),
+                "revision": self.head,
+                "version": self.version,
+            }
+        )
+        for relative, value in catalogue_files.items():
+            self._write(f"catalogue/{relative}", value)
+        ledger = "".join(
+            f"{sha256(value)}  {relative}\n"
+            for relative, value in sorted(catalogue_files.items())
+        ).encode()
+        self._write("catalogue/CHECKSUMS.sha256", ledger)
+
+    def _build(self, output: Path | None = None) -> dict[str, Any]:
+        return PACKAGE.build_archive(
+            dist=self.dist,
+            output_dir=output or self.output,
+            source_commit=self.head,
+            repository="chris-page-gov/gis-ai-go",
+            version=self.version,
+            base_path="/gis-ai-go/",
+        )
+
+    def _verify(
+        self,
+        output: Path | None = None,
+        *,
+        source_commit: str | None = None,
+        expected_digest: str | None = None,
+    ) -> dict[str, Any]:
+        target = output or self.output
+        return VERIFY.verify_archive(
+            archive_path=target / "artifact.tar",
+            checksum_path=target / "artifact.tar.sha256",
+            receipt_path=target / "archive-receipt.json",
+            expected_source_commit=source_commit or self.head,
+            expected_repository="chris-page-gov/gis-ai-go",
+            expected_version=self.version,
+            expected_base_path="/gis-ai-go/",
+            expected_archive_sha256=expected_digest,
+        )
+
+    def _archive_files(self, output: Path | None = None) -> dict[str, bytes]:
+        target = output or self.output
+        with tarfile.open(target / "artifact.tar", mode="r:") as archive:
+            return {
+                member.name: archive.extractfile(member).read()  # type: ignore[union-attr]
+                for member in archive.getmembers()
+            }
+
+    def test_builds_and_verifies_exact_deterministic_outputs(self) -> None:
+        first = self._build()
+        second_output = self.root / "second"
+        second = self._build(second_output)
+        self.assertEqual(set(path.name for path in self.output.iterdir()), PACKAGE.OUTPUT_NAMES)
+        for name in sorted(PACKAGE.OUTPUT_NAMES):
+            self.assertEqual((self.output / name).read_bytes(), (second_output / name).read_bytes())
+        self.assertEqual(first, second)
+        verified = self._verify(expected_digest=first["archive"]["sha256"])
+        self.assertEqual(verified, first)
+        self.assertEqual(first["okfContentRootSha256"], self.content_root)
+
+    def test_archive_preserves_distribution_bytes_and_normalises_tar_metadata(self) -> None:
+        self._build()
+        source = PACKAGE.inventory_regular_files(self.dist)
+        archive_files = self._archive_files()
+        for path, value in source.items():
+            self.assertEqual(archive_files[path], value)
+        self.assertEqual(archive_files[".nojekyll"], b"")
+        with tarfile.open(self.output / "artifact.tar", mode="r:") as archive:
+            members = archive.getmembers()
+        self.assertEqual(
+            [member.name for member in members], sorted(member.name for member in members)
+        )
+        for member in members:
+            self.assertTrue(member.isfile())
+            self.assertEqual(member.type, tarfile.REGTYPE)
+            self.assertEqual((member.uid, member.gid, member.uname, member.gname), (0, 0, "", ""))
+            self.assertEqual((member.mode, member.mtime, member.pax_headers), (0o644, 0, {}))
+
+    def test_public_checksum_ledger_is_complete_fetchable_and_acyclic(self) -> None:
+        self._build()
+        files = self._archive_files()
+        rows = VERIFY.parse_checksum_ledger(
+            files["publication/CHECKSUMS.sha256"], "publication checksums"
+        )
+        ledger_paths = [row["path"] for row in rows]
+        self.assertNotIn(".nojekyll", ledger_paths)
+        self.assertNotIn("publication/CHECKSUMS.sha256", ledger_paths)
+        self.assertEqual(
+            ledger_paths,
+            sorted(set(files) - {".nojekyll", "publication/CHECKSUMS.sha256"}),
+        )
+        manifest = json.loads(files["publication/manifest.json"])
+        payload_paths = [item["path"] for item in manifest["payload"]["files"]]
+        self.assertIn(".nojekyll", payload_paths)
+        supporting_paths = [item["path"] for item in manifest["publicationFiles"]]
+        self.assertEqual(
+            supporting_paths,
+            [
+                "publication/provenance.json",
+                "publication/sbom.cdx.json",
+                "publication/site-receipt.json",
+            ],
+        )
+
+    def test_metadata_has_fixed_schemas_identity_and_no_wall_clock(self) -> None:
+        receipt = self._build()
+        files = self._archive_files()
+        manifest = json.loads(files["publication/manifest.json"])
+        provenance = json.loads(files["publication/provenance.json"])
+        site_receipt = json.loads(files["publication/site-receipt.json"])
+        sbom = json.loads(files["publication/sbom.cdx.json"])
+        self.assertEqual(receipt["schema"], "gis-ai-go.pages-archive-receipt.v1")
+        self.assertEqual(manifest["schema"], "gis-ai-go.pages-manifest.v1")
+        self.assertEqual(provenance["schema"], "gis-ai-go.pages-provenance.v1")
+        self.assertEqual(site_receipt["schema"], "gis-ai-go.pages-site-receipt.v1")
+        self.assertEqual((sbom["bomFormat"], sbom["specVersion"]), ("CycloneDX", "1.6"))
+        for document in (receipt, manifest, provenance, site_receipt):
+            self.assertEqual(document["repository"], "chris-page-gov/gis-ai-go")
+            self.assertEqual(document["sourceCommit"], self.head)
+            self.assertEqual(document["version"], self.version)
+            self.assertEqual(document["basePath"], "/gis-ai-go/")
+            self.assertEqual(
+                document["canonicalUrl"],
+                "https://chris-page-gov.github.io/gis-ai-go/",
+            )
+            serialised = json.dumps(document)
+            for forbidden in ("createdAt", "generatedAt", "publishedAt", "timestamp"):
+                self.assertNotIn(forbidden, serialised)
+        self.assertFalse(provenance["determinism"]["wallClockIncluded"])
+
+    def test_rejects_symbolic_link_in_distribution(self) -> None:
+        (self.dist / "assets" / "linked.js").symlink_to(self.dist / "assets" / "app.js")
+        with self.assertRaisesRegex(ValueError, "symbolic links"):
+            self._build()
+
+    def test_rejects_hard_link_in_distribution(self) -> None:
+        os.link(self.dist / "assets" / "app.js", self.dist / "assets" / "hard.js")
+        with self.assertRaisesRegex(ValueError, "hard-linked"):
+            self._build()
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires POSIX FIFO support")
+    def test_rejects_special_file_in_distribution(self) -> None:
+        os.mkfifo(self.dist / "assets" / "pipe")
+        with self.assertRaisesRegex(ValueError, "regular files only"):
+            self._build()
+
+    def test_rejects_historical_research_and_unexpected_files(self) -> None:
+        self._write("research/notes.txt", b"not for publication\n")
+        with self.assertRaisesRegex(ValueError, "forbidden"):
+            self._build()
+        (self.dist / "research" / "notes.txt").unlink()
+        (self.dist / "research").rmdir()
+        self._write("notes.txt", b"unexpected\n")
+        with self.assertRaisesRegex(ValueError, "inventory is not exact"):
+            self._build()
+
+    def test_rejects_catalogue_byte_change(self) -> None:
+        path = self.dist / "catalogue" / "okf-bundle.json"
+        path.write_bytes(path.read_bytes() + b" ")
+        with self.assertRaisesRegex(ValueError, "catalogue checksum mismatch"):
+            self._build()
+
+    def test_rejects_catalogue_revision_different_from_publication_source(self) -> None:
+        receipt_path = self.dist / "catalogue" / "build-receipt.json"
+        receipt = json.loads(receipt_path.read_bytes())
+        receipt["revision"] = "b" * 40
+        receipt_bytes = canonical_json(receipt)
+        receipt_path.write_bytes(receipt_bytes)
+        ledger_path = self.dist / "catalogue" / "CHECKSUMS.sha256"
+        rows = VERIFY.parse_checksum_ledger(ledger_path.read_bytes(), "catalogue checksums")
+        ledger_path.write_bytes(
+            "".join(
+                f"{sha256(receipt_bytes) if row['path'] == 'build-receipt.json' else row['sha256']}"
+                f"  {row['path']}\n"
+                for row in rows
+            ).encode()
+        )
+        with self.assertRaisesRegex(ValueError, "revision differs"):
+            self._build()
+
+    def test_rejects_output_directory_symlink(self) -> None:
+        target = self.root / "target"
+        target.mkdir()
+        self.output.symlink_to(target, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "output directory must be a real directory"):
+            self._build()
+        self.assertEqual(list(target.iterdir()), [])
+
+    def test_rejects_preexisting_output_symlink(self) -> None:
+        self.output.mkdir()
+        target = self.root / "outside.txt"
+        target.write_text("do not replace\n", encoding="utf-8")
+        (self.output / "artifact.tar").symlink_to(target)
+        with self.assertRaisesRegex(ValueError, "ordinary single-link file"):
+            self._build()
+        self.assertEqual(target.read_text(encoding="utf-8"), "do not replace\n")
+
+    def test_verifier_rejects_outer_file_symlink(self) -> None:
+        self._build()
+        real_checksum = self.root / "real-checksum"
+        (self.output / "artifact.tar.sha256").replace(real_checksum)
+        (self.output / "artifact.tar.sha256").symlink_to(real_checksum)
+        with self.assertRaisesRegex(ValueError, "ordinary single-link"):
+            self._verify()
+
+    def test_rejects_wrong_source_commit_and_digest(self) -> None:
+        receipt = self._build()
+        with self.assertRaisesRegex(ValueError, "sourceCommit"):
+            self._verify(source_commit="b" * 40)
+        with self.assertRaisesRegex(ValueError, "accepted artefact"):
+            self._verify(expected_digest="b" * 64)
+        self.assertNotEqual(receipt["archive"]["sha256"], "b" * 64)
+
+    def test_rejects_noncanonical_archive_even_with_coordinated_outer_files(self) -> None:
+        receipt = self._build()
+        archive_path = self.output / "artifact.tar"
+        archive_path.write_bytes(archive_path.read_bytes() + (b"\0" * 512))
+        altered = archive_path.read_bytes()
+        digest = sha256(altered)
+        checksum = f"{digest}  artifact.tar\n".encode()
+        (self.output / "artifact.tar.sha256").write_bytes(checksum)
+        receipt["archive"]["bytes"] = len(altered)
+        receipt["archive"]["sha256"] = digest
+        receipt["checksum"]["sha256"] = sha256(checksum)
+        (self.output / "archive-receipt.json").write_bytes(canonical_json(receipt))
+        with self.assertRaisesRegex(ValueError, "canonical deterministic"):
+            self._verify(expected_digest=digest)
+
+    def test_rejects_hard_link_tar_member(self) -> None:
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+            regular = tarfile.TarInfo("index.html")
+            regular.size = 1
+            regular.mode = 0o644
+            regular.mtime = 0
+            archive.addfile(regular, io.BytesIO(b"x"))
+            linked = tarfile.TarInfo("linked.html")
+            linked.type = tarfile.LNKTYPE
+            linked.linkname = "index.html"
+            linked.mode = 0o644
+            linked.mtime = 0
+            archive.addfile(linked)
+        with self.assertRaisesRegex(ValueError, "regular files only"):
+            VERIFY.read_archive(buffer.getvalue())
+
+    def test_cli_contract_builds_then_verifies(self) -> None:
+        package = subprocess.run(
+            [
+                "python3", "scripts/package_pages.py",
+                "--dist", str(self.dist),
+                "--output-dir", str(self.output),
+                "--source-commit", self.head,
+                "--repository", "chris-page-gov/gis-ai-go",
+                "--version", self.version,
+                "--base-path", "/gis-ai-go/",
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        receipt = json.loads((self.output / "archive-receipt.json").read_bytes())
+        verify = subprocess.run(
+            [
+                "python3", "scripts/verify_pages_archive.py",
+                "--archive", str(self.output / "artifact.tar"),
+                "--checksum", str(self.output / "artifact.tar.sha256"),
+                "--receipt", str(self.output / "archive-receipt.json"),
+                "--expected-source-commit", self.head,
+                "--expected-repository", "chris-page-gov/gis-ai-go",
+                "--expected-version", self.version,
+                "--expected-base-path", "/gis-ai-go/",
+                "--expected-archive-sha256", receipt["archive"]["sha256"],
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("Built deterministic Pages archive sha256=", package.stdout)
+        self.assertIn("Verified Pages archive sha256=", verify.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -177,7 +177,8 @@ class PagesWorkflowTests(unittest.TestCase):
         self.assertIn("'.payloadRootSha256'", PAGES_WORKFLOW)
         self.assertIn("'.publication.checksumsSha256'", PAGES_WORKFLOW)
         verification = PAGES_WORKFLOW.split("\n  public-verification:\n", 1)[1]
-        self.assertIn("ref: ${{ inputs.source_commit }}", verification)
+        self.assertEqual(PAGES_WORKFLOW.count("ref: ${{ github.sha }}"), 2)
+        self.assertNotIn("ref: ${{ inputs.source_commit }}", PAGES_WORKFLOW)
         self.assertIn("PUBLIC_BASE_URL: ${{ needs.deploy.outputs.page_url }}", verification)
         self.assertIn("EXPECTED_SOURCE_COMMIT: ${{ inputs.source_commit }}", verification)
         self.assertIn(

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+PAGES_WORKFLOW = (ROOT / ".github" / "workflows" / "pages.yml").read_text(
+    encoding="utf-8"
+)
+
+
+class PagesWorkflowTests(unittest.TestCase):
+    def test_every_external_action_is_pinned_to_a_full_commit(self) -> None:
+        for workflow_name, workflow in (
+            ("ci.yml", CI_WORKFLOW),
+            ("pages.yml", PAGES_WORKFLOW),
+        ):
+            uses = re.findall(r"^\s*uses:\s+([^@\s]+)@([^\s]+)", workflow, re.MULTILINE)
+            self.assertGreater(len(uses), 0, workflow_name)
+            for action, revision in uses:
+                with self.subTest(workflow=workflow_name, action=action):
+                    self.assertRegex(revision, r"^[0-9a-f]{40}$")
+
+    def test_workflows_default_to_no_token_permissions(self) -> None:
+        self.assertIn("\npermissions: {}\n", CI_WORKFLOW)
+        self.assertIn("\npermissions: {}\n", PAGES_WORKFLOW)
+
+        self.assertIn("\n    permissions:\n      contents: read\n", CI_WORKFLOW)
+        self.assertIn(
+            "\n    permissions:\n"
+            "      actions: read\n"
+            "      attestations: write\n"
+            "      contents: read\n"
+            "      id-token: write\n",
+            CI_WORKFLOW,
+        )
+        self.assertNotIn("contents: write", CI_WORKFLOW + PAGES_WORKFLOW)
+
+    def test_ci_publishes_pages_source_only_after_successful_main_assurance(self) -> None:
+        guard = (
+            "if: ${{ github.event_name == 'push' && "
+            "github.ref == 'refs/heads/main' && success() }}"
+        )
+        self.assertGreaterEqual(CI_WORKFLOW.count(guard), 3)
+        self.assertIn("name: pages-source-${{ github.sha }}", CI_WORKFLOW)
+        self.assertIn("if-no-files-found: error", CI_WORKFLOW)
+        self.assertIn("retention-days: 90", CI_WORKFLOW)
+
+        diagnostic = CI_WORKFLOW.split("- name: Upload generated evidence", 1)[1].split(
+            "\n\n  provenance:", 1
+        )[0]
+        self.assertIn("if: always()", diagnostic)
+        self.assertIn("!artifacts/pages/**", diagnostic)
+        self.assertNotIn("pages-source-${{ github.sha }}", diagnostic)
+
+    def test_ci_reverifies_and_attests_the_exact_archive(self) -> None:
+        provenance = CI_WORKFLOW.split("\n  provenance:\n", 1)[1]
+        self.assertIn("needs: assurance", provenance)
+        self.assertIn("actions: read", provenance)
+        self.assertIn("attestations: write", provenance)
+        self.assertIn("id-token: write", provenance)
+        self.assertIn("name: pages-source-${{ github.sha }}", provenance)
+        self.assertIn("scripts/verify_pages_archive.py", provenance)
+        self.assertIn(
+            "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
+            provenance,
+        )
+        self.assertIn("subject-path: artifacts/pages/artifact.tar", provenance)
+
+    def test_deployment_is_manual_and_has_the_exact_audit_inputs(self) -> None:
+        self.assertIn("\n  workflow_dispatch:\n", PAGES_WORKFLOW)
+        self.assertNotRegex(PAGES_WORKFLOW, r"(?m)^  (push|pull_request|schedule):")
+
+        inputs = PAGES_WORKFLOW.split("    inputs:\n", 1)[1].split(
+            "\npermissions: {}", 1
+        )[0]
+        names = re.findall(r"^      ([a-z][a-z0-9_]*):$", inputs, re.MULTILINE)
+        self.assertEqual(
+            names,
+            ["source_run_id", "source_commit", "archive_sha256", "mode", "reason"],
+        )
+        for name in names:
+            match = re.search(
+                rf"(?ms)^      {name}:\n(.*?)(?=^      [a-z][a-z0-9_]*:$|\Z)",
+                inputs,
+            )
+            self.assertIsNotNone(match)
+            self.assertIn("required: true", match.group(1))
+        self.assertRegex(
+            inputs,
+            r"options:\n\s+- deploy\n\s+- rollback\n\s+- restore",
+        )
+
+    def test_prepare_accepts_only_an_exact_successful_main_ci_artifact(self) -> None:
+        for assertion in (
+            "GITHUB_REF\" != 'refs/heads/main'",
+            'GITHUB_WORKFLOW_REF\" != \"$expected_workflow_ref\"',
+            "GITHUB_REF_PROTECTED\" != 'true'",
+            '.event == "push"',
+            '.status == "completed"',
+            '.conclusion == "success"',
+            '.head_branch == "main"',
+            ".head_sha == $source_commit",
+            '.path == ".github/workflows/ci.yml"',
+            ".repository.full_name == $repository",
+            ".head_repository.full_name == $repository",
+            'artifact_name="pages-source-${SOURCE_COMMIT}"',
+            "select(.name == $artifact_name and .expired == false)",
+            "^sha256:[0-9a-f]{64}$",
+        ):
+            with self.subTest(assertion=assertion):
+                self.assertIn(assertion, PAGES_WORKFLOW)
+
+        self.assertIn('[[ "$REASON" =~ [[:cntrl:]] ]]', PAGES_WORKFLOW)
+        self.assertIn("run-id: ${{ inputs.source_run_id }}", PAGES_WORKFLOW)
+        self.assertIn("name: pages-source-${{ inputs.source_commit }}", PAGES_WORKFLOW)
+        self.assertIn(
+            '--expected-archive-sha256 "$ARCHIVE_SHA256"', PAGES_WORKFLOW
+        )
+
+    def test_prepare_enforces_github_provenance_identity(self) -> None:
+        for flag in (
+            '--repo "$GITHUB_REPOSITORY"',
+            '--signer-workflow "$signer_workflow"',
+            '--signer-digest "$SOURCE_COMMIT"',
+            "--source-ref refs/heads/main",
+            '--source-digest "$SOURCE_COMMIT"',
+            "--deny-self-hosted-runners",
+        ):
+            with self.subTest(flag=flag):
+                self.assertIn(flag, PAGES_WORKFLOW)
+
+    def test_deploy_job_has_only_pages_deployment_authority(self) -> None:
+        deploy = PAGES_WORKFLOW.split("\n  deploy:\n", 1)[1].split(
+            "\n  public-verification:\n", 1
+        )[0]
+        self.assertIn("environment:\n      name: github-pages", deploy)
+        self.assertIn(
+            "permissions:\n      actions: read\n      id-token: write\n      pages: write",
+            deploy,
+        )
+        self.assertNotIn("contents:", deploy)
+        self.assertNotIn("attestations:", deploy)
+        self.assertIn("path: artifacts/pages/artifact.tar", deploy)
+        self.assertIn("name: github-pages", deploy)
+        self.assertIn("artifact_name: github-pages", deploy)
+        self.assertIn("sha256sum --check --strict artifact.tar.sha256", deploy)
+
+    def test_deployment_workflow_never_rebuilds_the_site(self) -> None:
+        for forbidden in (
+            "scripts/package_pages.py",
+            "pnpm run build",
+            "vite build",
+            "npm run build",
+            "actions/upload-pages-artifact",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, PAGES_WORKFLOW)
+
+    def test_public_acceptance_uses_exact_source_and_deployment_receipt_values(self) -> None:
+        self.assertIn(
+            "okf_content_root: ${{ steps.product.outputs.okf_content_root }}",
+            PAGES_WORKFLOW,
+        )
+        self.assertIn(
+            "payload_root: ${{ steps.product.outputs.payload_root }}",
+            PAGES_WORKFLOW,
+        )
+        self.assertIn(
+            "public_checksums_sha256: ${{ steps.product.outputs.public_checksums_sha256 }}",
+            PAGES_WORKFLOW,
+        )
+        self.assertIn("'.okfContentRootSha256'", PAGES_WORKFLOW)
+        self.assertIn("'.payloadRootSha256'", PAGES_WORKFLOW)
+        self.assertIn("'.publication.checksumsSha256'", PAGES_WORKFLOW)
+        verification = PAGES_WORKFLOW.split("\n  public-verification:\n", 1)[1]
+        self.assertIn("ref: ${{ inputs.source_commit }}", verification)
+        self.assertIn("PUBLIC_BASE_URL: ${{ needs.deploy.outputs.page_url }}", verification)
+        self.assertIn("EXPECTED_SOURCE_COMMIT: ${{ inputs.source_commit }}", verification)
+        self.assertIn(
+            "EXPECTED_VERSION: ${{ needs.prepare.outputs.product_version }}",
+            verification,
+        )
+        self.assertIn(
+            "EXPECTED_OKF_CONTENT_ROOT: ${{ needs.prepare.outputs.okf_content_root }}",
+            verification,
+        )
+        self.assertIn(
+            "EXPECTED_PAYLOAD_ROOT: ${{ needs.prepare.outputs.payload_root }}",
+            verification,
+        )
+        self.assertIn(
+            "EXPECTED_PUBLIC_CHECKSUMS_SHA256: "
+            "${{ needs.prepare.outputs.public_checksums_sha256 }}",
+            verification,
+        )
+        self.assertIn("EXPECTED_ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}", verification)
+        self.assertIn(
+            "pnpm --filter @gis-ai-go/public-explorer run test:public", verification
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- package the checked static Explorer once as a deterministic POSIX ustar archive;
- bind its source commit, version, OKF content root, complete inventory, checksums,
  provenance, site receipt and CycloneDX SBOM;
- attest the exact protected-main archive after full CI assurance;
- add a manual, least-privilege deploy/rollback/restore workflow that accepts only a
  successful `main` push run and redeploys the preserved tar without rebuilding;
- add live Pages acceptance for identity, every public checksum, reviewed discovery
  journeys, direct URLs/history, exact CSP, network boundary and accessibility;
- record ADR-0007, the operator runbook and candidate verification evidence.

## Why

DISC-104 is the publication gate for the `v0.1.0` discovery product. Build and
deployment must be separate so the public site is traceable to one reviewed archive
and rollback proves that retained bytes can be redeployed rather than merely that old
source still builds.

## Boundaries

- no repository-root or historical research viewer publication;
- no provider calls, server, credential, property row, protected data or real
  geometry;
- no automatic deployment from pull requests or ordinary pushes;
- Pages remains disabled until this change merges and the resulting protected-main
  archive and attestation pass.

## Validation

- complete `pnpm run check` gate passed;
- 17 archive and hostile-input contract tests passed;
- 10 workflow identity, permission, attestation and no-build contract tests passed;
- local canonical archive package and verifier round trip passed;
- local `/gis-ai-go/` deployment rehearsal passed all 4 public-browser tests;
- substituted payload and supporting-metadata tamper rehearsals were rejected by
  the outer-receipt-bound payload root and public checksum-ledger digest;
- exact external Action pins resolved against official GitHub tag refs;
- immutable research diff, local links, secrets/machine paths and `git diff --check`
  passed.

This implements the code and controls for #6. The issue remains open until the
protected-main artefact is deployed, publicly verified, rolled back and restored.
