### PR TITLE
fix(publication): make Pages archive ingestible

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -61,8 +61,10 @@ reproducible GitHub Pages deployment.
 
 ## Current blockers
 
-- GitHub Pages stays disabled until the immutable publication workflow and
-  protected-main artefact pass their local and remote gates.
+- GitHub Pages is configured but has no successful deployment. Three accepted
+  artefacts reached Pages ingestion before its tar-header checks rejected
+  unprefixed, root-owned members; the canonical producer and verifier now carry the
+  compatibility correction, which needs protected-main evidence.
 - Protected PSGA and commercial deployments require separate rights, credentials
   and isolated infrastructure; they do not block the open product.
 
@@ -84,7 +86,7 @@ reproducible GitHub Pages deployment.
 - DISC-103 security review: the selected HMLR inputs and copied licence are
   independently bound to approved v0.3.0 digests, and coordinated source, rights,
   licence and lock mutations now fail closed;
-- DISC-104 local candidate: 17 archive and 10 workflow contract tests, the complete
+- DISC-104 local candidate: 20 archive and 10 workflow contract tests, the complete
   repository gate and 4 public-artefact browser tests pass; protected-main build,
   attestation, deployment and rollback evidence remain to be produced;
 - public repository: verified with personal `noreply` commit identity;

--- a/changelog.d/DISC-104-pages-ownership.fixed.md
+++ b/changelog.d/DISC-104-pages-ownership.fixed.md
@@ -1,0 +1,3 @@
+- Normalised Pages tar members to the required `./` root and a deterministic
+  non-root owner so GitHub can ingest the attested archive without changing its
+  publication bytes at deployment.

--- a/docs/decisions/ADR-0007-immutable-pages-publication.md
+++ b/docs/decisions/ADR-0007-immutable-pages-publication.md
@@ -23,8 +23,10 @@ for a successful push to protected `main`. The deterministic archive contains on
 the checked Explorer distribution, `.nojekyll` and publication metadata. It records
 the source commit, product version, `/gis-ai-go/` base path, canonical URL, OKF
 content root, complete file manifest, checksums, provenance, site receipt and
-CycloneDX SBOM. Tar paths, ownership, modes and modification times are normalised;
-wall-clock time is excluded.
+CycloneDX SBOM. Tar paths use the Pages-required `./` root, ownership uses a fixed
+non-root numeric identity, and modes and modification times are normalised;
+wall-clock time is excluded. The fixed identity describes archive transport only;
+it does not claim an operating-system account.
 
 Attest the exact tar archive in a separate successful-main job. Retain the tar,
 checksum and outer receipt together as `pages-source-<source-commit>`. Deployment is

--- a/docs/operations/DISC-104_RUNBOOK.md
+++ b/docs/operations/DISC-104_RUNBOOK.md
@@ -27,8 +27,10 @@ archive-receipt.json
 ```
 
 The tar contains only the generated site plus `.nojekyll` and the
-`publication/` manifest, checksums, provenance, site receipt and SBOM.
-The Actions service applies its standard compressed outer transport; this does not
+`publication/` manifest, checksums, provenance, site receipt and SBOM. Every member
+is stored below the explicit `./` root with deterministic non-root ownership, mode
+`0644` and epoch modification time, as checked by the independent verifier. The
+Actions service applies its standard compressed outer transport; this does not
 change the inner `artifact.tar` or its accepted SHA-256.
 
 ## First-time repository configuration

--- a/docs/operations/DISC-104_VERIFICATION.md
+++ b/docs/operations/DISC-104_VERIFICATION.md
@@ -31,35 +31,70 @@ Before merge, record:
 - complete repository assurance and CodeQL at the pull-request head; and
 - independent review of the archive, workflow and public-browser boundaries.
 
-The complete local candidate gate passed on 20 August 2026 against the uncommitted
-DISC-104 candidate based on protected `main` at
-`e5a522ee17f3a0a6f5857245c5ae3acd767efc25`:
+The complete local candidate gate most recently passed on 20 August 2026 against
+the Pages compatibility candidate based on protected `main` at
+`8e48e68ed6f072be22d46cc866dac947a7a71a4d`:
 
-- 17 deterministic archive and hostile-input contract tests;
+- 20 deterministic archive and hostile-input contract tests;
 - 10 workflow event, identity, provenance, permission and no-build deployment
   contract tests;
 - 4 gateway tests, 16 Explorer build-policy tests, 42 Explorer unit and component
-  tests, 58 repository Python tests and 2 execution-boundary tests;
+  tests, 61 repository Python tests and 2 execution-boundary tests;
 - 25 existing local real-browser journeys;
 - 8 schemas and 53 evaluation records, 289 local links, 183 immutable research
   hashes, 2 source-ledger snapshots and 71 source identifiers;
-- 442 text files scanned without a baseline secret or machine-path match;
+- 443 text files scanned without a baseline secret or machine-path match;
 - 9 rendered diagrams and a 145-component repository CycloneDX SBOM.
 
-The candidate packager and verifier reproduced uncompressed canonical POSIX ustar
-archive SHA-256
+Before the Pages header compatibility correction, packager and verifier contract
+`1.0.0` reproduced uncompressed canonical POSIX ustar archive SHA-256
 `aca0decf3637e836e0818619456deec75601b0a99475ca6d71b17a23c8fc0f31`
 and payload root
 `9b0f95f52bc77f45924a767cf774f70e9806b5b10b0ccbe0e460701e3e05ee55`
 from merged source commit `e5a522e` and OKF content root
 `c3fdadf975194580d1f659e7f3f3b609099b720129b9d8149801115f659c4040`.
-This is a local rehearsal identity, not the future protected-main publication
-artefact. The archive was extracted under the `/gis-ai-go/` mount and the separate
-public suite passed all 4 identity, accepted-manifest payload, trusted-ledger checksum,
-reviewed-journey, history, network, CSP, accessibility and 320 CSS-pixel tests.
+This is a historical local rehearsal identity, not a compatible protected-main
+publication artefact. The archive was extracted under the `/gis-ai-go/` mount and
+the separate public suite passed all 4 identity, accepted-manifest payload,
+trusted-ledger checksum, reviewed-journey, history, network, CSP, accessibility and
+320 CSS-pixel tests.
 
 All nine external Action pins were independently resolved against their official
 GitHub tag refs; the annotated pnpm tag was dereferenced to its exact commit.
+
+## Pages ingestion compatibility evidence
+
+The first three deployment attempts stopped after validation, provenance,
+configuration and artefact staging had passed:
+
+- runs
+  [`32319998787`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32319998787)
+  and
+  [`32320096985`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32320096985)
+  selected the artefact from source commit `9ff1281`;
+- run
+  [`32320645861`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32320645861)
+  selected the artefact from source commit `8e48e68` after restoring the standard
+  compressed Actions transport;
+- all three reached `actions/deploy-pages`, created a Pages deployment and then
+  returned GitHub's generic `deployment_failed` state; public verification was
+  correctly skipped.
+
+The exact staged archive from the third run retained SHA-256
+`d151284c48467c7420f37c1bca7a99619c3230711a0c5d6a9162f7f12c8ac573`.
+It contained 57 regular members, but all member paths omitted the required `./`
+root and all used numeric owner and group `0`. GitHub's Pages maintainer documents
+the `./` prefix as an intentional ingestion requirement in
+[`actions/deploy-pages` issue 203](https://github.com/actions/deploy-pages/issues/203#issuecomment-1652804586),
+and the same tracker documents root-owned members as a cause of the opaque failure
+in
+[`actions/deploy-pages` issue 58](https://github.com/actions/deploy-pages/issues/58#issuecomment-1367490639).
+
+Packager and verifier contract `1.0.1` therefore requires `./` member paths and
+fixed non-root numeric ownership. Regressions reject an unprefixed path and a
+root-owned member. The deployment job still cannot rebuild or repackage an accepted
+archive; a fresh protected-main build and attestation are required before another
+dispatch.
 
 ## Protected-main source evidence
 

--- a/scripts/package_pages.py
+++ b/scripts/package_pages.py
@@ -21,7 +21,11 @@ ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_REPOSITORY = "chris-page-gov/gis-ai-go"
 EXPECTED_BASE_PATH = "/gis-ai-go/"
 CANONICAL_URL = "https://chris-page-gov.github.io/gis-ai-go/"
-BUILDER_VERSION = "1.0.0"
+BUILDER_VERSION = "1.0.1"
+ARCHIVE_UID = 1000
+ARCHIVE_GID = 1000
+ARCHIVE_USER_NAME = ""
+ARCHIVE_GROUP_NAME = ""
 MAX_FILE_BYTES = 32 * 1024 * 1024
 MAX_TOTAL_BYTES = 128 * 1024 * 1024
 MAX_FILES = 10_000
@@ -347,13 +351,16 @@ def deterministic_tar(files: dict[str, bytes]) -> bytes:
             if path != ".nojekyll" and not path.startswith("publication/"):
                 safe_relative_path(path)
             value = files[path]
-            member = tarfile.TarInfo(path)
+            # Pages ingestion requires every member to use an explicit ./ root.
+            member = tarfile.TarInfo(f"./{path}")
             member.size = len(value)
             member.mode = 0o644
-            member.uid = 0
-            member.gid = 0
-            member.uname = ""
-            member.gname = ""
+            # GitHub Pages rejects root-owned tar members during ingestion. Keep
+            # ownership deterministic, but deliberately non-privileged.
+            member.uid = ARCHIVE_UID
+            member.gid = ARCHIVE_GID
+            member.uname = ARCHIVE_USER_NAME
+            member.gname = ARCHIVE_GROUP_NAME
             member.mtime = 0
             member.type = tarfile.REGTYPE
             archive.addfile(member, io.BytesIO(value))
@@ -406,10 +413,10 @@ def build_archive(
             "determinism": {
                 "archiveFormat": "POSIX ustar",
                 "pathOrder": "lexicographic UTF-8 publication path",
-                "uid": 0,
-                "gid": 0,
-                "userName": "",
-                "groupName": "",
+                "uid": ARCHIVE_UID,
+                "gid": ARCHIVE_GID,
+                "userName": ARCHIVE_USER_NAME,
+                "groupName": ARCHIVE_GROUP_NAME,
                 "fileMode": "0644",
                 "modificationTime": 0,
                 "wallClockIncluded": False,

--- a/scripts/verify_pages_archive.py
+++ b/scripts/verify_pages_archive.py
@@ -29,6 +29,10 @@ MAX_FILES = 10_010
 MAX_METADATA_BYTES = 2 * 1024 * 1024
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
 COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+ARCHIVE_UID = 1000
+ARCHIVE_GID = 1000
+ARCHIVE_USER_NAME = ""
+ARCHIVE_GROUP_NAME = ""
 
 
 def sha256_bytes(value: bytes) -> str:
@@ -61,7 +65,13 @@ def safe_archive_path(value: str) -> str:
     logical = PurePosixPath(value)
     if (
         not value
+        or value in {".", ".."}
         or value.startswith("/")
+        or value.startswith("./")
+        or value.endswith("/")
+        or "//" in value
+        or "/./" in value
+        or value.endswith("/.")
         or "\\" in value
         or "\0" in value
         or logical.is_absolute()
@@ -83,6 +93,14 @@ def safe_archive_path(value: str) -> str:
     if hidden and value not in {".nojekyll", "catalogue/.explorer-generated"}:
         raise ValueError(f"unexpected hidden archive path: {value}")
     return value
+
+
+def logical_tar_member_path(value: str) -> str:
+    """Return the logical publication path from the exact Pages tar form."""
+    if not value.startswith("./"):
+        raise ValueError(f"archive member must start with './': {value!r}")
+    logical = value[2:]
+    return safe_archive_path(logical)
 
 
 def parse_checksum_ledger(value: bytes, label: str) -> list[dict[str, str]]:
@@ -134,13 +152,13 @@ def deterministic_tar(files: dict[str, bytes]) -> bytes:
     with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
         for path in sorted(files):
             value = files[path]
-            member = tarfile.TarInfo(path)
+            member = tarfile.TarInfo(f"./{path}")
             member.size = len(value)
             member.mode = 0o644
-            member.uid = 0
-            member.gid = 0
-            member.uname = ""
-            member.gname = ""
+            member.uid = ARCHIVE_UID
+            member.gid = ARCHIVE_GID
+            member.uname = ARCHIVE_USER_NAME
+            member.gname = ARCHIVE_GROUP_NAME
             member.mtime = 0
             member.type = tarfile.REGTYPE
             archive.addfile(member, io.BytesIO(value))
@@ -154,22 +172,25 @@ def read_archive(value: bytes) -> dict[str, bytes]:
             members = archive.getmembers()
             if len(members) > MAX_FILES:
                 raise ValueError(f"archive exceeds {MAX_FILES} members")
-            paths = [member.name for member in members]
+            paths = [logical_tar_member_path(member.name) for member in members]
             if paths != sorted(paths) or len(paths) != len(set(paths)):
                 raise ValueError("archive paths must be unique and sorted")
-            for member in members:
-                path = safe_archive_path(member.name)
+            for member, path in zip(members, paths, strict=True):
                 if member.type != tarfile.REGTYPE or not member.isfile():
                     raise ValueError(f"archive must contain regular files only: {path}")
                 if member.linkname:
                     raise ValueError(f"archive member must not link elsewhere: {path}")
                 if member.pax_headers:
                     raise ValueError(f"archive must not contain PAX metadata: {path}")
+                if member.uid == 0 or member.gid == 0:
+                    raise ValueError(
+                        f"archive member must use normalised non-root ownership: {path}"
+                    )
                 if (
-                    member.uid != 0
-                    or member.gid != 0
-                    or member.uname != ""
-                    or member.gname != ""
+                    member.uid != ARCHIVE_UID
+                    or member.gid != ARCHIVE_GID
+                    or member.uname != ARCHIVE_USER_NAME
+                    or member.gname != ARCHIVE_GROUP_NAME
                     or member.mode != 0o644
                     or member.mtime != 0
                 ):
@@ -508,7 +529,7 @@ def verify_archive(
         label="publication provenance",
     )
     if require_keys(provenance["builder"], {"name", "version"}, "provenance builder") != {
-        "name": "scripts/package_pages.py", "version": "1.0.0"
+        "name": "scripts/package_pages.py", "version": "1.0.1"
     }:
         raise ValueError("publication provenance builder is not recognised")
     source = require_keys(
@@ -560,7 +581,9 @@ def verify_archive(
     )
     if determinism != {
         "archiveFormat": "POSIX ustar", "pathOrder": "lexicographic UTF-8 publication path",
-        "uid": 0, "gid": 0, "userName": "", "groupName": "", "fileMode": "0644",
+        "uid": ARCHIVE_UID, "gid": ARCHIVE_GID,
+        "userName": ARCHIVE_USER_NAME, "groupName": ARCHIVE_GROUP_NAME,
+        "fileMode": "0644",
         "modificationTime": 0, "wallClockIncluded": False,
     }:
         raise ValueError("publication provenance determinism contract differs")

--- a/tests/contract/test_pages_publication.py
+++ b/tests/contract/test_pages_publication.py
@@ -134,11 +134,14 @@ class PagesPublicationContractTests(unittest.TestCase):
 
     def _archive_files(self, output: Path | None = None) -> dict[str, bytes]:
         target = output or self.output
+        files: dict[str, bytes] = {}
         with tarfile.open(target / "artifact.tar", mode="r:") as archive:
-            return {
-                member.name: archive.extractfile(member).read()  # type: ignore[union-attr]
-                for member in archive.getmembers()
-            }
+            for member in archive.getmembers():
+                handle = archive.extractfile(member)
+                if handle is None:
+                    self.fail(f"archive member cannot be read: {member.name}")
+                files[VERIFY.logical_tar_member_path(member.name)] = handle.read()
+        return files
 
     def test_builds_and_verifies_exact_deterministic_outputs(self) -> None:
         first = self._build()
@@ -162,12 +165,23 @@ class PagesPublicationContractTests(unittest.TestCase):
         with tarfile.open(self.output / "artifact.tar", mode="r:") as archive:
             members = archive.getmembers()
         self.assertEqual(
-            [member.name for member in members], sorted(member.name for member in members)
+            [member.name for member in members],
+            [f"./{path}" for path in sorted(archive_files)],
         )
         for member in members:
             self.assertTrue(member.isfile())
             self.assertEqual(member.type, tarfile.REGTYPE)
-            self.assertEqual((member.uid, member.gid, member.uname, member.gname), (0, 0, "", ""))
+            self.assertEqual(
+                (member.uid, member.gid, member.uname, member.gname),
+                (
+                    PACKAGE.ARCHIVE_UID,
+                    PACKAGE.ARCHIVE_GID,
+                    PACKAGE.ARCHIVE_USER_NAME,
+                    PACKAGE.ARCHIVE_GROUP_NAME,
+                ),
+            )
+            self.assertNotEqual(member.uid, 0)
+            self.assertNotEqual(member.gid, 0)
             self.assertEqual((member.mode, member.mtime, member.pax_headers), (0o644, 0, {}))
 
     def test_public_checksum_ledger_is_complete_fetchable_and_acyclic(self) -> None:
@@ -206,6 +220,10 @@ class PagesPublicationContractTests(unittest.TestCase):
         self.assertEqual(receipt["schema"], "gis-ai-go.pages-archive-receipt.v1")
         self.assertEqual(manifest["schema"], "gis-ai-go.pages-manifest.v1")
         self.assertEqual(provenance["schema"], "gis-ai-go.pages-provenance.v1")
+        self.assertEqual(
+            provenance["builder"],
+            {"name": "scripts/package_pages.py", "version": "1.0.1"},
+        )
         self.assertEqual(site_receipt["schema"], "gis-ai-go.pages-site-receipt.v1")
         self.assertEqual((sbom["bomFormat"], sbom["specVersion"]), ("CycloneDX", "1.6"))
         for document in (receipt, manifest, provenance, site_receipt):
@@ -323,19 +341,62 @@ class PagesPublicationContractTests(unittest.TestCase):
     def test_rejects_hard_link_tar_member(self) -> None:
         buffer = io.BytesIO()
         with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
-            regular = tarfile.TarInfo("index.html")
+            regular = tarfile.TarInfo("./index.html")
             regular.size = 1
             regular.mode = 0o644
+            regular.uid = VERIFY.ARCHIVE_UID
+            regular.gid = VERIFY.ARCHIVE_GID
             regular.mtime = 0
             archive.addfile(regular, io.BytesIO(b"x"))
-            linked = tarfile.TarInfo("linked.html")
+            linked = tarfile.TarInfo("./linked.html")
             linked.type = tarfile.LNKTYPE
-            linked.linkname = "index.html"
+            linked.linkname = "./index.html"
             linked.mode = 0o644
+            linked.uid = VERIFY.ARCHIVE_UID
+            linked.gid = VERIFY.ARCHIVE_GID
             linked.mtime = 0
             archive.addfile(linked)
         with self.assertRaisesRegex(ValueError, "regular files only"):
             VERIFY.read_archive(buffer.getvalue())
+
+    def test_rejects_root_owned_tar_member(self) -> None:
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+            member = tarfile.TarInfo("./index.html")
+            member.size = 1
+            member.mode = 0o644
+            member.uid = 0
+            member.gid = 0
+            member.mtime = 0
+            archive.addfile(member, io.BytesIO(b"x"))
+        with self.assertRaisesRegex(ValueError, "non-root ownership"):
+            VERIFY.read_archive(buffer.getvalue())
+
+    def test_rejects_tar_member_without_pages_root_prefix(self) -> None:
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+            member = tarfile.TarInfo("index.html")
+            member.size = 1
+            member.mode = 0o644
+            member.uid = VERIFY.ARCHIVE_UID
+            member.gid = VERIFY.ARCHIVE_GID
+            member.mtime = 0
+            archive.addfile(member, io.BytesIO(b"x"))
+        with self.assertRaisesRegex(ValueError, "must start with './'"):
+            VERIFY.read_archive(buffer.getvalue())
+
+    def test_rejects_noncanonical_or_traversing_pages_member_paths(self) -> None:
+        for value in (
+            "./../index.html",
+            "././index.html",
+            ".//index.html",
+            "./assets//app.js",
+            "./assets/./app.js",
+            "./assets/",
+            "./.",
+        ):
+            with self.subTest(value=value), self.assertRaisesRegex(ValueError, "unsafe"):
+                VERIFY.logical_tar_member_path(value)
 
     def test_cli_contract_builds_then_verifies(self) -> None:
         package = subprocess.run(


### PR DESCRIPTION
## Outcome

Make the immutable GIS AI GO Pages archive compatible with GitHub's ingestion
contract without rebuilding or repackaging it during deployment.

Closes no issue; advances #6.

## Root cause

Three deployment runs passed source, digest, receipt, provenance, configuration and
staging checks, then failed at Pages ingestion. The exact staged tar used bare member
paths and root ownership. GitHub's Pages maintainer requires the `./` member root and
documents root-owned members as a cause of the same opaque failure.

## Changes

- emit canonical POSIX ustar members as `./<logical-path>`;
- use deterministic non-root uid/gid `1000/1000` while retaining mode `0644` and
  epoch modification time;
- independently require and reconstruct the exact same archive contract;
- reject missing prefixes, root ownership, traversal and non-canonical paths;
- bump the packager contract to `1.0.1` and record the failed-run evidence;
- retain the standard compressed Actions wrapper and unchanged-tar deployment.

## Verification

- `pnpm run check` — pass;
- 20 archive plus 10 workflow contract tests — pass;
- 25 local Playwright journeys — pass;
- links, immutable research hashes, source ledgers and secret scan — pass;
- independent archive review — ship, no P0–P2 findings.

## Publication boundary

This pull request does not deploy the site. After merge, protected-main CI must
build and attest a fresh archive; only that exact digest may be dispatched to Pages.
