### PR TITLE
fix(pages): use supported artifact transport

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -338,7 +338,6 @@ jobs:
           path: artifacts/pages/artifact.tar
           if-no-files-found: error
           retention-days: 1
-          compression-level: 0
 
       - name: Deploy unchanged Pages archive
         id: deployment

--- a/changelog.d/DISC-104.added.md
+++ b/changelog.d/DISC-104.added.md
@@ -1,2 +1,3 @@
 - Added checksum-bound, provenance-attested GitHub Pages publication with
   least-privilege deployment, live browser assurance and artefact-only rollback.
+- Used the standard compressed Actions transport around the unchanged attested tar.

--- a/docs/decisions/ADR-0007-immutable-pages-publication.md
+++ b/docs/decisions/ADR-0007-immutable-pages-publication.md
@@ -34,7 +34,8 @@ a manually dispatched workflow on `main` that must:
 2. download the named retained artefact rather than check out and rebuild the site;
 3. verify its declared SHA-256 digest, deterministic receipt and GitHub build
    provenance;
-4. upload that unchanged tar as the current `github-pages` artefact;
+4. upload that unchanged tar as the current `github-pages` artefact, using the
+   Actions service's standard compressed transport wrapper;
 5. deploy through the branch-restricted `github-pages` environment; and
 6. run the public-browser suite against the returned Pages URL.
 

--- a/docs/operations/DISC-104_RUNBOOK.md
+++ b/docs/operations/DISC-104_RUNBOOK.md
@@ -28,6 +28,8 @@ archive-receipt.json
 
 The tar contains only the generated site plus `.nojekyll` and the
 `publication/` manifest, checksums, provenance, site receipt and SBOM.
+The Actions service applies its standard compressed outer transport; this does not
+change the inner `artifact.tar` or its accepted SHA-256.
 
 ## First-time repository configuration
 

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -148,6 +148,7 @@ class PagesWorkflowTests(unittest.TestCase):
         self.assertIn("name: github-pages", deploy)
         self.assertIn("artifact_name: github-pages", deploy)
         self.assertIn("sha256sum --check --strict artifact.tar.sha256", deploy)
+        self.assertNotIn("compression-level: 0", deploy)
 
     def test_deployment_workflow_never_rebuilds_the_site(self) -> None:
         for forbidden in (


### PR DESCRIPTION
## What changed

- restore the default compressed Actions transport around the unchanged
  `artifact.tar` supplied to GitHub Pages;
- retain the exact inner tar digest, receipt, source identity and attestation;
- add a workflow regression and document the outer/inner archive boundary.

## Evidence

- deployment runs 32319998787 and 32320096985 both passed source-run, archive,
  receipt, digest and attestation validation, then failed only at Pages ingestion;
- the pinned official Pages upload action uses the same upload-artifact action with
  its default transport compression rather than level 0;
- 27 archive/workflow contract tests, link checks, secret/machine-path scan and
  `git diff --check` pass;
- independent archive-boundary review reports no P0-P2 findings.

## Boundary

This does not rebuild or alter the deployable tar. DISC-104 issue #6 remains open
until the accepted artefact is deployed, publicly verified, rolled back and restored.
