### PR TITLE
fix(pages): use supported verified payload transport

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -290,8 +290,33 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
+      - name: Materialise verified Pages payload
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          mkdir -p deployment-staging
+          uv run --locked --cache-dir .uv-cache python scripts/stage_pages_payload.py \
+            --archive artifacts/pages/artifact.tar \
+            --checksum artifacts/pages/artifact.tar.sha256 \
+            --receipt artifacts/pages/archive-receipt.json \
+            --output-dir deployment-staging/site \
+            --expected-source-commit "$SOURCE_COMMIT" \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-version "$(tr -d '\r\n' < VERSION)" \
+            --expected-base-path /gis-ai-go/ \
+            --expected-archive-sha256 "$ARCHIVE_SHA256"
+
+      - name: Stage verified payload for GitHub Pages
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          name: github-pages
+          path: deployment-staging/site
+          retention-days: 1
+          include-hidden-files: true
+
   deploy:
-    name: Deploy preserved archive
+    name: Deploy verified Pages payload
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -305,41 +330,10 @@ jobs:
     outputs:
       page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Download exact CI artefact again
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
-          name: pages-source-${{ inputs.source_commit }}
-          path: artifacts/pages
-          github-token: ${{ github.token }}
-
-      - name: Recheck preserved archive digest
-        env:
-          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
-        run: |
-          actual_sha256="$(sha256sum artifacts/pages/artifact.tar | cut -d ' ' -f 1)"
-          if [[ "$actual_sha256" != "$ARCHIVE_SHA256" ]]; then
-            echo 'The redeployed archive digest differs from the accepted digest' >&2
-            exit 1
-          fi
-          (
-            cd artifacts/pages
-            sha256sum --check --strict artifact.tar.sha256
-          )
-
       - name: Confirm Pages configuration
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - name: Stage unchanged Pages archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: github-pages
-          path: artifacts/pages/artifact.tar
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Deploy unchanged Pages archive
+      - name: Deploy verified Pages payload
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,7 +36,7 @@ Start every implementation task by reading, in order:
 Stage 0 is complete at commit `983b1a102aa8038c9f50ae1b1894315c3ae0b89f`.
 The canonical OKF build, accessible static Explorer and reviewed public examples
 are merged through `DISC-101`, `DISC-102` and `DISC-103`; protected `main` is at
-`e5a522ee17f3a0a6f5857245c5ae3acd767efc25`. The Explorer is a functional static
+`eced0ae697818b4989ebe95c5bf1572cc6ec90c2`. The Explorer is a functional static
 candidate in repository and CI, but it is not deployed. There is no MCP listener,
 live provider adapter, policy engine, identity integration or evidence store.
 
@@ -45,8 +45,12 @@ The owner has authorised autonomous implementation in the open under
 outcome is the `v0.1.0` public discovery product. The repository is public under the
 owner's personal `chris-page-gov` account. Pull-request assurance, security controls
 and branch protection govern development on `main`. The active outcome is
-`DISC-104`: package the validated static product as an immutable artefact, deploy it
-through GitHub Pages, verify it publicly and prove rollback without rebuilding.
+`DISC-104`: retain the validated static product as an immutable, attested source
+artefact; safely recheck and stage its exact logical files through GitHub's pinned
+official Pages transport; verify the public result; and prove rollback without
+rebuilding the product. Four custom-tar deployments have failed closed at Pages
+ingestion. If the supported official transport also fails, stop changes and
+escalate the recorded evidence to GitHub Support.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -61,18 +61,20 @@ reproducible GitHub Pages deployment.
 
 ## Current blockers
 
-- GitHub Pages is configured but has no successful deployment. Three accepted
-  artefacts reached Pages ingestion before its tar-header checks rejected
-  unprefixed, root-owned members; the canonical producer and verifier now carry the
-  compatibility correction, which needs protected-main evidence.
+- GitHub Pages is configured but has no successful deployment. Four verified
+  deployment attempts reached Pages ingestion and failed closed, including the
+  corrected deterministic tar from protected `main` at `eced0ae`. The active
+  candidate retains that tar as attested source evidence, safely materialises and
+  rechecks its exact files, then uses GitHub's pinned official Pages transport. If
+  that supported path fails, deployment stops for escalation to GitHub Support.
 - Protected PSGA and commercial deployments require separate rights, credentials
   and isolated infrastructure; they do not block the open product.
 
 ## Latest evidence
 
-- canonical OKF content, Explorer and reviewed public examples: merged on protected
-  `main` at `e5a522e`;
-- main assurance and CodeQL: passing at `e5a522e` on 20 August 2026;
+- canonical OKF content, Explorer, reviewed public examples and the corrected
+  source-archive contract: merged on protected `main` at `eced0ae`;
+- main assurance, provenance and CodeQL: passing at `eced0ae` on 20 August 2026;
 - Explorer assurance includes
   16 build-policy tests, 42 unit and component tests, 25 browser journeys and
   production integrity checks;
@@ -86,9 +88,15 @@ reproducible GitHub Pages deployment.
 - DISC-103 security review: the selected HMLR inputs and copied licence are
   independently bound to approved v0.3.0 digests, and coordinated source, rights,
   licence and lock mutations now fail closed;
-- DISC-104 local candidate: 20 archive and 10 workflow contract tests, the complete
-  repository gate and 4 public-artefact browser tests pass; protected-main build,
-  attestation, deployment and rollback evidence remain to be produced;
+- DISC-104 supported-transport candidate: the complete local gate passes with 27
+  archive and staging contracts, 11 workflow contracts, 69 repository Python
+  tests, 25 browser journeys and the full integrity, link, secret, diagram and SBOM
+  checks;
+- DISC-104 protected-main source evidence: run `32322035483` built and attested
+  archive SHA-256 `b20ba6cab1811b976417aef6ca4c61bc33270063d7646ab8469e3273399edd11`;
+- DISC-104 transport candidate: the independently verified source files are staged
+  without rebuilding and passed to the pinned official GitHub Pages uploader;
+  candidate assurance, deployment and rollback evidence remain to be produced;
 - public repository: verified with personal `noreply` commit identity;
 - deployed product: none;
 - latest supported release: none.

--- a/changelog.d/DISC-104.added.md
+++ b/changelog.d/DISC-104.added.md
@@ -1,3 +1,4 @@
 - Added checksum-bound, provenance-attested GitHub Pages publication with
   least-privilege deployment, live browser assurance and artefact-only rollback.
-- Used the standard compressed Actions transport around the unchanged attested tar.
+- Retained the immutable attested source archive while safely materialising and
+  rechecking its exact product bytes for GitHub's pinned official Pages transport.

--- a/docs/decisions/ADR-0007-immutable-pages-publication.md
+++ b/docs/decisions/ADR-0007-immutable-pages-publication.md
@@ -1,6 +1,6 @@
 # ADR-0007: Immutable GitHub Pages publication
 
-- status: accepted
+- status: partially superseded by ADR-0008
 - decided on: 20 August 2026
 - work item: DISC-104
 
@@ -70,3 +70,8 @@ decision does not claim `frame-ancestors` or other header-only controls.
   path and is not authorised by this workflow;
 - a change to archive format or publication identity requires a new ADR version or
   superseding decision and new rollback evidence.
+
+ADR-0008 supersedes only the unchanged-tar transport decision in step 4. The
+protected Pages environment in step 5 and the deterministic source archive,
+attestation, manual selection, public verification and rollback requirements remain
+in force.

--- a/docs/decisions/ADR-0008-supported-pages-transport.md
+++ b/docs/decisions/ADR-0008-supported-pages-transport.md
@@ -1,0 +1,69 @@
+# ADR-0008: Supported Pages transport from verified payload
+
+- status: accepted
+- decided on: 20 August 2026
+- work item: DISC-104
+- supersedes: ADR-0007 deployment transport step 4
+
+## Context
+
+ADR-0007 deliberately separated the attested publication archive from deployment
+authority. Four dispatches verified the selected source run, commit, archive digest,
+receipt, provenance and Pages configuration, then failed closed during GitHub Pages
+ingestion. The fourth run proved that the exact corrected POSIX ustar reached Pages
+with `./` paths, non-root ownership, regular files only and no links or special
+members. GitHub still returned only `deployment_failed`.
+
+GitHub identifies its pinned `actions/upload-pages-artifact` action as the Pages
+packaging implementation reference. That action creates a native GNU tar from a
+directory before uploading the current-run `github-pages` artefact. Continuing to
+guess undocumented tar-header details would weaken the evidence boundary without
+providing a supported result.
+
+## Decision
+
+Retain three distinct and explicitly named layers:
+
+1. **Attested source archive** — protected-main CI builds the deterministic
+   `artifact.tar`, checksum and receipt once. The exact tar digest is retained and
+   attested as `pages-source-<source-commit>`.
+2. **Verified logical payload** — the manual workflow revalidates the source run,
+   archive, receipt and GitHub provenance, then safely materialises its already
+   verified regular files into a new empty directory. It rejects traversal, links,
+   special files, pre-existing output and any inventory or byte mismatch.
+3. **GitHub Pages transport** — the same successful prepare job passes only that
+   verified directory to the exact commit-pinned official
+   `actions/upload-pages-artifact` action, including the two allowlisted hidden
+   files. GitHub creates the platform transport tar. The protected deploy job only
+   configures Pages and deploys that current-run artefact.
+
+The workflow must not run the Explorer build, edit a publication file or treat the
+platform tar as the attested source archive. The dispatch `archive_sha256` remains
+the SHA-256 of the retained source archive. Public verification must still fetch and
+hash the complete served payload and supporting publication metadata against roots
+and digests from the independently verified source receipt.
+
+Rollback and restore select retained accepted source archives. They rematerialise
+the exact same logical publication bytes and create a new supported platform
+transport envelope; they do not rebuild the product. Therefore, the Pages transport
+tar digest may differ between deployments while the selected source archive digest,
+payload root, publication checksums, source commit and product version remain exact.
+
+If the exact pinned official transport also fails ingestion, stop changing archive
+formats and escalate the recorded run, deployment and artefact identities to GitHub
+Support.
+
+## Consequences
+
+- the public URL remains traceable to one attested source archive and its complete
+  verified logical payload;
+- the workflow describes the platform tar as a transport envelope, not immutable
+  product evidence;
+- upload happens only after all source gates pass and before the separate
+  least-privilege deployment job;
+- allowlisted hidden files are retained without exposing `.git`, `.github` or any
+  unverified file;
+- public verification remains the final proof that GitHub served the selected
+  accepted bytes; and
+- ADR-0007's build, attestation, selection, security and rollback principles remain
+  accepted except for its unchanged-tar transport claim.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,6 +11,7 @@ research recommendations remain unchanged in the preserved pack at
 - [ADR-0005: Static public Explorer](ADR-0005-static-public-explorer.md)
 - [ADR-0006: Reviewed public geospatial examples](ADR-0006-reviewed-public-geospatial-examples.md)
 - [ADR-0007: Immutable GitHub Pages publication](ADR-0007-immutable-pages-publication.md)
+- [ADR-0008: Supported Pages transport from verified payload](ADR-0008-supported-pages-transport.md)
 
 Research decisions D01–D19 are accepted as constraints for building and evaluating
 Stage 0, not as blanket authority for later production stages. Research decision D20

--- a/docs/operations/DISC-104_RUNBOOK.md
+++ b/docs/operations/DISC-104_RUNBOOK.md
@@ -26,12 +26,19 @@ artifact.tar.sha256
 archive-receipt.json
 ```
 
-The tar contains only the generated site plus `.nojekyll` and the
+The source tar contains only the generated site plus `.nojekyll` and the
 `publication/` manifest, checksums, provenance, site receipt and SBOM. Every member
 is stored below the explicit `./` root with deterministic non-root ownership, mode
-`0644` and epoch modification time, as checked by the independent verifier. The
-Actions service applies its standard compressed outer transport; this does not
-change the inner `artifact.tar` or its accepted SHA-256.
+`0644` and epoch modification time, as checked by the independent verifier. This
+attested tar is immutable source evidence; it is not the GitHub-generated Pages
+transport tar.
+
+After all source checks pass, the workflow safely materialises the exact logical
+files into a new empty directory and byte-compares the result. The exact pinned
+official `actions/upload-pages-artifact` action then creates GitHub's supported
+transport envelope. This changes no publication file, payload root, source archive
+digest or receipt, but the platform transport tar may have a different digest on
+each deployment.
 
 ## First-time repository configuration
 
@@ -82,10 +89,12 @@ gh workflow run pages.yml \
   -f reason='Initial v0.1.0 public discovery deployment'
 ```
 
-The workflow validates the source run, archive and attestation before the
-`github-pages` environment is entered. It then deploys the unchanged tar and runs
-the public Playwright suite against the URL returned by GitHub Pages. A failed
-public check is a failed deployment gate even if Pages accepted the bytes.
+The workflow validates the source run, archive and attestation, materialises and
+rechecks its exact logical bytes, then creates the current-run `github-pages`
+transport with GitHub's pinned official action. The separate protected environment
+deploys that transport and the public Playwright suite checks the URL returned by
+GitHub Pages. A failed public check is a failed deployment gate even if Pages
+accepted the bytes.
 
 Record the workflow run, deployment ID, public URL, source run and commit, archive
 digest, attestation URL, version, OKF root and public-test result.
@@ -99,7 +108,7 @@ site; A is its accepted predecessor.
 2. Dispatch the same workflow with A's identities, `mode=rollback` and a clear
    reason.
 3. Confirm the public receipt now identifies A and the complete public suite passes.
-4. Reverify B without rebuilding it.
+4. Reverify B without rebuilding the product.
 5. Dispatch B with `mode=restore` and a clear reason.
 6. Confirm the public receipt identifies B and the complete public suite passes.
 
@@ -110,7 +119,9 @@ Example mode-specific fields are:
 -f mode=restore  -f reason='DISC-104 restore rehearsal to accepted artefact B'
 ```
 
-Never substitute a local rebuild, a workflow artefact from a pull request, a failed
+The supported Pages transport envelope is regenerated for each dispatch, but the
+selected source archive and every logical publication byte remain exact. Never
+substitute a local rebuild, a workflow artefact from a pull request, a failed
 run or a mutable branch archive. The current workflow accepts only an unexpired
 Actions source artefact. A release asset preserves evidence but is not an accepted
 deployment input; if the Actions artefact has expired, stop until a separately

--- a/docs/operations/DISC-104_VERIFICATION.md
+++ b/docs/operations/DISC-104_VERIFICATION.md
@@ -32,18 +32,18 @@ Before merge, record:
 - independent review of the archive, workflow and public-browser boundaries.
 
 The complete local candidate gate most recently passed on 20 August 2026 against
-the Pages compatibility candidate based on protected `main` at
-`8e48e68ed6f072be22d46cc866dac947a7a71a4d`:
+the supported-transport candidate based on protected `main` at
+`eced0ae697818b4989ebe95c5bf1572cc6ec90c2`:
 
-- 20 deterministic archive and hostile-input contract tests;
-- 10 workflow event, identity, provenance, permission and no-build deployment
-  contract tests;
+- 27 deterministic archive, safe-staging and hostile-input contract tests;
+- 11 workflow event, identity, provenance, staging, permission and no-build
+  deployment contract tests;
 - 4 gateway tests, 16 Explorer build-policy tests, 42 Explorer unit and component
-  tests, 61 repository Python tests and 2 execution-boundary tests;
+  tests, 69 repository Python tests and 2 execution-boundary tests;
 - 25 existing local real-browser journeys;
-- 8 schemas and 53 evaluation records, 289 local links, 183 immutable research
+- 8 schemas and 53 evaluation records, 290 local links, 183 immutable research
   hashes, 2 source-ledger snapshots and 71 source identifiers;
-- 443 text files scanned without a baseline secret or machine-path match;
+- 446 text files scanned without a baseline secret or machine-path match;
 - 9 rendered diagrams and a 145-component repository CycloneDX SBOM.
 
 Before the Pages header compatibility correction, packager and verifier contract
@@ -59,12 +59,12 @@ the separate public suite passed all 4 identity, accepted-manifest payload,
 trusted-ledger checksum, reviewed-journey, history, network, CSP, accessibility and
 320 CSS-pixel tests.
 
-All nine external Action pins were independently resolved against their official
+All ten external Action pins were independently resolved against their official
 GitHub tag refs; the annotated pnpm tag was dereferenced to its exact commit.
 
 ## Pages ingestion compatibility evidence
 
-The first three deployment attempts stopped after validation, provenance,
+The first four deployment attempts stopped after validation, provenance,
 configuration and artefact staging had passed:
 
 - runs
@@ -76,7 +76,10 @@ configuration and artefact staging had passed:
   [`32320645861`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32320645861)
   selected the artefact from source commit `8e48e68` after restoring the standard
   compressed Actions transport;
-- all three reached `actions/deploy-pages`, created a Pages deployment and then
+- run
+  [`32322255222`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32322255222)
+  selected the corrected, attested source artefact from commit `eced0ae`;
+- all four reached `actions/deploy-pages`, created a Pages deployment and then
   returned GitHub's generic `deployment_failed` state; public verification was
   correctly skipped.
 
@@ -92,30 +95,48 @@ in
 
 Packager and verifier contract `1.0.1` therefore requires `./` member paths and
 fixed non-root numeric ownership. Regressions reject an unprefixed path and a
-root-owned member. The deployment job still cannot rebuild or repackage an accepted
-archive; a fresh protected-main build and attestation are required before another
-dispatch.
+root-owned member. Protected-main run `32322035483` then produced and attested
+corrected source archive SHA-256
+`b20ba6cab1811b976417aef6ca4c61bc33270063d7646ab8469e3273399edd11`.
+All 57 members used the corrected metadata and the fourth workflow uploaded those
+exact bytes, but Pages still rejected its custom tar encoding.
+
+ADR-0008 therefore retains that deterministic tar as attested source evidence but
+supersedes the unchanged-tar deployment claim. The current workflow candidate
+safely materialises and rechecks its exact logical files, then uses the exact pinned
+official `actions/upload-pages-artifact` implementation to create only the platform
+transport envelope. If that supported path also fails, the run evidence must be
+escalated to GitHub Support rather than prompting another speculative archive
+change.
 
 ## Protected-main source evidence
 
-Complete after the implementation pull request merges:
-
-- source commit: pending;
-- successful CI push run and `assurance` job: pending;
-- source artefact name and ID: pending;
-- `artifact.tar` SHA-256 and outer receipt: pending;
-- GitHub build-provenance attestation: pending;
-- product version and OKF content root: pending.
+- source commit: `eced0ae697818b4989ebe95c5bf1572cc6ec90c2`;
+- successful CI push run: [`32322035483`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32322035483),
+  including successful `assurance` and `provenance` jobs;
+- source artefact: `pages-source-eced0ae697818b4989ebe95c5bf1572cc6ec90c2`,
+  ID `9390109262`;
+- `artifact.tar` SHA-256:
+  `b20ba6cab1811b976417aef6ca4c61bc33270063d7646ab8469e3273399edd11`;
+- outer receipt SHA-256:
+  `c5ad1ee357b7a098c09aab355a3e174ac31c8a24c90ec30f74f6c47b1bd44596`;
+- strict GitHub attestation verification: protected `main`, source commit
+  `eced0ae`, `.github/workflows/ci.yml`, GitHub-hosted runner and CI invocation
+  `32322035483` all matched;
+- product version `0.0.0`, payload root
+  `7d0adda69e77b815e75e860426cb3ac107b89a70abdd91d771070024c459444b`
+  and OKF content root
+  `c8415e83643b43b6fbde43cf30cf80ce8e5440f69770cfd9433337a5087f37fd`.
 
 ## Repository configuration evidence
 
-Complete before first deployment:
-
-- Pages build type `workflow`, HTTPS enforced and no custom domain: pending;
-- `github-pages` environment restricted to exact branch `main`: pending;
-- complete-SHA Action pin enforcement: pending;
-- existing protected-main ruleset and read-only default workflow token reverified:
-  pending.
+- Pages build type is `workflow`, the site is public, HTTPS is enforced and no
+  custom domain is set;
+- the `github-pages` environment is restricted to exact branch `main`;
+- repository Actions require complete-SHA pins;
+- the no-bypass protected-main ruleset still requires strict `assurance`, linear
+  squash-only pull requests and resolved review threads; and
+- the default workflow token remains read-only and cannot approve pull requests.
 
 ## Deployment and public evidence
 

--- a/scripts/stage_pages_payload.py
+++ b/scripts/stage_pages_payload.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Safely stage the exact logical files from a verified Pages source archive."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import verify_pages_archive as verifier
+
+
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_READ_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+_WRITE_FLAGS = (
+    os.O_WRONLY
+    | os.O_CREAT
+    | os.O_EXCL
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_FILE_MODE = 0o644
+_DIRECTORY_MODE = 0o755
+
+Identity = tuple[int, int]
+
+
+def _identity(metadata: os.stat_result) -> Identity:
+    return metadata.st_dev, metadata.st_ino
+
+
+def _require_same_identity(
+    metadata: os.stat_result,
+    expected: Identity,
+    label: str,
+) -> None:
+    if _identity(metadata) != expected:
+        raise ValueError(f"{label} changed while the Pages payload was staged")
+
+
+def _open_real_directory(path: Path, label: str) -> tuple[int, Identity]:
+    try:
+        before = path.lstat()
+    except FileNotFoundError as error:
+        raise ValueError(f"{label} must already exist as a real directory") from error
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISDIR(before.st_mode):
+        raise ValueError(f"{label} must already exist as a real directory")
+    try:
+        descriptor = os.open(path, _DIRECTORY_FLAGS)
+    except OSError as error:
+        raise ValueError(f"{label} could not be opened safely") from error
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise ValueError(f"{label} must be a real directory")
+        _require_same_identity(opened, _identity(before), label)
+        return descriptor, _identity(opened)
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _existing_output_error(parent_descriptor: int, name: str) -> ValueError:
+    try:
+        metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return ValueError("output directory changed while it was created")
+    if stat.S_ISLNK(metadata.st_mode):
+        return ValueError("output directory must not be a symbolic link")
+    return ValueError("output directory must not already exist")
+
+
+def _create_output_directory(
+    output_dir: Path,
+) -> tuple[int, Identity, int, Identity, str]:
+    name = output_dir.name
+    if not name or name in {".", ".."}:
+        raise ValueError("output directory must name a new child directory")
+    parent = output_dir.parent
+    parent_descriptor, parent_identity = _open_real_directory(
+        parent, "output directory parent"
+    )
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=parent_descriptor)
+        except FileExistsError as error:
+            raise _existing_output_error(parent_descriptor, name) from error
+        try:
+            created = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+            if not stat.S_ISDIR(created.st_mode) or stat.S_ISLNK(created.st_mode):
+                raise ValueError("new output directory is not a real directory")
+            output_descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_descriptor)
+        except Exception:
+            raise
+        try:
+            opened = os.fstat(output_descriptor)
+            if not stat.S_ISDIR(opened.st_mode):
+                raise ValueError("new output directory is not a real directory")
+            _require_same_identity(opened, _identity(created), "output directory")
+            os.fchmod(output_descriptor, _DIRECTORY_MODE)
+            return (
+                parent_descriptor,
+                parent_identity,
+                output_descriptor,
+                _identity(opened),
+                name,
+            )
+        except Exception:
+            os.close(output_descriptor)
+            raise
+    except Exception:
+        os.close(parent_descriptor)
+        raise
+
+
+def _open_child_directory(
+    parent_descriptor: int,
+    name: str,
+    logical_parts: tuple[str, ...],
+    directory_identities: dict[tuple[str, ...], Identity],
+) -> int:
+    expected = directory_identities.get(logical_parts)
+    if expected is None:
+        try:
+            os.mkdir(name, _DIRECTORY_MODE, dir_fd=parent_descriptor)
+        except FileExistsError as error:
+            logical = "/".join(logical_parts)
+            raise ValueError(f"staging directory appeared unexpectedly: {logical}") from error
+        created = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if not stat.S_ISDIR(created.st_mode) or stat.S_ISLNK(created.st_mode):
+            logical = "/".join(logical_parts)
+            raise ValueError(f"staging path is not a real directory: {logical}")
+        expected = _identity(created)
+        directory_identities[logical_parts] = expected
+    try:
+        descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_descriptor)
+    except OSError as error:
+        logical = "/".join(logical_parts)
+        raise ValueError(f"staging directory could not be opened safely: {logical}") from error
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise ValueError(f"staging path is not a directory: {'/'.join(logical_parts)}")
+        _require_same_identity(opened, expected, f"staging directory {'/'.join(logical_parts)}")
+        if stat.S_IMODE(opened.st_mode) != _DIRECTORY_MODE:
+            os.fchmod(descriptor, _DIRECTORY_MODE)
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _write_all(descriptor: int, value: bytes) -> None:
+    view = memoryview(value)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("write returned no progress")
+        view = view[written:]
+
+
+def _write_regular_file(
+    root_descriptor: int,
+    logical_path: str,
+    value: bytes,
+    directory_identities: dict[tuple[str, ...], Identity],
+    file_identities: dict[str, Identity],
+) -> None:
+    parts = tuple(logical_path.split("/"))
+    current_descriptor = os.dup(root_descriptor)
+    try:
+        prefix: tuple[str, ...] = ()
+        for part in parts[:-1]:
+            prefix = (*prefix, part)
+            child_descriptor = _open_child_directory(
+                current_descriptor,
+                part,
+                prefix,
+                directory_identities,
+            )
+            os.close(current_descriptor)
+            current_descriptor = child_descriptor
+
+        name = parts[-1]
+        try:
+            file_descriptor = os.open(
+                name,
+                _WRITE_FLAGS,
+                0o600,
+                dir_fd=current_descriptor,
+            )
+        except FileExistsError as error:
+            raise ValueError(f"staging file appeared unexpectedly: {logical_path}") from error
+        except OSError as error:
+            raise ValueError(f"staging file could not be created safely: {logical_path}") from error
+        try:
+            opened = os.fstat(file_descriptor)
+            if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+                raise ValueError(f"staging file is not a single-link regular file: {logical_path}")
+            os.fchmod(file_descriptor, _FILE_MODE)
+            _write_all(file_descriptor, value)
+            completed = os.fstat(file_descriptor)
+            if completed.st_size != len(value):
+                raise ValueError(f"staging file byte count differs: {logical_path}")
+            file_identity = _identity(completed)
+        finally:
+            os.close(file_descriptor)
+
+        named = os.stat(name, dir_fd=current_descriptor, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(named.st_mode)
+            or named.st_nlink != 1
+            or stat.S_IMODE(named.st_mode) != _FILE_MODE
+        ):
+            raise ValueError(f"staging file metadata differs: {logical_path}")
+        _require_same_identity(named, file_identity, f"staging file {logical_path}")
+        file_identities[logical_path] = file_identity
+    finally:
+        os.close(current_descriptor)
+
+
+def _read_all(descriptor: int) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(descriptor, 1024 * 1024)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def _inventory_directory(
+    descriptor: int,
+    logical_parts: tuple[str, ...],
+    directory_identities: dict[tuple[str, ...], Identity],
+    file_identities: dict[str, Identity],
+    observed_directories: set[tuple[str, ...]],
+    observed_files: dict[str, bytes],
+) -> None:
+    opened = os.fstat(descriptor)
+    expected_directory = directory_identities.get(logical_parts)
+    if expected_directory is None:
+        raise ValueError(f"unexpected staging directory: {'/'.join(logical_parts)}")
+    _require_same_identity(
+        opened,
+        expected_directory,
+        f"staging directory {'/'.join(logical_parts) or '.'}",
+    )
+    if not stat.S_ISDIR(opened.st_mode) or stat.S_IMODE(opened.st_mode) != _DIRECTORY_MODE:
+        raise ValueError(f"staging directory metadata differs: {'/'.join(logical_parts) or '.'}")
+    observed_directories.add(logical_parts)
+
+    with os.scandir(descriptor) as entries:
+        ordered = sorted(entries, key=lambda entry: os.fsencode(entry.name))
+    for entry in ordered:
+        name = entry.name
+        if name in {"", ".", ".."} or "/" in name or "\0" in name:
+            raise ValueError(f"unsafe staged entry name: {name!r}")
+        child_parts = (*logical_parts, name)
+        metadata = entry.stat(follow_symlinks=False)
+        if stat.S_ISDIR(metadata.st_mode):
+            expected = directory_identities.get(child_parts)
+            if expected is None:
+                raise ValueError(f"unexpected staging directory: {'/'.join(child_parts)}")
+            _require_same_identity(
+                metadata,
+                expected,
+                f"staging directory {'/'.join(child_parts)}",
+            )
+            child_descriptor = _open_child_directory(
+                descriptor,
+                name,
+                child_parts,
+                directory_identities,
+            )
+            try:
+                _inventory_directory(
+                    child_descriptor,
+                    child_parts,
+                    directory_identities,
+                    file_identities,
+                    observed_directories,
+                    observed_files,
+                )
+            finally:
+                os.close(child_descriptor)
+            continue
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            logical_path = "/".join(child_parts)
+            raise ValueError(f"staging tree contains a link or special file: {logical_path}")
+        logical_path = "/".join(child_parts)
+        expected_file = file_identities.get(logical_path)
+        if expected_file is None:
+            raise ValueError(f"unexpected staging file: {logical_path}")
+        _require_same_identity(metadata, expected_file, f"staging file {logical_path}")
+        if stat.S_IMODE(metadata.st_mode) != _FILE_MODE:
+            raise ValueError(f"staging file mode differs: {logical_path}")
+        try:
+            file_descriptor = os.open(name, _READ_FLAGS, dir_fd=descriptor)
+        except OSError as error:
+            raise ValueError(
+                f"staging file could not be reopened safely: {logical_path}"
+            ) from error
+        try:
+            reopened = os.fstat(file_descriptor)
+            if not stat.S_ISREG(reopened.st_mode) or reopened.st_nlink != 1:
+                raise ValueError(f"staging file is not a regular file: {logical_path}")
+            _require_same_identity(reopened, expected_file, f"staging file {logical_path}")
+            observed_files[logical_path] = _read_all(file_descriptor)
+        finally:
+            os.close(file_descriptor)
+
+
+def _assert_named_output_identity(
+    output_dir: Path,
+    parent_descriptor: int,
+    parent_identity: Identity,
+    output_name: str,
+    output_identity: Identity,
+) -> None:
+    parent_metadata = output_dir.parent.lstat()
+    if stat.S_ISLNK(parent_metadata.st_mode) or not stat.S_ISDIR(parent_metadata.st_mode):
+        raise ValueError("output directory parent changed while the Pages payload was staged")
+    _require_same_identity(parent_metadata, parent_identity, "output directory parent")
+    named = os.stat(output_name, dir_fd=parent_descriptor, follow_symlinks=False)
+    if stat.S_ISLNK(named.st_mode) or not stat.S_ISDIR(named.st_mode):
+        raise ValueError("output directory changed while the Pages payload was staged")
+    _require_same_identity(named, output_identity, "output directory")
+
+
+def materialise_files(files: dict[str, bytes], output_dir: Path) -> dict[str, bytes]:
+    """Write verified logical files to a newly created, descriptor-pinned directory."""
+    if not files:
+        raise ValueError("verified Pages payload must contain at least one file")
+    for logical_path in files:
+        verifier.safe_archive_path(logical_path)
+
+    (
+        parent_descriptor,
+        parent_identity,
+        output_descriptor,
+        output_identity,
+        output_name,
+    ) = _create_output_directory(output_dir)
+    directory_identities: dict[tuple[str, ...], Identity] = {(): output_identity}
+    file_identities: dict[str, Identity] = {}
+    try:
+        for logical_path in sorted(files, key=os.fsencode):
+            _write_regular_file(
+                output_descriptor,
+                logical_path,
+                files[logical_path],
+                directory_identities,
+                file_identities,
+            )
+
+        observed_directories: set[tuple[str, ...]] = set()
+        observed_files: dict[str, bytes] = {}
+        _inventory_directory(
+            output_descriptor,
+            (),
+            directory_identities,
+            file_identities,
+            observed_directories,
+            observed_files,
+        )
+        if observed_directories != set(directory_identities):
+            raise ValueError("staged directory inventory differs from the verified payload")
+        if observed_files != files:
+            raise ValueError("staged file inventory or bytes differ from the verified payload")
+        _assert_named_output_identity(
+            output_dir,
+            parent_descriptor,
+            parent_identity,
+            output_name,
+            output_identity,
+        )
+        return observed_files
+    finally:
+        os.close(output_descriptor)
+        os.close(parent_descriptor)
+
+
+def stage_payload(
+    *,
+    archive_path: Path,
+    checksum_path: Path,
+    receipt_path: Path,
+    output_dir: Path,
+    expected_source_commit: str,
+    expected_repository: str,
+    expected_version: str,
+    expected_base_path: str,
+    expected_archive_sha256: str,
+) -> dict[str, Any]:
+    """Verify an accepted source archive, then stage its exact logical bytes."""
+    receipt = verifier.verify_archive(
+        archive_path=archive_path,
+        checksum_path=checksum_path,
+        receipt_path=receipt_path,
+        expected_source_commit=expected_source_commit,
+        expected_repository=expected_repository,
+        expected_version=expected_version,
+        expected_base_path=expected_base_path,
+        expected_archive_sha256=expected_archive_sha256,
+    )
+    archive_bytes = verifier.read_outer_file(
+        archive_path,
+        "Pages archive",
+        verifier.MAX_ARCHIVE_BYTES,
+    )
+    archive_sha256 = verifier.sha256_bytes(archive_bytes)
+    if (
+        archive_sha256 != expected_archive_sha256
+        or archive_sha256 != receipt["archive"]["sha256"]
+    ):
+        raise ValueError("Pages archive changed after verification")
+    files = verifier.read_archive(archive_bytes)
+    observed = materialise_files(files, output_dir)
+    return {
+        "archiveSha256": archive_sha256,
+        "payloadRootSha256": receipt["payloadRootSha256"],
+        "fileCount": len(observed),
+        "outputDir": str(output_dir),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--checksum", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--expected-source-commit", required=True)
+    parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-base-path", required=True)
+    parser.add_argument("--expected-archive-sha256", required=True)
+    args = parser.parse_args()
+    staged = stage_payload(
+        archive_path=args.archive,
+        checksum_path=args.checksum,
+        receipt_path=args.receipt,
+        output_dir=args.output_dir,
+        expected_source_commit=args.expected_source_commit,
+        expected_repository=args.expected_repository,
+        expected_version=args.expected_version,
+        expected_base_path=args.expected_base_path,
+        expected_archive_sha256=args.expected_archive_sha256,
+    )
+    print(
+        "Staged verified Pages payload "
+        f"archive-sha256={staged['archiveSha256']} "
+        f"payload-root-sha256={staged['payloadRootSha256']} "
+        f"files={staged['fileCount']} output={staged['outputDir']}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/contract/test_pages_staging.py
+++ b/tests/contract/test_pages_staging.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script(name: str) -> ModuleType:
+    specification = importlib.util.spec_from_file_location(name, ROOT / "scripts" / f"{name}.py")
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"cannot load {name}")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+VERIFY = load_script("verify_pages_archive")
+sys.modules["verify_pages_archive"] = VERIFY
+PACKAGE = load_script("package_pages")
+STAGE = load_script("stage_pages_payload")
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+class PagesStagingContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.dist = self.root / "dist"
+        self.package_output = self.root / "package"
+        self.staging_container = self.root / "deployment-staging"
+        self.staging_output = self.staging_container / "site"
+        self.head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+        self.content_root = "a" * 64
+        self._make_checked_distribution()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _write_dist(self, relative: str, value: bytes) -> None:
+        path = self.dist / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(value)
+
+    def _make_checked_distribution(self) -> None:
+        self._write_dist(
+            "index.html",
+            (
+                '<!doctype html><html lang="en-GB"><head>'
+                '<link rel="icon" href="./favicon.svg">'
+                '<link rel="stylesheet" href="./assets/app.css">'
+                '<script type="module" src="./assets/app.js"></script>'
+                "</head><body>GIS AI GO</body></html>\n"
+            ).encode(),
+        )
+        self._write_dist(
+            "favicon.svg",
+            b'<svg xmlns="http://www.w3.org/2000/svg"></svg>\n',
+        )
+        self._write_dist("assets/app.css", b"body { color: #111; }\n")
+        self._write_dist("assets/app.js", b"document.documentElement.className = 'js';\n")
+        self._write_dist(
+            "catalogue/.explorer-generated",
+            b"gis-ai-go-public-explorer-data.v1\n",
+        )
+
+        catalogue_manifest = canonical_json({"files": [], "recordCount": 0, "recordIds": []})
+        catalogue_files = {
+            "manifest.json": catalogue_manifest,
+            "okf-bundle.json": canonical_json({"recordCount": 0, "records": []}),
+            "okf-bundle.jsonld": canonical_json({"@graph": []}),
+            "okf-explorer.json": canonical_json({"recordCount": 0, "records": []}),
+        }
+        catalogue_files["build-receipt.json"] = canonical_json(
+            {
+                "builder": "tests/fixture",
+                "builderVersion": "1.0.0",
+                "contentRootSha256": self.content_root,
+                "manifestSha256": sha256(catalogue_manifest),
+                "revision": self.head,
+                "version": self.version,
+            }
+        )
+        for relative, value in catalogue_files.items():
+            self._write_dist(f"catalogue/{relative}", value)
+        self._write_dist(
+            "catalogue/CHECKSUMS.sha256",
+            "".join(
+                f"{sha256(value)}  {relative}\n"
+                for relative, value in sorted(catalogue_files.items())
+            ).encode(),
+        )
+
+    def _build(self) -> dict[str, Any]:
+        return PACKAGE.build_archive(
+            dist=self.dist,
+            output_dir=self.package_output,
+            source_commit=self.head,
+            repository="chris-page-gov/gis-ai-go",
+            version=self.version,
+            base_path="/gis-ai-go/",
+        )
+
+    def _stage(self, *, output: Path | None = None, digest: str | None = None) -> dict[str, Any]:
+        receipt = json.loads((self.package_output / "archive-receipt.json").read_bytes())
+        target = output or self.staging_output
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return STAGE.stage_payload(
+            archive_path=self.package_output / "artifact.tar",
+            checksum_path=self.package_output / "artifact.tar.sha256",
+            receipt_path=self.package_output / "archive-receipt.json",
+            output_dir=target,
+            expected_source_commit=self.head,
+            expected_repository="chris-page-gov/gis-ai-go",
+            expected_version=self.version,
+            expected_base_path="/gis-ai-go/",
+            expected_archive_sha256=digest or receipt["archive"]["sha256"],
+        )
+
+    def _source_files(self) -> dict[str, bytes]:
+        return VERIFY.read_archive((self.package_output / "artifact.tar").read_bytes())
+
+    def _staged_files(self, output: Path | None = None) -> dict[str, bytes]:
+        target = output or self.staging_output
+        return {
+            path.relative_to(target).as_posix(): path.read_bytes()
+            for path in target.rglob("*")
+            if path.is_file()
+        }
+
+    def test_stages_exact_regular_bytes_including_allowlisted_hidden_files(self) -> None:
+        receipt = self._build()
+        staged = self._stage()
+        expected = self._source_files()
+        self.assertEqual(self._staged_files(), expected)
+        self.assertEqual(
+            staged,
+            {
+                "archiveSha256": receipt["archive"]["sha256"],
+                "payloadRootSha256": receipt["payloadRootSha256"],
+                "fileCount": len(expected),
+                "outputDir": str(self.staging_output),
+            },
+        )
+        self.assertEqual((self.staging_output / ".nojekyll").read_bytes(), b"")
+        self.assertIn("catalogue/.explorer-generated", expected)
+        for path in self.staging_output.rglob("*"):
+            metadata = path.lstat()
+            self.assertFalse(stat.S_ISLNK(metadata.st_mode))
+            if path.is_dir():
+                self.assertEqual(stat.S_IMODE(metadata.st_mode), 0o755)
+            else:
+                self.assertTrue(stat.S_ISREG(metadata.st_mode))
+                self.assertEqual(metadata.st_nlink, 1)
+                self.assertEqual(stat.S_IMODE(metadata.st_mode), 0o644)
+
+    def test_cli_stages_the_verified_archive_with_the_fixed_interface(self) -> None:
+        receipt = self._build()
+        self.staging_container.mkdir()
+        completed = subprocess.run(
+            [
+                "python3",
+                "scripts/stage_pages_payload.py",
+                "--archive",
+                str(self.package_output / "artifact.tar"),
+                "--checksum",
+                str(self.package_output / "artifact.tar.sha256"),
+                "--receipt",
+                str(self.package_output / "archive-receipt.json"),
+                "--output-dir",
+                str(self.staging_output),
+                "--expected-source-commit",
+                self.head,
+                "--expected-repository",
+                "chris-page-gov/gis-ai-go",
+                "--expected-version",
+                self.version,
+                "--expected-base-path",
+                "/gis-ai-go/",
+                "--expected-archive-sha256",
+                receipt["archive"]["sha256"],
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(self._staged_files(), self._source_files())
+        self.assertIn(
+            f"archive-sha256={receipt['archive']['sha256']} ",
+            completed.stdout,
+        )
+        self.assertIn(
+            f"payload-root-sha256={receipt['payloadRootSha256']} ",
+            completed.stdout,
+        )
+
+    def test_rejects_wrong_digest_before_creating_output(self) -> None:
+        self._build()
+        with self.assertRaisesRegex(ValueError, "accepted artefact"):
+            self._stage(digest="b" * 64)
+        self.assertFalse(self.staging_output.exists())
+
+    def test_rejects_preexisting_empty_and_nonempty_output_directories(self) -> None:
+        self._build()
+        for suffix, populated in (("empty", False), ("nonempty", True)):
+            with self.subTest(suffix=suffix):
+                output = self.root / suffix / "site"
+                output.mkdir(parents=True)
+                if populated:
+                    (output / "untrusted.txt").write_text("untrusted\n", encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, "must not already exist"):
+                    self._stage(output=output)
+                if populated:
+                    self.assertEqual(
+                        (output / "untrusted.txt").read_text(encoding="utf-8"),
+                        "untrusted\n",
+                    )
+
+    def test_rejects_output_and_parent_symbolic_links(self) -> None:
+        self._build()
+        real_parent = self.root / "real-parent"
+        real_parent.mkdir()
+        target = self.root / "target"
+        target.mkdir()
+
+        linked_output = real_parent / "linked-site"
+        linked_output.symlink_to(target, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "must not be a symbolic link"):
+            self._stage(output=linked_output)
+        self.assertEqual(list(target.iterdir()), [])
+
+        linked_parent = self.root / "linked-parent"
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "parent must already exist as a real directory"):
+            self._stage(output=linked_parent / "site")
+
+    def test_rejects_output_directory_replacement_race(self) -> None:
+        self._build()
+        self.staging_container.mkdir()
+        moved = self.staging_container / "moved-site"
+        decoy = self.staging_container / "decoy"
+        decoy.mkdir()
+        original = STAGE._write_regular_file
+        replaced = False
+
+        def replace_after_first_file(*args: Any, **kwargs: Any) -> None:
+            nonlocal replaced
+            original(*args, **kwargs)
+            if not replaced:
+                self.staging_output.rename(moved)
+                self.staging_output.symlink_to(decoy, target_is_directory=True)
+                replaced = True
+
+        with mock.patch.object(STAGE, "_write_regular_file", side_effect=replace_after_first_file):
+            with self.assertRaisesRegex(ValueError, "output directory changed"):
+                self._stage()
+        self.assertEqual(list(decoy.iterdir()), [])
+
+    def test_rejects_staged_byte_change_before_final_inventory(self) -> None:
+        self._build()
+        self.staging_container.mkdir()
+        original = STAGE._write_regular_file
+        changed = False
+
+        def change_index(*args: Any, **kwargs: Any) -> None:
+            nonlocal changed
+            original(*args, **kwargs)
+            logical_path = args[1]
+            if logical_path == "index.html" and not changed:
+                (self.staging_output / "index.html").write_bytes(b"changed after staging\n")
+                changed = True
+
+        with mock.patch.object(STAGE, "_write_regular_file", side_effect=change_index):
+            with self.assertRaisesRegex(ValueError, "inventory or bytes differ"):
+                self._stage()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -133,6 +133,59 @@ class PagesWorkflowTests(unittest.TestCase):
             with self.subTest(flag=flag):
                 self.assertIn(flag, PAGES_WORKFLOW)
 
+    def test_prepare_materialises_and_stages_only_the_verified_payload(self) -> None:
+        prepare = PAGES_WORKFLOW.split("\n  prepare:\n", 1)[1].split(
+            "\n  deploy:\n", 1
+        )[0]
+        stage_command = (
+            "uv run --locked --cache-dir .uv-cache python "
+            "scripts/stage_pages_payload.py"
+        )
+        self.assertIn("mkdir -p deployment-staging", prepare)
+        for argument in (
+            "--archive artifacts/pages/artifact.tar",
+            "--checksum artifacts/pages/artifact.tar.sha256",
+            "--receipt artifacts/pages/archive-receipt.json",
+            "--output-dir deployment-staging/site",
+            '--expected-source-commit "$SOURCE_COMMIT"',
+            '--expected-repository "$GITHUB_REPOSITORY"',
+            '--expected-version "$(tr -d \'\\r\\n\' < VERSION)"',
+            "--expected-base-path /gis-ai-go/",
+            '--expected-archive-sha256 "$ARCHIVE_SHA256"',
+        ):
+            with self.subTest(argument=argument):
+                self.assertIn(argument, prepare)
+
+        upload_action = (
+            "actions/upload-pages-artifact@"
+            "fc324d3547104276b827a68afc52ff2a11cc49c9"
+        )
+        self.assertEqual(PAGES_WORKFLOW.count(upload_action), 1)
+        upload = prepare.split(f"uses: {upload_action}", 1)[1].split("\n\n", 1)[0]
+        self.assertIn("name: github-pages", upload)
+        self.assertIn("path: deployment-staging/site", upload)
+        self.assertIn("retention-days: 1", upload)
+        self.assertIn("include-hidden-files: true", upload)
+        self.assertNotIn("if: always()", upload)
+
+        self.assertLess(
+            prepare.index("scripts/verify_pages_archive.py"),
+            prepare.index(stage_command),
+        )
+        self.assertLess(
+            prepare.index("gh attestation verify"), prepare.index(stage_command)
+        )
+        self.assertLess(
+            prepare.index("mkdir -p deployment-staging"),
+            prepare.index(stage_command),
+        )
+        self.assertLess(prepare.index(stage_command), prepare.index(upload_action))
+
+        diagnostic = prepare.split("- name: Upload validation evidence", 1)[1].split(
+            "\n\n      - name:", 1
+        )[0]
+        self.assertNotIn("deployment-staging", diagnostic)
+
     def test_deploy_job_has_only_pages_deployment_authority(self) -> None:
         deploy = PAGES_WORKFLOW.split("\n  deploy:\n", 1)[1].split(
             "\n  public-verification:\n", 1
@@ -144,11 +197,20 @@ class PagesWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("contents:", deploy)
         self.assertNotIn("attestations:", deploy)
-        self.assertIn("path: artifacts/pages/artifact.tar", deploy)
-        self.assertIn("name: github-pages", deploy)
         self.assertIn("artifact_name: github-pages", deploy)
-        self.assertIn("sha256sum --check --strict artifact.tar.sha256", deploy)
-        self.assertNotIn("compression-level: 0", deploy)
+        uses = re.findall(r"^\s*uses:\s+([^@\s]+)@", deploy, re.MULTILINE)
+        self.assertEqual(uses, ["actions/configure-pages", "actions/deploy-pages"])
+        for forbidden in (
+            "actions/checkout",
+            "actions/download-artifact",
+            "actions/upload-artifact",
+            "actions/upload-pages-artifact",
+            "scripts/stage_pages_payload.py",
+            "artifacts/pages",
+            "sha256sum",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, deploy)
 
     def test_deployment_workflow_never_rebuilds_the_site(self) -> None:
         for forbidden in (
@@ -156,7 +218,7 @@ class PagesWorkflowTests(unittest.TestCase):
             "pnpm run build",
             "vite build",
             "npm run build",
-            "actions/upload-pages-artifact",
+            "tar -x",
         ):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, PAGES_WORKFLOW)


### PR DESCRIPTION
## Summary

- retain the deterministic, attested Pages tar as immutable source evidence;
- verify and safely materialise its exact logical files into a fresh, link-safe
  staging directory;
- use the exact pinned official `actions/upload-pages-artifact` v5 transport;
- keep the protected deploy job limited to `configure-pages` and `deploy-pages`;
- record the four failed custom-tar attempts and the supported-transport decision in
  ADR-0008, the runbook and live progress.

## Why

Four dispatches passed source-run, digest, receipt, provenance, repository and
environment controls, then failed closed during GitHub Pages ingestion. The fourth
proved that corrected paths and non-root ownership were insufficient. This change
stops speculative tar-header changes and uses GitHub's supported packaging path
without rebuilding or changing any accepted publication byte.

If this exact official path also fails, the runbook requires escalation to GitHub
Support rather than another archive-format change.

## Verification

- complete `pnpm run check` passed;
- 27 archive and safe-staging contract tests passed;
- 11 workflow contract tests passed;
- 69 repository Python tests and 2 execution-boundary tests passed;
- 25 local Playwright journeys passed;
- exact protected-main archive `b20ba6ca…` staged as 57 byte-identical files,
  including both allowlisted hidden files and no links;
- link, immutable-research, secret, machine-path, schema, diagram and SBOM checks
  passed;
- two independent final reviews reported SHIP with no P0-P2 findings;
- Codex Security diff scan completed with zero findings.

## Publication boundary

This pull request does not publish the site. After protected-main assurance and
CodeQL pass, a separate manual dispatch will perform one controlled deployment with
the official transport. Public browser acceptance, rollback and restore remain
required before DISC-104 is complete.

Refs #6
