### PR TITLE
docs(pages): record deployment acceptance evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,22 +35,23 @@ Start every implementation task by reading, in order:
 
 Stage 0 is complete at commit `983b1a102aa8038c9f50ae1b1894315c3ae0b89f`.
 The canonical OKF build, accessible static Explorer and reviewed public examples
-are merged through `DISC-101`, `DISC-102` and `DISC-103`; protected `main` is at
-`eced0ae697818b4989ebe95c5bf1572cc6ec90c2`. The Explorer is a functional static
-candidate in repository and CI, but it is not deployed. There is no MCP listener,
-live provider adapter, policy engine, identity integration or evidence store.
+are merged through `DISC-101`, `DISC-102` and `DISC-103`. `DISC-104` is complete
+through [pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14),
+whose accepted implementation and deployed source commit is
+`a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified at
+<https://chris-page-gov.github.io/gis-ai-go/>. There is no MCP listener, live
+provider adapter, policy engine, identity integration or evidence store.
 
 The owner has authorised autonomous implementation in the open under
 [`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The active
 outcome is the `v0.1.0` public discovery product. The repository is public under the
 owner's personal `chris-page-gov` account. Pull-request assurance, security controls
-and branch protection govern development on `main`. The active outcome is
-`DISC-104`: retain the validated static product as an immutable, attested source
-artefact; safely recheck and stage its exact logical files through GitHub's pinned
-official Pages transport; verify the public result; and prove rollback without
-rebuilding the product. Four custom-tar deployments have failed closed at Pages
-ingestion. If the supported official transport also fails, stop changes and
-escalate the recorded evidence to GitHub Support.
+and branch protection govern development on `main`. `DISC-104` retained two
+immutable, attested protected-main source artefacts, deployed both through GitHub's
+pinned official Pages transport, rolled back to the earlier artefact and restored
+the current one without rebuilding either product. All four public-browser
+acceptance suites passed. The active workstream is `QUAL-105`: complete integrity,
+security, browser and WCAG release assurance before assembling `v0.1.0`.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,15 +10,13 @@ reproducible GitHub Pages deployment.
 
 ## Active workstream
 
-`DISC-104 — Publish immutable GitHub Pages artefacts`
+`QUAL-105 — Complete release assurance`
 
-- package only the checked Explorer distribution as a deterministic publication
-  artefact with checksums, provenance, receipt and SBOM;
-- deploy the exact artefact from a successful protected-`main` assurance run;
-- verify the public product, catalogue journeys, CSP, network boundary,
-  accessibility and source identity in a real browser;
-- rehearse rollback to a previous accepted artefact and restore the current one
-  without rebuilding either artefact.
+- complete the integrity, security, real-browser and WCAG acceptance gate against
+  protected `main` and the live public product;
+- keep deterministic artefact, deployment and rollback evidence bound to the
+  accepted source commits; and
+- resolve any release-blocking findings before assembling `v0.1.0`.
 
 ## Completed
 
@@ -51,30 +49,39 @@ reproducible GitHub Pages deployment.
   CodeQL;
 - the canonical public bundle now contains 36 records covering reviewed HMLR
   discovery journeys, HMLR datasets and non-executing ONS and LandIS provider
-  capabilities with exact rights and provenance boundaries.
+  capabilities with exact rights and provenance boundaries;
+- `DISC-104` merged through [pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14)
+  at `a0e826384cf50d9d81b87489dbf3580e8e3602f7` with passing main assurance,
+  provenance and CodeQL;
+- two accepted protected-main source artefacts were deployed successfully through
+  GitHub's pinned official Pages transport;
+- artefact-only rollback to source commit `eced0ae` and restoration of source
+  commit `a0e8263` both completed without rebuilding the product; and
+- the public product is verified at
+  <https://chris-page-gov.github.io/gis-ai-go/>.
 
 ## Next
 
-1. Publish and verify the immutable static product through `DISC-104`.
-2. Prove artefact-only rollback and restore the current accepted deployment.
+1. Complete `QUAL-105` integrity, security, browser and WCAG release assurance.
+2. Resolve any release-blocking findings and rerun the affected gates.
 3. Assemble, tag and verify the first supported `v0.1.0` release.
 
 ## Current blockers
 
-- GitHub Pages is configured but has no successful deployment. Four verified
-  deployment attempts reached Pages ingestion and failed closed, including the
-  corrected deterministic tar from protected `main` at `eced0ae`. The active
-  candidate retains that tar as attested source evidence, safely materialises and
-  rechecks its exact files, then uses GitHub's pinned official Pages transport. If
-  that supported path fails, deployment stops for escalation to GitHub Support.
+- No blocker is known for the open `v0.1.0` discovery product.
 - Protected PSGA and commercial deployments require separate rights, credentials
-  and isolated infrastructure; they do not block the open product.
+  and isolated infrastructure. They remain outside this release and do not block
+  the open product.
 
 ## Latest evidence
 
-- canonical OKF content, Explorer, reviewed public examples and the corrected
-  source-archive contract: merged on protected `main` at `eced0ae`;
-- main assurance, provenance and CodeQL: passing at `eced0ae` on 20 August 2026;
+- canonical OKF content, Explorer, reviewed public examples and supported Pages
+  publication: merged on protected `main` at
+  `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;
+- main assurance and provenance: passing in
+  [run 32324008595](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324008595);
+- CodeQL for Actions, JavaScript/TypeScript and Python: passing in
+  [run 32324008614](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324008614);
 - Explorer assurance includes
   16 build-policy tests, 42 unit and component tests, 25 browser journeys and
   production integrity checks;
@@ -88,15 +95,28 @@ reproducible GitHub Pages deployment.
 - DISC-103 security review: the selected HMLR inputs and copied licence are
   independently bound to approved v0.3.0 digests, and coordinated source, rights,
   licence and lock mutations now fail closed;
-- DISC-104 supported-transport candidate: the complete local gate passes with 27
+- DISC-104 supported transport: the complete local gate passes with 27
   archive and staging contracts, 11 workflow contracts, 69 repository Python
   tests, 25 browser journeys and the full integrity, link, secret, diagram and SBOM
   checks;
-- DISC-104 protected-main source evidence: run `32322035483` built and attested
-  archive SHA-256 `b20ba6cab1811b976417aef6ca4c61bc33270063d7646ab8469e3273399edd11`;
-- DISC-104 transport candidate: the independently verified source files are staged
-  without rebuilding and passed to the pinned official GitHub Pages uploader;
-  candidate assurance, deployment and rollback evidence remain to be produced;
+- DISC-104 artefact A: protected-main run `32322035483`, source commit
+  `eced0ae697818b4989ebe95c5bf1572cc6ec90c2`, archive SHA-256
+  `b20ba6cab1811b976417aef6ca4c61bc33270063d7646ab8469e3273399edd11`,
+  payload root `7d0adda69e77b815e75e860426cb3ac107b89a70abdd91d771070024c459444b`
+  and OKF content root
+  `c8415e83643b43b6fbde43cf30cf80ce8e5440f69770cfd9433337a5087f37fd`;
+- DISC-104 artefact B: protected-main run `32324008595`, source commit
+  `a0e826384cf50d9d81b87489dbf3580e8e3602f7`, archive SHA-256
+  `262231b123bd9fbd9ae01c5d3c138bd63a53d189a55436f6c1b37eff3b2f9194`,
+  receipt SHA-256
+  `75b7e3d8d6eaaf54a12a22176ba1eda1e8c3ceee2892058e1d04437b7b8bdb6b`,
+  payload root `cbc0893a46a4674ef7d13aa4aebcbeb0355f9c8a08286a6500bfc954cb5d6ef6`
+  and OKF content root
+  `a620158911cc60259f0ceab2af0dfdd886783a50bfe98000d692fd534bd08ec0`;
+- DISC-104 deployment evidence: artefact A in run `32324162767`, artefact B in
+  run `32324285041`, rollback to A in run `32324385218` and restore to B in run
+  `32324490516`; each public acceptance suite passed and the final live receipt is
+  bound to `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;
 - public repository: verified with personal `noreply` commit identity;
-- deployed product: none;
+- deployed product: <https://chris-page-gov.github.io/gis-ai-go/>;
 - latest supported release: none.

--- a/changelog.d/DISC-104-pages-ownership.fixed.md
+++ b/changelog.d/DISC-104-pages-ownership.fixed.md
@@ -1,3 +1,3 @@
-- Normalised Pages tar members to the required `./` root and a deterministic
-  non-root owner so GitHub can ingest the attested archive without changing its
-  publication bytes at deployment.
+- Normalised retained Pages source-archive members to an explicit `./` root and a
+  deterministic non-root owner, strengthening independent verification before the
+  exact publication bytes enter GitHub's supported Pages transport.

--- a/docs/implementation/DELIVERY_AND_RELEASE.md
+++ b/docs/implementation/DELIVERY_AND_RELEASE.md
@@ -54,11 +54,14 @@ test as a deployed capability.
 
 ## Deployment and rollback
 
-Deploy only from a verified tag or an artefact built from that tag. Verify the exact
-deployed commit in a real browser/client, including identity, primary journeys,
-accessibility, console, security headers and rollback. GitHub Pages remains disabled
-until the hardened `v0.1.0` Explorer passes its gate; the historical research viewer
-is never the product deployment.
+Before the first tag, a public acceptance candidate may deploy only from an attested
+successful protected-`main` artefact under the DISC-104 workflow. A supported
+release deploys only the artefact built and attested from the exact verified release
+commit, after that commit carries its immutable tag. Verify the exact deployed
+commit in a real browser/client, including identity, primary
+journeys, accessibility, console, security controls and rollback. The live Pages
+Explorer remains a release candidate until the `v0.1.0` gate passes; the historical
+research viewer is never the product deployment.
 
 Prefer an ordinary revert or previous immutable artefact over history rewriting.
 Suspend a provider, tool, registry entry or protected tier independently when its

--- a/docs/operations/DISC-104_VERIFICATION.md
+++ b/docs/operations/DISC-104_VERIFICATION.md
@@ -1,9 +1,9 @@
 # DISC-104 GitHub Pages verification record
 
-- status: implementation candidate
+- status: complete
 - reviewed on: 20 August 2026
 - work item: DISC-104
-- public URL: not deployed
+- public URL: <https://chris-page-gov.github.io/gis-ai-go/>
 
 ## Outcome
 
@@ -19,9 +19,9 @@ Deployment-time verifier and browser-test code always comes from the current
 protected-main workflow commit. A dispatch-selected source commit remains
 non-executable archive identity data.
 
-## Candidate gates
+## Implementation gates
 
-Before merge, record:
+The merge gate recorded:
 
 - deterministic archive tests, including repeated byte-for-byte output;
 - malicious path, symlink, hard-link, special-file, inventory and checksum
@@ -45,6 +45,13 @@ the supported-transport candidate based on protected `main` at
   hashes, 2 source-ledger snapshots and 71 source identifiers;
 - 446 text files scanned without a baseline secret or machine-path match;
 - 9 rendered diagrams and a 145-component repository CycloneDX SBOM.
+
+[Pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14) merged the
+supported transport at `a0e826384cf50d9d81b87489dbf3580e8e3602f7`.
+[Main run 32324008595](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324008595)
+passed both `assurance` and `provenance`.
+[CodeQL run 32324008614](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324008614)
+passed Actions, JavaScript/TypeScript and Python analysis.
 
 Before the Pages header compatibility correction, packager and verifier contract
 `1.0.0` reproduced uncompressed canonical POSIX ustar archive SHA-256
@@ -102,14 +109,15 @@ All 57 members used the corrected metadata and the fourth workflow uploaded thos
 exact bytes, but Pages still rejected its custom tar encoding.
 
 ADR-0008 therefore retains that deterministic tar as attested source evidence but
-supersedes the unchanged-tar deployment claim. The current workflow candidate
-safely materialises and rechecks its exact logical files, then uses the exact pinned
+supersedes the unchanged-tar deployment claim. The merged workflow safely
+materialises and rechecks its exact logical files, then uses the exact pinned
 official `actions/upload-pages-artifact` implementation to create only the platform
-transport envelope. If that supported path also fails, the run evidence must be
-escalated to GitHub Support rather than prompting another speculative archive
-change.
+transport envelope. This supported path succeeded for both accepted source
+artefacts, the rollback and the restore. No Pages ingestion blocker remains.
 
-## Protected-main source evidence
+## Accepted protected-main source evidence
+
+### Artefact A
 
 - source commit: `eced0ae697818b4989ebe95c5bf1572cc6ec90c2`;
 - successful CI push run: [`32322035483`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32322035483),
@@ -128,6 +136,23 @@ change.
   and OKF content root
   `c8415e83643b43b6fbde43cf30cf80ce8e5440f69770cfd9433337a5087f37fd`.
 
+### Artefact B
+
+- source commit: `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;
+- successful CI push run: [`32324008595`](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324008595),
+  including successful `assurance` and `provenance` jobs;
+- `artifact.tar` SHA-256:
+  `262231b123bd9fbd9ae01c5d3c138bd63a53d189a55436f6c1b37eff3b2f9194`;
+- outer receipt SHA-256:
+  `75b7e3d8d6eaaf54a12a22176ba1eda1e8c3ceee2892058e1d04437b7b8bdb6b`;
+- strict GitHub attestation verification: protected `main`, source commit
+  `a0e8263`, `.github/workflows/ci.yml`, GitHub-hosted runner and CI invocation
+  `32324008595` all matched; and
+- product version `0.0.0`, payload root
+  `cbc0893a46a4674ef7d13aa4aebcbeb0355f9c8a08286a6500bfc954cb5d6ef6`
+  and OKF content root
+  `a620158911cc60259f0ceab2af0dfdd886783a50bfe98000d692fd534bd08ec0`.
+
 ## Repository configuration evidence
 
 - Pages build type is `workflow`, the site is public, HTTPS is enforced and no
@@ -140,22 +165,28 @@ change.
 
 ## Deployment and public evidence
 
-Complete after first deployment:
-
-- deployment workflow run, Pages deployment ID and public URL: pending;
-- live receipt identity equals selected source artefact: pending;
-- checksum and JSON/JSON-LD parity: pending;
-- default, Price Paid, ONS, LandIS, direct-route and history journeys: pending;
-- exact CSP, clean console and publication-path-only requests: pending;
-- keyboard, axe A/AA and 320 CSS-pixel acceptance: pending.
+- artefact A original deployment: [run 32324162767](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324162767),
+  Pages deployment `5994521091`;
+- artefact B original deployment: [run 32324285041](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324285041),
+  Pages deployment `5994542308`;
+- artefact A rollback: [run 32324385218](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324385218),
+  Pages deployment `5994560798`; the live receipt was bound to
+  `eced0ae697818b4989ebe95c5bf1572cc6ec90c2`;
+- artefact B restore: [run 32324490516](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324490516),
+  Pages deployment `5994580314`; the final live receipt is bound to
+  `a0e826384cf50d9d81b87489dbf3580e8e3602f7`; and
+- the public acceptance suite passed after each of the four deployments. The four
+  successful suites covered live receipt identity, checksum and JSON/JSON-LD
+  parity, the default, Price Paid, ONS, LandIS, direct-route and history journeys,
+  exact CSP, a clean console, the publication-path-only network boundary,
+  keyboard use, axe A/AA checks and 320 CSS-pixel acceptance.
 
 ## Rollback rehearsal
 
-Complete with two accepted protected-main artefacts:
+The two accepted protected-main artefacts were retained independently. Run
+`32324385218` redeployed artefact A without a product build and its public suite
+confirmed the older source receipt. Run `32324490516` then redeployed artefact B
+without a product build and its public suite confirmed the restored current source
+receipt.
 
-- artefact A identities and original deployment: pending;
-- artefact B identities and original deployment: pending;
-- rollback run redeploying A without a build and its public evidence: pending;
-- restore run redeploying B without a build and its public evidence: pending.
-
-DISC-104 remains incomplete while any item in this record is pending.
+DISC-104 is complete. `QUAL-105` now owns the release-assurance gate for `v0.1.0`.


### PR DESCRIPTION
## What changed

- records the successful supported GitHub Pages deployment for both accepted protected-main source artefacts;
- records artefact-only rollback to `eced0ae697818b4989ebe95c5bf1572cc6ec90c2` and restoration of `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;
- updates the start-here context and delivery tracker so `QUAL-105` is the active release-assurance workstream;
- clarifies that the live Explorer is a public release candidate until the `v0.1.0` gate passes; and
- corrects the changelog description to distinguish the retained attested source archive from GitHub's supported Pages transport envelope.

## Why

DISC-104 is operationally complete. Both source artefacts deployed through the pinned official Pages transport, the public browser suite passed after each deployment, and rollback and restoration succeeded without rebuilding either product. The repository record must now match that live evidence before release assurance begins.

## Evidence

- public product: https://chris-page-gov.github.io/gis-ai-go/
- accepted source B: protected-main CI run 32324008595 at `a0e826384cf50d9d81b87489dbf3580e8e3602f7`
- CodeQL: run 32324008614 passed Actions, JavaScript/TypeScript and Python analysis
- deploy A: run 32324162767, deployment 5994521091
- deploy B: run 32324285041, deployment 5994542308
- rollback A: run 32324385218, deployment 5994560798
- restore B: run 32324490516, deployment 5994580314
- final live receipt: source `a0e826384cf50d9d81b87489dbf3580e8e3602f7`, payload root `cbc0893a46a4674ef7d13aa4aebcbeb0355f9c8a08286a6500bfc954cb5d6ef6`, OKF root `a620158911cc60259f0ceab2af0dfdd886783a50bfe98000d692fd534bd08ec0`

## Validation

- `pnpm run validate:links` — 290 Markdown links, 183 research hashes and 2 source ledgers passed;
- `pnpm run validate:secrets` — 446 text files passed the baseline secret and machine-path scan;
- `git diff --check` passed;
- immutable research diff is empty; and
- independent evidence review found no remaining P0-P2 or material documentation error.

## Deployment boundary and rollback

This PR changes documentation and a changelog fragment only. It does not rebuild or redeploy the live product. The final accepted deployment remains source commit `a0e826384cf50d9d81b87489dbf3580e8e3602f7`; rollback continues to use the retained accepted source artefacts without rebuilding them.

Refs #6
