### PR TITLE
feat(assurance): complete v0.1.0 release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Install pnpm
@@ -45,6 +46,33 @@ jobs:
 
       - name: Run assurance
         run: pnpm run check
+
+      - name: Enforce release readiness on a version transition
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) base_sha="$PR_BASE_SHA" ;;
+            push) base_sha="$PUSH_BASE_SHA" ;;
+            *) echo 'Unsupported release-transition event' >&2; exit 1 ;;
+          esac
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]] || \
+             [[ "$base_sha" == '0000000000000000000000000000000000000000' ]]; then
+            echo 'A valid event base commit is required for release-transition assurance' >&2
+            exit 1
+          fi
+          git cat-file -e "$base_sha^{commit}"
+          git cat-file -e "$GITHUB_SHA^{commit}"
+          set +e
+          git diff --quiet "$base_sha" "$GITHUB_SHA" -- VERSION
+          version_diff_status=$?
+          set -e
+          case "$version_diff_status" in
+            0) ;;
+            1) pnpm run validate:release-readiness ;;
+            *) echo 'Unable to compare VERSION with the event base' >&2; exit 1 ;;
+          esac
 
       - name: Package immutable Pages source
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && success() }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -168,9 +168,26 @@ jobs:
           path: artifacts/pages
           github-token: ${{ github.token }}
 
+      - name: Read selected archive version
+        id: selected_version
+        run: |
+          selected_version="$(jq -er '
+            if (.version | type) == "string" then
+              .version
+            else
+              error("archive receipt version must be a string")
+            end
+          ' artifacts/pages/archive-receipt.json)"
+          if [[ ! "$selected_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo 'The selected archive version is not a stable semantic version' >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "$selected_version" >> "$GITHUB_OUTPUT"
+
       - name: Verify archive structure and receipt
         env:
           ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          SELECTED_VERSION: ${{ steps.selected_version.outputs.version }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
         run: |
           uv run --locked --cache-dir .uv-cache python scripts/verify_pages_archive.py \
@@ -179,7 +196,7 @@ jobs:
             --receipt artifacts/pages/archive-receipt.json \
             --expected-source-commit "$SOURCE_COMMIT" \
             --expected-repository "$GITHUB_REPOSITORY" \
-            --expected-version "$(tr -d '\n' < VERSION)" \
+            --expected-version "$SELECTED_VERSION" \
             --expected-base-path /gis-ai-go/ \
             --expected-archive-sha256 "$ARCHIVE_SHA256"
 
@@ -199,14 +216,11 @@ jobs:
             --deny-self-hosted-runners \
             --format json > deployment-evidence/attestation-verification.json
 
-      - name: Record accepted product version
+      - name: Record accepted product identity
         id: product
+        env:
+          SELECTED_VERSION: ${{ steps.selected_version.outputs.version }}
         run: |
-          version="$(tr -d '\r\n' < VERSION)"
-          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo 'VERSION is not a stable semantic version' >&2
-            exit 1
-          fi
           okf_content_root="$(jq -r '.okfContentRootSha256' \
             artifacts/pages/archive-receipt.json)"
           payload_root="$(jq -r '.payloadRootSha256' \
@@ -226,7 +240,7 @@ jobs:
             exit 1
           fi
           {
-            printf 'version=%s\n' "$version"
+            printf 'version=%s\n' "$SELECTED_VERSION"
             printf 'okf_content_root=%s\n' "$okf_content_root"
             printf 'payload_root=%s\n' "$payload_root"
             printf 'public_checksums_sha256=%s\n' "$public_checksums_sha256"
@@ -293,6 +307,7 @@ jobs:
       - name: Materialise verified Pages payload
         env:
           ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          SELECTED_VERSION: ${{ steps.selected_version.outputs.version }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
         run: |
           mkdir -p deployment-staging
@@ -303,7 +318,7 @@ jobs:
             --output-dir deployment-staging/site \
             --expected-source-commit "$SOURCE_COMMIT" \
             --expected-repository "$GITHUB_REPOSITORY" \
-            --expected-version "$(tr -d '\r\n' < VERSION)" \
+            --expected-version "$SELECTED_VERSION" \
             --expected-base-path /gis-ai-go/ \
             --expected-archive-sha256 "$ARCHIVE_SHA256"
 
@@ -383,11 +398,73 @@ jobs:
           PUBLIC_BASE_URL: ${{ needs.deploy.outputs.page_url }}
         run: pnpm --filter @gis-ai-go/public-explorer run test:public
 
+      - name: Write public verification receipt
+        env:
+          ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}
+          DEPLOYMENT_MODE: ${{ inputs.mode }}
+          OKF_CONTENT_ROOT: ${{ needs.prepare.outputs.okf_content_root }}
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+          PAYLOAD_ROOT: ${{ needs.prepare.outputs.payload_root }}
+          PRODUCT_VERSION: ${{ needs.prepare.outputs.product_version }}
+          PUBLIC_CHECKSUMS_SHA256: ${{ needs.prepare.outputs.public_checksums_sha256 }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          WORKFLOW_COMMIT: ${{ github.sha }}
+          WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p public-verification-evidence
+          jq -S -n \
+            --arg schemaVersion 'gis-ai-go.pages-public-verification-receipt.v1' \
+            --arg repository "$REPOSITORY" \
+            --arg workflowRun "$WORKFLOW_RUN_URL" \
+            --arg workflowRunAttempt "$WORKFLOW_RUN_ATTEMPT" \
+            --arg workflowRunId "$WORKFLOW_RUN_ID" \
+            --arg workflowCommit "$WORKFLOW_COMMIT" \
+            --arg mode "$DEPLOYMENT_MODE" \
+            --arg publicUrl "$PAGE_URL" \
+            --arg productVersion "$PRODUCT_VERSION" \
+            --arg sourceRunId "$SOURCE_RUN_ID" \
+            --arg sourceCommit "$SOURCE_COMMIT" \
+            --arg archiveSha256 "$ARCHIVE_SHA256" \
+            --arg payloadRoot "$PAYLOAD_ROOT" \
+            --arg okfContentRoot "$OKF_CONTENT_ROOT" \
+            --arg publicChecksumsSha256 "$PUBLIC_CHECKSUMS_SHA256" \
+            '{
+              schemaVersion: $schemaVersion,
+              repository: $repository,
+              workflowRun: $workflowRun,
+              workflowRunAttempt: $workflowRunAttempt,
+              workflowRunId: $workflowRunId,
+              workflowCommit: $workflowCommit,
+              mode: $mode,
+              publicUrl: $publicUrl,
+              productVersion: $productVersion,
+              sourceRunId: $sourceRunId,
+              sourceCommit: $sourceCommit,
+              archiveSha256: $archiveSha256,
+              payloadRootSha256: $payloadRoot,
+              okfContentRootSha256: $okfContentRoot,
+              publicChecksumsSha256: $publicChecksumsSha256
+            }' > public-verification-evidence/public-verification-receipt.json
+
       - name: Upload public verification evidence
-        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: public-verification-${{ inputs.source_commit }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            public-verification-evidence/public-verification-receipt.json
+            apps/public-explorer/test-results/
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload failed public verification diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-verification-failure-${{ inputs.source_commit }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: apps/public-explorer/test-results/
           if-no-files-found: warn
           retention-days: 90

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -75,6 +75,14 @@ reproducible GitHub Pages deployment.
 
 ## Latest evidence
 
+- QUAL-105 complete local gate: type checking, 4 gateway tests, 16 Explorer
+  build-policy tests, 42 Explorer unit and component tests, 82 repository Python
+  tests, 2 execution-boundary tests and 27 real-browser tests pass;
+- QUAL-105 reproducibility: two complete clean locked builds produce byte-identical
+  Pages archives, checksums and receipts; the public workflow now emits a mandatory
+  canonical verification receipt after a successful deployed-browser gate;
+- QUAL-105 independent security and accessibility reviews: no P0-P2 finding or
+  material evidence error remains;
 - canonical OKF content, Explorer, reviewed public examples and supported Pages
   publication: merged on protected `main` at
   `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;

--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@ boundary is deliberately broader than AI or MCP.
 
 ## Status
 
-**Stage 0 is verified and `v0.1.0` is in active delivery.** The foundation contains
-governance, candidate contracts, synthetic fixtures, architecture sources and an
-assurance harness. The first functional release will add the accessible public
-discovery product described in the [roadmap](docs/implementation/ROADMAP.md).
+**Stage 0 is verified and `v0.1.0` is in release assurance.** The accessible public
+discovery product described in the [roadmap](docs/implementation/ROADMAP.md) is
+deployed as a release candidate at <https://chris-page-gov.github.io/gis-ai-go/>.
+It is not yet a supported release.
 
-The Explorer is implemented as a local static build but is not yet deployed; there
-is no MCP service. Live status is in
+The Explorer is a static, metadata-only product; there is no MCP service. Live status is in
 [`PROGRESS.md`](PROGRESS.md); current authority and boundaries are in
 [`CONTEXT.md`](CONTEXT.md); notable changes are in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/apps/public-explorer/test/browser/accessibility.spec.ts
+++ b/apps/public-explorer/test/browser/accessibility.spec.ts
@@ -1,4 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
+import type { Locator, Page } from "@playwright/test";
 
 import { expect, test } from "../fixtures/assurance";
 
@@ -9,13 +10,28 @@ const views = [
   ["map", "Coverage schematic — not a property map"],
 ] as const;
 
+async function expectKeyboardVisibleFocusOutline(
+  page: Page,
+  control: Locator,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await page.keyboard.press("Tab");
+    if (await control.evaluate((element) => element === document.activeElement)) break;
+  }
+  await expect(control).toBeFocused();
+  await expect(control).toHaveCSS("outline-style", "solid");
+  await expect(control).toHaveCSS("outline-width", "3px");
+  await expect(control).toHaveCSS("outline-offset", "2px");
+  await expect(control).not.toHaveCSS("outline-color", "rgba(0, 0, 0, 0)");
+}
+
 for (const [view, heading] of views) {
   test(`${view} view has no detectable WCAG A or AA violations`, async ({ page }) => {
     await page.goto(`/?view=${view}`);
     await expect(page.getByRole("heading", { level: 2, name: heading })).toBeVisible();
 
     const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"])
       .analyze();
     expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
   });
@@ -54,11 +70,45 @@ test("visual catalogue views provide complete text alternatives", async ({ page 
   ).toBeVisible();
 });
 
-test.describe("small touch viewport", () => {
+test("shows visible keyboard focus on links, form controls and view controls", async ({ page }) => {
+  await page.goto("/?view=cards&q=Price%20Paid");
+  await expect(page.getByRole("heading", { level: 2, name: "Catalogue" })).toBeVisible();
+
+  await expectKeyboardVisibleFocusOutline(
+    page,
+    page.locator('a[href$="#record=hmlr%3Adataset%3Aprice-paid-data"]'),
+  );
+
+  await page.goto("/?view=cards&q=Price%20Paid");
+  await expectKeyboardVisibleFocusOutline(
+    page,
+    page.getByRole("searchbox", { name: /Search(?: the public)? catalogue/i }),
+  );
+
+  await page.goto("/?view=cards&q=Price%20Paid");
+  await expectKeyboardVisibleFocusOutline(
+    page,
+    page.getByRole("link", { name: /^Graph$/i }),
+  );
+});
+
+test.describe("320 CSS-pixel, 400% zoom-equivalent reflow", () => {
   test.use({ hasTouch: true, viewport: { height: 800, width: 320 } });
 
   test("remains operable without document-level horizontal scrolling", async ({ page }) => {
+    // Playwright cannot set optical browser zoom reliably. A 320 CSS-pixel viewport
+    // exercises the WCAG reflow equivalent of a 1,280 CSS-pixel viewport at 400%.
     await page.goto("/?view=cards");
+
+    const search = page.getByRole("searchbox", {
+      name: /Search(?: the public)? catalogue/i,
+    });
+    await search.fill("Price Paid");
+    await page.getByRole("button", { name: /^Search$/i }).tap();
+    await expect(
+      page.locator('a[href$="#record=hmlr%3Adataset%3Aprice-paid-data"]'),
+    ).toBeVisible();
+
     await page.getByRole("link", { name: /^Map$/i }).tap();
     await expect(
       page.getByRole("heading", { level: 2, name: "Coverage schematic — not a property map" }),

--- a/apps/public-explorer/test/browser/journeys.spec.ts
+++ b/apps/public-explorer/test/browser/journeys.spec.ts
@@ -2,6 +2,99 @@ import { expect, test } from "../fixtures/assurance";
 
 const PRICE_PAID_ID = "hmlr:dataset:price-paid-data";
 
+const INERT_WEBMCP_SENTINEL = String.raw`
+(() => {
+  const activity = [];
+  const record = (message) => {
+    activity.push(message);
+  };
+  const method = (name) => new Proxy(Object.freeze(function () {}), {
+    apply() {
+      record(name + " called");
+      return undefined;
+    },
+    construct() {
+      record(name + " constructed");
+      return {};
+    },
+    set() {
+      record(name + " property set");
+      return false;
+    },
+    defineProperty() {
+      record(name + " property defined");
+      return false;
+    },
+    deleteProperty() {
+      record(name + " property deleted");
+      return false;
+    },
+    setPrototypeOf() {
+      record(name + " prototype changed");
+      return false;
+    },
+  });
+  const target = Object.freeze(Object.assign(function () {}, {
+    registerTool: method("registerTool"),
+    unregisterTool: method("unregisterTool"),
+    provideContext: method("provideContext"),
+    clearContext: method("clearContext"),
+  }));
+  const sentinel = new Proxy(target, {
+    apply() {
+      record("sentinel called");
+      return undefined;
+    },
+    construct() {
+      record("sentinel constructed");
+      return {};
+    },
+    set() {
+      record("sentinel property set");
+      return false;
+    },
+    defineProperty() {
+      record("sentinel property defined");
+      return false;
+    },
+    deleteProperty() {
+      record("sentinel property deleted");
+      return false;
+    },
+    setPrototypeOf() {
+      record("sentinel prototype changed");
+      return false;
+    },
+  });
+
+  const expose = (owner, name, label) => {
+    Object.defineProperty(owner, name, {
+      configurable: false,
+      enumerable: false,
+      get: () => sentinel,
+      set: () => record(label + " replaced"),
+    });
+  };
+  expose(globalThis, "webMCP", "globalThis.webMCP");
+  expose(globalThis, "modelContext", "globalThis.modelContext");
+  expose(navigator, "modelContext", "navigator.modelContext");
+
+  Object.defineProperty(globalThis, "__gisAiGoWebMcpAudit", {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: Object.freeze({
+      snapshot: () => ({
+        activity: [...activity],
+        globalModelContextIntact: Reflect.get(globalThis, "modelContext") === sentinel,
+        navigatorModelContextIntact: Reflect.get(navigator, "modelContext") === sentinel,
+        webMCPIntact: Reflect.get(globalThis, "webMCP") === sentinel,
+      }),
+    }),
+  });
+})();
+`;
+
 test("answers the focused question by default without WebMCP", async ({ page }) => {
   await page.goto("/");
 
@@ -37,6 +130,75 @@ test("answers the focused question by default without WebMCP", async ({ page }) 
     globalModelContext: undefined,
     navigatorModelContext: undefined,
     webMCP: undefined,
+  });
+});
+
+test("gracefully ignores inert WebMCP sentinels during the focused journey", async ({ page }) => {
+  // This is graceful non-use assurance, not a claim of WebMCP capability or interoperability.
+  await page.route("**/webmcp-sentinel.js", async (route) => {
+    await route.fulfill({
+      body: INERT_WEBMCP_SENTINEL,
+      contentType: "application/javascript; charset=utf-8",
+      status: 200,
+    });
+  });
+
+  let sentinelInjected = false;
+  await page.route(
+    "**/",
+    async (route) => {
+      const response = await route.fetch();
+      const html = await response.text();
+      const moduleMarker = '<script type="module"';
+      if (!html.includes(moduleMarker)) {
+        throw new Error("Explorer entry page has no module script marker");
+      }
+      sentinelInjected = true;
+      await route.fulfill({
+        response,
+        body: html.replace(
+          moduleMarker,
+          '<script src="./webmcp-sentinel.js"></script>\n    <script type="module"',
+        ),
+      });
+    },
+    { times: 1 },
+  );
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", {
+      level: 1,
+      name: "INSPIRE polygon: indicative or legal boundary?",
+    }),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByText(
+        "Polygons are indicative and do not establish the exact legal extent of a title.",
+        { exact: true },
+      )
+      .first(),
+  ).toBeVisible();
+  expect(sentinelInjected).toBe(true);
+
+  const audit = await page.evaluate(() => {
+    const value = Reflect.get(globalThis, "__gisAiGoWebMcpAudit") as {
+      snapshot: () => {
+        activity: string[];
+        globalModelContextIntact: boolean;
+        navigatorModelContextIntact: boolean;
+        webMCPIntact: boolean;
+      };
+    };
+    return value.snapshot();
+  });
+  expect(audit).toEqual({
+    activity: [],
+    globalModelContextIntact: true,
+    navigatorModelContextIntact: true,
+    webMCPIntact: true,
   });
 });
 

--- a/apps/public-explorer/test/browser/public-deployment.spec.ts
+++ b/apps/public-explorer/test/browser/public-deployment.spec.ts
@@ -300,7 +300,7 @@ test("passes public keyboard, WCAG and 320-pixel reflow acceptance", async ({ pa
   await expect(page.locator("#main-content")).toBeFocused();
 
   const violations = await new AxeBuilder({ page })
-    .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"])
     .analyze();
   expect(violations.violations, JSON.stringify(violations.violations, null, 2)).toEqual([]);
   expect(

--- a/changelog.d/QUAL-105.security.md
+++ b/changelog.d/QUAL-105.security.md
@@ -1,0 +1,2 @@
+- Added release-level reproducibility, optional-browser-API, visible-focus and
+  post-deployment receipt assurance for the public discovery product.

--- a/docs/implementation/DELIVERY_AND_RELEASE.md
+++ b/docs/implementation/DELIVERY_AND_RELEASE.md
@@ -31,6 +31,12 @@ same-pattern tests.
   capabilities and patch releases remain backwards compatible.
 - Keep `VERSION`, root/component npm and Python manifests and workspace-lock versions
   synchronised. `pnpm run validate:versions` enforces this invariant.
+- Run `pnpm run validate:release-readiness` in a release pull request. That explicit
+  gate additionally requires the dated changelog section, exact release link,
+  matching release notes and consumed material fragments. Required CI invokes it
+  automatically whenever `VERSION` changes in a pull request and again on the
+  resulting `main` push. Ordinary feature pull requests with an unchanged version
+  do not run the release-only metadata checks.
 - Feature branches add `changelog.d` fragments; the release pull request folds them
   into `CHANGELOG.md` and deletes them.
 - The release commit is the only commit that changes versions, finalises the dated

--- a/docs/operations/QUAL-105_VERIFICATION.md
+++ b/docs/operations/QUAL-105_VERIFICATION.md
@@ -1,0 +1,147 @@
+# QUAL-105 release-assurance verification record
+
+- status: implementation candidate
+- reviewed on: 20 August 2026
+- work item: [QUAL-105](https://github.com/chris-page-gov/gis-ai-go/issues/7)
+- release target: `v0.1.0`
+- public candidate: <https://chris-page-gov.github.io/gis-ai-go/>
+
+## Outcome
+
+QUAL-105 is the final assurance gate before assembling the first supported public
+discovery release. It does not add runtime capability. It closes evidence gaps for
+whole-product reproducibility, optional browser-API non-use, visible keyboard focus
+and durable post-deployment verification.
+
+The release remains a static, public, metadata-only discovery product. This gate
+does not claim an MCP listener, provider execution, identity integration, policy
+engine, protected-data integration or production service assurance.
+
+## Accepted baseline
+
+- DISC-104 deployment evidence is merged on protected `main` at
+  `5cc1626c9e412393a520b463c6ba670ee51799f0`;
+- main assurance and provenance passed in
+  [run 32325393703](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32325393703);
+- CodeQL for Actions, JavaScript/TypeScript and Python passed in
+  [run 32325393339](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32325393339);
+- the final DISC-104 restore passed in
+  [run 32324490516](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32324490516),
+  deployment `5994580314`; and
+- on 20 August 2026, the repository had no open CodeQL, Dependabot or secret-scanning
+  alerts.
+
+The live candidate reports source
+`a0e826384cf50d9d81b87489dbf3580e8e3602f7`, version `0.0.0`, payload root
+`cbc0893a46a4674ef7d13aa4aebcbeb0355f9c8a08286a6500bfc954cb5d6ef6` and OKF
+content root `a620158911cc60259f0ceab2af0dfdd886783a50bfe98000d692fd534bd08ec0`.
+
+## Acceptance matrix
+
+### Release journeys and negative cases
+
+The candidate retains the complete catalogue, direct-route, back/forward, download,
+hostile-state, CSP, network, forced-colours, reduced-motion and small-viewport
+browser suites. It adds a WebMCP-present case with inert sentinels and proves that
+the Explorer neither invokes, replaces nor mutates them. This is graceful non-use
+evidence, not a WebMCP capability claim.
+
+### Security and accessibility findings
+
+The required repository scan, CodeQL, dependency and secret-alert state must remain
+clear of unresolved Critical or High findings. Axe WCAG A/AA checks, keyboard use,
+visible focus, forced colours, reduced motion and 320 CSS-pixel reflow must pass.
+The 320 CSS-pixel case is the reflow equivalent of a 1,280 CSS-pixel viewport at
+400% zoom; it does not claim optical-zoom testing.
+
+### Record evidence contract
+
+The canonical build and Explorer parser require every one of the 36 public records
+to provide authority, access, rights, freshness and one or more resolved source
+references. Selected HMLR, ONS and LandIS records retain their stricter rights,
+provenance and legal caveat checks.
+
+### Clean-build and archive reproducibility
+
+The release gate removes only the three declared generated roots, runs the complete
+locked OKF and Explorer build twice, packages each result through the production
+Pages packager, then requires byte equality for `artifact.tar`,
+`artifact.tar.sha256` and `archive-receipt.json`. It fails on any output difference
+and reports the common archive SHA-256 on success.
+
+### Deployed identity and console
+
+DISC-104 proved the exact live commit, payload, OKF root, checksum ledger, primary
+journeys, clean console and publication-path-only network boundary across original
+deployment, rollback and restoration. The tagged release must repeat this public
+gate and retain a successful `public-verification-receipt.json` before the GitHub
+Release is published.
+
+### Release evidence and metadata
+
+A supported non-`0.0.0` version must have synchronised manifests and workspace
+locks, a dated changelog section, exact release link, matching release-notes file
+and no unconsumed material changelog fragments. Required CI invokes
+`pnpm run validate:release-readiness` when `VERSION` changes, while post-release
+feature branches with an unchanged version may retain their required changelog
+fragments. The public workflow must upload a canonical verification receipt even
+when the passing browser run produces no trace or failure file.
+
+## Candidate verification
+
+The working-tree candidate passed:
+
+- TypeScript type checking, 4 gateway tests, 16 Explorer build-policy tests and 42
+  Explorer unit and component tests;
+- 82 repository Python tests and 2 execution-boundary tests, including 5 release
+  reproducibility contracts, 15 Pages workflow contracts and release-metadata
+  regressions;
+- 27 local real-browser tests, including the added WebMCP-present, visible-focus and
+  400%-equivalent reflow cases;
+- two complete clean locked builds with byte-identical `artifact.tar`, checksum and
+  archive receipt outputs;
+- validation of 291 local Markdown links, 183 immutable research hashes and 2 source
+  ledger snapshots resolving 71 source identifiers;
+- a scan of 450 text files with no baseline secret or machine-path match; and
+- an unchanged immutable research tree.
+
+The complete local `pnpm run check` passed on 20 August 2026. It also validated 8
+schemas and 53 records, rendered 9 diagrams and generated a 145-component CycloneDX
+SBOM. Independent accessibility review repeated the corrected browser evidence and
+found no P0-P2 or material evidence error. A final exact-snapshot Codex Security
+diff scan covered all 17 changed or added files and directly supporting controls;
+no P0-P2 finding survived validation and reportability review.
+
+Protected pull-request assurance and CodeQL must still pass on the committed
+candidate. Required merge evidence is:
+
+- the exact committed candidate and pull request;
+- required `assurance` on that head;
+- CodeQL for Actions, JavaScript/TypeScript and Python; and
+- the resulting protected-main assurance and provenance after merge.
+
+## Limitations and residual risks
+
+- The product is a static metadata catalogue, not an HMLR, ONS, Ordnance Survey or
+  LandIS operational service and is not endorsed by those providers.
+- HMLR INSPIRE polygons are indicative and do not establish the exact legal extent
+  of a title. The schematic view is not a property or parcel map.
+- Source currency, access and reuse remain record- and provider-specific; users must
+  follow the displayed evidence and official source terms.
+- Automated axe and browser checks are strong regression evidence but do not replace
+  a specialist accessibility audit or user research with disabled people.
+- CodeQL, dependency alerts and the repository secret scan are baselines, not a
+  penetration test or a security assessment of later service, identity or provider
+  integrations.
+- The WebMCP-present test proves inert compatibility only. No WebMCP tool is exposed
+  or supported in `v0.1.0`.
+- GitHub Pages supplies the hosting boundary. The application enforces its exact
+  meta Content Security Policy, but the repository does not control response-header
+  policies such as `frame-ancestors`.
+- Actions artefacts expire. The supported release must attach the canonical archive,
+  checksum, receipt, SBOM, attestation verification and public-verification evidence
+  to its immutable GitHub Release.
+
+QUAL-105 remains open until the tagged `v0.1.0` artefact is deployed, its public
+receipt passes, the GitHub Release and durable assets exist, and final evidence is
+merged on protected `main`.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -3,7 +3,8 @@
 This directory preserves the Stage 0 boundary, dependency baseline and verification
 as historical evidence. Current authority and status are in [`CONTEXT.md`](../../CONTEXT.md)
 and [`PROGRESS.md`](../../PROGRESS.md); ADR-0004 records progression beyond the local
-pause. There is no deployed product yet.
+pause. The static Explorer is deployed as a public release candidate; no supported
+release or MCP service exists yet.
 
 - [Stage 0 boundary](STAGE_0_BOUNDARY.md)
 - [Dependency baseline](DEPENDENCIES.md)
@@ -12,3 +13,4 @@ pause. There is no deployed product yet.
 - [DISC-103 reviewed examples verification record](DISC-103_VERIFICATION.md)
 - [DISC-104 GitHub Pages runbook](DISC-104_RUNBOOK.md)
 - [DISC-104 GitHub Pages verification record](DISC-104_VERIFICATION.md)
+- [QUAL-105 release-assurance verification record](QUAL-105_VERIFICATION.md)

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
     "test": "pnpm run test:typescript && pnpm run test:explorer && pnpm run test:python",
     "build:okf": "uv run --locked --cache-dir .uv-cache python scripts/build_okf.py --output artifacts/okf",
     "build:explorer": "pnpm run build:okf && pnpm --filter @gis-ai-go/public-explorer run build",
+    "validate:release-reproducibility": "uv run --locked --cache-dir .uv-cache python scripts/check_release_reproducibility.py",
     "validate:contracts": "uv run --locked --cache-dir .uv-cache python scripts/validate_contracts.py",
     "validate:versions": "uv run --locked --cache-dir .uv-cache python scripts/check_versions.py",
+    "validate:release-readiness": "uv run --locked --cache-dir .uv-cache python scripts/check_versions.py --release-ready",
     "validate:links": "uv run --locked --cache-dir .uv-cache python scripts/check_links.py",
     "validate:secrets": "uv run --locked --cache-dir .uv-cache python scripts/scan_secrets.py",
     "render:diagrams": "node scripts/render_diagrams.mjs --output artifacts/diagrams",
     "sbom": "uv run --locked --cache-dir .uv-cache python scripts/generate_sbom.py --output artifacts/sbom.cdx.json",
-    "check": "pnpm run typecheck && pnpm run test && pnpm run test:browser && pnpm run validate:versions && pnpm run validate:contracts && pnpm run validate:links && pnpm run validate:secrets && pnpm run render:diagrams && pnpm run sbom"
+    "check": "pnpm run typecheck && pnpm run test && pnpm run test:browser && pnpm run validate:release-reproducibility && pnpm run validate:versions && pnpm run validate:contracts && pnpm run validate:links && pnpm run validate:secrets && pnpm run render:diagrams && pnpm run sbom"
   },
   "devDependencies": {
     "@types/node": "24.13.3",

--- a/scripts/check_release_reproducibility.py
+++ b/scripts/check_release_reproducibility.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Prove that two clean, locked GIS AI GO release builds are byte-identical."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_REPOSITORY = "chris-page-gov/gis-ai-go"
+EXPECTED_BASE_PATH = "/gis-ai-go/"
+GENERATED_ROOTS = (
+    PurePosixPath("apps/public-explorer/dist"),
+    PurePosixPath("apps/public-explorer/public/catalogue"),
+    PurePosixPath("artifacts/okf"),
+)
+GENERATED_MARKERS = {
+    PurePosixPath("apps/public-explorer/public/catalogue"): (
+        ".explorer-generated",
+        b"gis-ai-go-public-explorer-data.v1\n",
+    ),
+    PurePosixPath("artifacts/okf"): (
+        ".okf-generated",
+        b"gis-ai-go-okf-builder.v1\n",
+    ),
+}
+RELEASE_OUTPUTS = (
+    "artifact.tar",
+    "artifact.tar.sha256",
+    "archive-receipt.json",
+)
+BUILD_COMMAND = ("pnpm", "run", "build:explorer")
+BUILD_TIMEOUT_SECONDS = 5 * 60
+PACKAGE_TIMEOUT_SECONDS = 2 * 60
+MAX_GENERATED_FILES = 10_000
+MAX_GENERATED_BYTES = 128 * 1024 * 1024
+MAX_RELEASE_OUTPUT_BYTES = 160 * 1024 * 1024
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+VERSION_RE = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\Z")
+CHECKSUM_ROW_RE = re.compile(r"([0-9a-f]{64})  (.+)\Z")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _safe_relative_path(value: str, label: str) -> str:
+    logical = PurePosixPath(value)
+    if (
+        not value
+        or value.startswith("/")
+        or "\\" in value
+        or "\0" in value
+        or logical.is_absolute()
+        or any(part in {"", ".", ".."} for part in logical.parts)
+    ):
+        raise ValueError(f"unsafe {label} path: {value!r}")
+    return value
+
+
+def _expected_directories(files: set[str]) -> set[str]:
+    directories: set[str] = set()
+    for value in files:
+        parts = PurePosixPath(value).parts[:-1]
+        for length in range(1, len(parts) + 1):
+            directories.add(PurePosixPath(*parts[:length]).as_posix())
+    return directories
+
+
+def _inventory_regular_tree(root: Path, label: str) -> tuple[set[str], set[str]]:
+    metadata = root.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"{label} root must be a real directory")
+
+    directories: set[str] = set()
+    files: set[str] = set()
+    total_bytes = 0
+
+    def visit(directory: Path, prefix: PurePosixPath | None = None) -> None:
+        nonlocal total_bytes
+        with os.scandir(directory) as entries:
+            ordered = sorted(entries, key=lambda entry: entry.name)
+        for entry in ordered:
+            relative = entry.name if prefix is None else f"{prefix.as_posix()}/{entry.name}"
+            _safe_relative_path(relative, label)
+            entry_metadata = entry.stat(follow_symlinks=False)
+            if stat.S_ISLNK(entry_metadata.st_mode):
+                raise ValueError(f"{label} must not contain symbolic links: {relative}")
+            if stat.S_ISDIR(entry_metadata.st_mode):
+                directories.add(relative)
+                visit(Path(entry.path), PurePosixPath(relative))
+                continue
+            if not stat.S_ISREG(entry_metadata.st_mode):
+                raise ValueError(f"{label} must contain regular files only: {relative}")
+            if entry_metadata.st_nlink != 1:
+                raise ValueError(f"{label} must not contain hard-linked files: {relative}")
+            total_bytes += entry_metadata.st_size
+            if total_bytes > MAX_GENERATED_BYTES:
+                raise ValueError(f"{label} exceeds {MAX_GENERATED_BYTES} bytes")
+            if len(files) >= MAX_GENERATED_FILES:
+                raise ValueError(f"{label} exceeds {MAX_GENERATED_FILES} files")
+            files.add(relative)
+
+    visit(root)
+    return directories, files
+
+
+def _parse_checksum_ledger(value: bytes, label: str) -> list[tuple[str, str]]:
+    try:
+        text = value.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{label} checksum ledger must be UTF-8") from error
+    if not text.endswith("\n"):
+        raise ValueError(f"{label} checksum ledger must end with a newline")
+    rows: list[tuple[str, str]] = []
+    for line in text[:-1].split("\n"):
+        match = CHECKSUM_ROW_RE.fullmatch(line)
+        if match is None:
+            raise ValueError(f"invalid {label} checksum row: {line!r}")
+        rows.append((match.group(1), _safe_relative_path(match.group(2), label)))
+    paths = [path for _, path in rows]
+    if not rows or paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise ValueError(f"{label} checksum paths must be non-empty, unique and sorted")
+    return rows
+
+
+def _validate_checksum_generated_root(
+    target: Path,
+    *,
+    label: str,
+    marker_name: str,
+    marker_value: bytes,
+    source_commit: str,
+    version: str,
+) -> None:
+    directories, files = _inventory_regular_tree(target, label)
+    marker_path = target / marker_name
+    checksum_path = target / "CHECKSUMS.sha256"
+    if marker_name not in files or marker_path.read_bytes() != marker_value:
+        raise ValueError(f"refusing to remove {label}: generated marker is missing or invalid")
+    if "CHECKSUMS.sha256" not in files:
+        raise ValueError(f"refusing to remove {label}: checksum ledger is missing")
+    rows = _parse_checksum_ledger(checksum_path.read_bytes(), label)
+    locked_paths = [path for _, path in rows]
+    if marker_name in locked_paths or "CHECKSUMS.sha256" in locked_paths:
+        raise ValueError(f"refusing to remove {label}: checksum inventory is recursive")
+    expected_files = {marker_name, "CHECKSUMS.sha256", *locked_paths}
+    if files != expected_files or directories != _expected_directories(expected_files):
+        raise ValueError(f"refusing to remove {label}: inventory is not exactly generated")
+    for expected, relative in rows:
+        value = (target / relative).read_bytes()
+        if sha256_bytes(value) != expected:
+            raise ValueError(f"refusing to remove {label}: checksum mismatch for {relative}")
+
+    try:
+        receipt = json.loads((target / "build-receipt.json").read_bytes())
+    except (FileNotFoundError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"refusing to remove {label}: build receipt is invalid") from error
+    if not isinstance(receipt, dict):
+        raise ValueError(f"refusing to remove {label}: build receipt must be an object")
+    if receipt.get("revision") != source_commit or receipt.get("version") != version:
+        raise ValueError(f"refusing to remove {label}: build identity differs from this checkout")
+
+
+def _load_pages_packager() -> ModuleType:
+    path = ROOT / "scripts/package_pages.py"
+    specification = importlib.util.spec_from_file_location("gis_ai_go_package_pages", path)
+    if specification is None or specification.loader is None:
+        raise RuntimeError("cannot load the canonical Pages packager")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _validate_distribution(target: Path, source_commit: str, version: str) -> None:
+    label = "Explorer distribution"
+    directories, files = _inventory_regular_tree(target, label)
+    packager = _load_pages_packager()
+    distribution = packager.inventory_regular_files(target)
+    if files != set(distribution) or directories != _expected_directories(files):
+        raise ValueError("refusing to remove Explorer distribution: inventory is not exact")
+    packager.require_checked_distribution(distribution, version, source_commit)
+
+
+def resolve_cleanup_target(root: Path, relative: PurePosixPath | str) -> Path:
+    """Resolve one exact generated root without following repository symlinks."""
+    logical = PurePosixPath(relative)
+    if logical not in GENERATED_ROOTS:
+        raise ValueError(f"cleanup target is not allowlisted: {logical.as_posix()}")
+    root_metadata = root.lstat()
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError("repository root must be a real directory")
+
+    current = root
+    for part in logical.parts[:-1]:
+        current = current / part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            return root.joinpath(*logical.parts)
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"cleanup parent must be a real directory: {current}")
+    return root.joinpath(*logical.parts)
+
+
+def clean_generated_roots(root: Path, source_commit: str, version: str) -> list[str]:
+    """Validate every present root first, then remove only the fixed generated roots."""
+    if not COMMIT_RE.fullmatch(source_commit):
+        raise ValueError("source commit must be a full lower-case Git commit")
+    if not VERSION_RE.fullmatch(version):
+        raise ValueError("version must be a stable semantic version")
+    targets: list[tuple[PurePosixPath, Path]] = []
+    for relative in GENERATED_ROOTS:
+        target = resolve_cleanup_target(root, relative)
+        if not target.exists() and not target.is_symlink():
+            continue
+        metadata = target.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"refusing to remove non-directory generated root: {relative}")
+        if relative == GENERATED_ROOTS[0]:
+            _validate_distribution(target, source_commit, version)
+        else:
+            marker_name, marker_value = GENERATED_MARKERS[relative]
+            _validate_checksum_generated_root(
+                target,
+                label=relative.as_posix(),
+                marker_name=marker_name,
+                marker_value=marker_value,
+                source_commit=source_commit,
+                version=version,
+            )
+        targets.append((relative, target))
+
+    if targets and not shutil.rmtree.avoids_symlink_attacks:
+        raise RuntimeError("secure generated-root cleanup is unavailable on this platform")
+    removed: list[str] = []
+    for relative, target in targets:
+        metadata = target.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"generated root changed before cleanup: {relative}")
+        shutil.rmtree(target)
+        if target.exists() or target.is_symlink():
+            raise RuntimeError(f"generated root remains after cleanup: {relative}")
+        removed.append(relative.as_posix())
+    return removed
+
+
+def _release_output_bytes(root: Path) -> dict[str, bytes]:
+    metadata = root.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError("release output root must be a real directory")
+    actual = {path.name for path in root.iterdir()}
+    expected = set(RELEASE_OUTPUTS)
+    if actual != expected:
+        raise ValueError(
+            "release output inventory must be exactly the three canonical files; "
+            f"missing={sorted(expected - actual)}; extra={sorted(actual - expected)}"
+        )
+    values: dict[str, bytes] = {}
+    for name in RELEASE_OUTPUTS:
+        path = root / name
+        file_metadata = path.lstat()
+        if (
+            stat.S_ISLNK(file_metadata.st_mode)
+            or not stat.S_ISREG(file_metadata.st_mode)
+            or file_metadata.st_nlink != 1
+        ):
+            raise ValueError(f"release output must be an ordinary single-link file: {name}")
+        if file_metadata.st_size > MAX_RELEASE_OUTPUT_BYTES:
+            raise ValueError(f"release output exceeds {MAX_RELEASE_OUTPUT_BYTES} bytes: {name}")
+        values[name] = path.read_bytes()
+    return values
+
+
+def compare_release_outputs(first: Path, second: Path) -> dict[str, str]:
+    """Require exact inventories and byte equality for all three release outputs."""
+    first_values = _release_output_bytes(first)
+    second_values = _release_output_bytes(second)
+    differences = [
+        name for name in RELEASE_OUTPUTS if first_values[name] != second_values[name]
+    ]
+    if differences:
+        detail = ", ".join(
+            f"{name} ({sha256_bytes(first_values[name])} != "
+            f"{sha256_bytes(second_values[name])})"
+            for name in differences
+        )
+        raise ValueError(f"clean release builds are not byte-identical: {detail}")
+    return {name: sha256_bytes(first_values[name]) for name in RELEASE_OUTPUTS}
+
+
+def _run(command: list[str] | tuple[str, ...], *, root: Path, timeout: int) -> None:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CI": "1",
+            "LANG": "C",
+            "LC_ALL": "C",
+            "SOURCE_DATE_EPOCH": "0",
+            "TZ": "UTC",
+        }
+    )
+    subprocess.run(command, cwd=root, check=True, env=environment, timeout=timeout)
+
+
+def _git_head(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    value = result.stdout.strip()
+    if not COMMIT_RE.fullmatch(value):
+        raise ValueError("Git HEAD is not a full lower-case commit")
+    return value
+
+
+def _package(root: Path, output: Path, source_commit: str, version: str) -> None:
+    _run(
+        [
+            sys.executable,
+            "scripts/package_pages.py",
+            "--dist",
+            "apps/public-explorer/dist",
+            "--output-dir",
+            str(output),
+            "--source-commit",
+            source_commit,
+            "--repository",
+            EXPECTED_REPOSITORY,
+            "--version",
+            version,
+            "--base-path",
+            EXPECTED_BASE_PATH,
+        ],
+        root=root,
+        timeout=PACKAGE_TIMEOUT_SECONDS,
+    )
+
+
+def check_release_reproducibility(root: Path = ROOT) -> dict[str, str]:
+    source_commit = _git_head(root)
+    version = (root / "VERSION").read_text(encoding="utf-8").strip()
+    if not VERSION_RE.fullmatch(version):
+        raise ValueError("VERSION must contain one stable semantic version")
+
+    with tempfile.TemporaryDirectory(prefix="gis-ai-go-release-reproducibility-") as temporary:
+        outputs: list[Path] = []
+        for build_number in (1, 2):
+            removed = clean_generated_roots(root, source_commit, version)
+            print(
+                f"Starting clean release build {build_number}/2; "
+                f"removed={','.join(removed) if removed else 'none'}.",
+                flush=True,
+            )
+            _run(BUILD_COMMAND, root=root, timeout=BUILD_TIMEOUT_SECONDS)
+            output = Path(temporary) / f"build-{build_number}"
+            _package(root, output, source_commit, version)
+            outputs.append(output)
+        digests = compare_release_outputs(outputs[0], outputs[1])
+
+    print(
+        "Two clean locked builds produced byte-identical release outputs: "
+        + ", ".join(f"{name}=sha256:{digests[name]}" for name in RELEASE_OUTPUTS)
+        + ".",
+        flush=True,
+    )
+    return digests
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    check_release_reproducibility()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import tomllib
 from pathlib import Path
+from typing import Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
 STABLE_SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+RELEASE_DATE = r"\d{4}-\d{2}-\d{2}"
 
 
 def is_valid_product_version(value: str) -> bool:
@@ -24,7 +27,76 @@ def load_toml(path: Path) -> dict[str, object]:
         return tomllib.load(handle)
 
 
-def main() -> None:
+def release_metadata_errors(root: Path, version: str) -> list[str]:
+    """Return release metadata errors for a supported, non-bootstrap version."""
+    if version == "0.0.0":
+        return []
+
+    errors: list[str] = []
+    changelog_path = root / "CHANGELOG.md"
+    if changelog_path.is_file():
+        changelog = changelog_path.read_text(encoding="utf-8")
+    else:
+        changelog = ""
+        errors.append("CHANGELOG.md is missing")
+    release_header = re.compile(
+        rf"^## \[{re.escape(version)}\] - {RELEASE_DATE}$",
+        re.MULTILINE,
+    )
+    if release_header.search(changelog) is None:
+        errors.append(f"CHANGELOG.md has no dated [{version}] release section")
+
+    release_link = (
+        f"[{version}]: https://github.com/chris-page-gov/gis-ai-go/releases/tag/v{version}"
+    )
+    if release_link not in changelog.splitlines():
+        errors.append(f"CHANGELOG.md has no exact [{version}] release link")
+
+    release_notes = root / "RELEASE_NOTES" / f"{version}.md"
+    if not release_notes.is_file():
+        errors.append(f"{release_notes.relative_to(root).as_posix()} is missing")
+    elif not release_notes.read_text(encoding="utf-8").strip():
+        errors.append(f"{release_notes.relative_to(root).as_posix()} is empty")
+
+    fragment_directory = root / "changelog.d"
+    if not (fragment_directory / "README.md").is_file():
+        errors.append("changelog.d/README.md is missing")
+    fragments = sorted(
+        path.name
+        for path in fragment_directory.glob("*.md")
+        if path.name != "README.md"
+    )
+    if fragments:
+        errors.append(f"unconsumed changelog fragments: {', '.join(fragments)}")
+
+    return errors
+
+
+def release_readiness_errors(
+    root: Path,
+    version: str,
+    *,
+    release_ready: bool,
+) -> list[str]:
+    """Return release-only errors when an explicit release gate is requested."""
+    if not release_ready:
+        return []
+    if version == "0.0.0":
+        return ["VERSION 0.0.0 is the bootstrap candidate and cannot be released"]
+    return release_metadata_errors(root, version)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate product-version synchronisation and optional release metadata."
+    )
+    parser.add_argument(
+        "--release-ready",
+        action="store_true",
+        help="also require complete release notes, changelog metadata and consumed fragments",
+    )
+    arguments = parser.parse_args(argv)
+
     version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
     if not is_valid_product_version(version):
         raise SystemExit(f"VERSION must be stable Semantic Versioning X.Y.Z: {version!r}")
@@ -65,7 +137,19 @@ def main() -> None:
         details = "; ".join([*missing, *mismatches])
         raise SystemExit(f"Product versions do not match VERSION {version}: {details}")
 
-    print(f"Validated product version {version} across {len(observed)} manifests and locks.")
+    release_errors = release_readiness_errors(
+        ROOT,
+        version,
+        release_ready=arguments.release_ready,
+    )
+    if release_errors:
+        raise SystemExit("Release metadata is incomplete: " + "; ".join(release_errors))
+
+    suffix = " Release metadata is complete." if arguments.release_ready else ""
+    print(
+        f"Validated product version {version} across {len(observed)} manifests and locks."
+        f"{suffix}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -23,6 +24,41 @@ class PagesWorkflowTests(unittest.TestCase):
             for action, revision in uses:
                 with self.subTest(workflow=workflow_name, action=action):
                     self.assertRegex(revision, r"^[0-9a-f]{40}$")
+
+    def test_ci_enforces_release_readiness_only_on_a_version_transition(self) -> None:
+        checkout = CI_WORKFLOW.split("- name: Check out repository", 1)[1].split(
+            "\n\n      - name:", 1
+        )[0]
+        self.assertIn("fetch-depth: 2", checkout)
+
+        assurance_name = "- name: Run assurance"
+        transition_name = "- name: Enforce release readiness on a version transition"
+        package_name = "- name: Package immutable Pages source"
+        self.assertLess(CI_WORKFLOW.index(assurance_name), CI_WORKFLOW.index(transition_name))
+        self.assertLess(CI_WORKFLOW.index(transition_name), CI_WORKFLOW.index(package_name))
+
+        transition = CI_WORKFLOW.split(transition_name, 1)[1].split(
+            f"\n\n      {package_name}", 1
+        )[0]
+        self.assertIn("PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}", transition)
+        self.assertIn("PUSH_BASE_SHA: ${{ github.event.before }}", transition)
+        self.assertIn('case "$GITHUB_EVENT_NAME" in', transition)
+        self.assertIn('pull_request) base_sha="$PR_BASE_SHA" ;;', transition)
+        self.assertIn('push) base_sha="$PUSH_BASE_SHA" ;;', transition)
+        self.assertIn('[[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]', transition)
+        self.assertIn("0000000000000000000000000000000000000000", transition)
+        self.assertIn('git cat-file -e "$base_sha^{commit}"', transition)
+        self.assertIn('git cat-file -e "$GITHUB_SHA^{commit}"', transition)
+        self.assertIn(
+            'git diff --quiet "$base_sha" "$GITHUB_SHA" -- VERSION',
+            transition,
+        )
+        self.assertIn("version_diff_status=$?", transition)
+        self.assertIn("1) pnpm run validate:release-readiness ;;", transition)
+        self.assertIn("*) echo 'Unable to compare VERSION with the event base'", transition)
+
+        scripts = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))["scripts"]
+        self.assertNotIn("validate:release-readiness", scripts["check"])
 
     def test_workflows_default_to_no_token_permissions(self) -> None:
         self.assertIn("\npermissions: {}\n", CI_WORKFLOW)
@@ -121,6 +157,73 @@ class PagesWorkflowTests(unittest.TestCase):
             '--expected-archive-sha256 "$ARCHIVE_SHA256"', PAGES_WORKFLOW
         )
 
+    def test_prepare_binds_the_selected_archive_version_across_rollbacks(self) -> None:
+        prepare = PAGES_WORKFLOW.split("\n  prepare:\n", 1)[1].split(
+            "\n  deploy:\n", 1
+        )[0]
+        download_name = "- name: Download exact CI artefact"
+        selected_name = "- name: Read selected archive version"
+        verify_name = "- name: Verify archive structure and receipt"
+        product_name = "- name: Record accepted product identity"
+        stage_name = "- name: Materialise verified Pages payload"
+        self.assertLess(prepare.index(download_name), prepare.index(selected_name))
+        self.assertLess(prepare.index(selected_name), prepare.index(verify_name))
+        self.assertLess(prepare.index(verify_name), prepare.index(product_name))
+        self.assertLess(prepare.index(product_name), prepare.index(stage_name))
+
+        selected = prepare.split(selected_name, 1)[1].split(
+            f"\n\n      {verify_name}", 1
+        )[0]
+        self.assertIn("id: selected_version", selected)
+        self.assertIn("jq -er", selected)
+        self.assertIn('if (.version | type) == "string" then', selected)
+        self.assertIn(".version", selected)
+        self.assertIn(
+            'if [[ ! "$selected_version" =~ '
+            "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\."
+            "(0|[1-9][0-9]*)$ ]]; then",
+            selected,
+        )
+        self.assertIn(
+            "printf 'version=%s\\n' \"$selected_version\" >> \"$GITHUB_OUTPUT\"",
+            selected,
+        )
+        self.assertNotIn("eval", selected)
+
+        stable_semver = re.compile(
+            r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+        )
+        older_selected_version = "0.0.1"
+        self.assertRegex(older_selected_version, stable_semver)
+        self.assertNotRegex("0.0.1-rc.1", stable_semver)
+
+        selected_binding = (
+            "SELECTED_VERSION: ${{ steps.selected_version.outputs.version }}"
+        )
+        self.assertEqual(prepare.count(selected_binding), 3)
+        self.assertEqual(prepare.count('--expected-version "$SELECTED_VERSION"'), 2)
+        self.assertIn("printf 'version=%s\\n' \"$SELECTED_VERSION\"", prepare)
+        self.assertIn(
+            "product_version: ${{ steps.product.outputs.version }}", prepare
+        )
+        self.assertIn(
+            "PRODUCT_VERSION: ${{ steps.product.outputs.version }}", prepare
+        )
+        self.assertIn('--arg productVersion "$PRODUCT_VERSION"', prepare)
+        public_verification = PAGES_WORKFLOW.split(
+            "\n  public-verification:\n", 1
+        )[1]
+        self.assertIn(
+            "EXPECTED_VERSION: ${{ needs.prepare.outputs.product_version }}",
+            public_verification,
+        )
+        self.assertIn(
+            "PRODUCT_VERSION: ${{ needs.prepare.outputs.product_version }}",
+            public_verification,
+        )
+        self.assertNotRegex(prepare, r"<\s*VERSION\b")
+        self.assertNotIn("tr -d", prepare)
+
     def test_prepare_enforces_github_provenance_identity(self) -> None:
         for flag in (
             '--repo "$GITHUB_REPOSITORY"',
@@ -149,7 +252,7 @@ class PagesWorkflowTests(unittest.TestCase):
             "--output-dir deployment-staging/site",
             '--expected-source-commit "$SOURCE_COMMIT"',
             '--expected-repository "$GITHUB_REPOSITORY"',
-            '--expected-version "$(tr -d \'\\r\\n\' < VERSION)"',
+            '--expected-version "$SELECTED_VERSION"',
             "--expected-base-path /gis-ai-go/",
             '--expected-archive-sha256 "$ARCHIVE_SHA256"',
         ):
@@ -265,6 +368,142 @@ class PagesWorkflowTests(unittest.TestCase):
         self.assertIn(
             "pnpm --filter @gis-ai-go/public-explorer run test:public", verification
         )
+
+    def test_successful_public_acceptance_writes_and_uploads_canonical_receipt(
+        self,
+    ) -> None:
+        verification = PAGES_WORKFLOW.split("\n  public-verification:\n", 1)[1]
+        acceptance_command = (
+            "pnpm --filter @gis-ai-go/public-explorer run test:public"
+        )
+        receipt_name = "- name: Write public verification receipt"
+        upload_name = "- name: Upload public verification evidence"
+        failure_upload_name = "- name: Upload failed public verification diagnostics"
+        summary_name = "- name: Record accepted deployment"
+        self.assertLess(
+            verification.index(acceptance_command), verification.index(receipt_name)
+        )
+        self.assertLess(
+            verification.index(receipt_name), verification.index(upload_name)
+        )
+        self.assertLess(
+            verification.index(upload_name), verification.index(failure_upload_name)
+        )
+        self.assertLess(
+            verification.index(failure_upload_name), verification.index(summary_name)
+        )
+
+        receipt = verification.split(receipt_name, 1)[1].split(
+            f"\n\n      {upload_name}", 1
+        )[0]
+        for binding in (
+            "ARCHIVE_SHA256: ${{ inputs.archive_sha256 }}",
+            "DEPLOYMENT_MODE: ${{ inputs.mode }}",
+            "OKF_CONTENT_ROOT: ${{ needs.prepare.outputs.okf_content_root }}",
+            "PAGE_URL: ${{ needs.deploy.outputs.page_url }}",
+            "PAYLOAD_ROOT: ${{ needs.prepare.outputs.payload_root }}",
+            "PRODUCT_VERSION: ${{ needs.prepare.outputs.product_version }}",
+            "PUBLIC_CHECKSUMS_SHA256: "
+            "${{ needs.prepare.outputs.public_checksums_sha256 }}",
+            "REPOSITORY: ${{ github.repository }}",
+            "SOURCE_COMMIT: ${{ inputs.source_commit }}",
+            "SOURCE_RUN_ID: ${{ inputs.source_run_id }}",
+            "WORKFLOW_COMMIT: ${{ github.sha }}",
+            "WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}",
+            "WORKFLOW_RUN_ID: ${{ github.run_id }}",
+            "WORKFLOW_RUN_URL: ${{ github.server_url }}/"
+            "${{ github.repository }}/actions/runs/${{ github.run_id }}",
+        ):
+            with self.subTest(binding=binding):
+                self.assertIn(binding, receipt)
+
+        self.assertIn("jq -S -n", receipt)
+        self.assertIn(
+            "--arg schemaVersion "
+            "'gis-ai-go.pages-public-verification-receipt.v1'",
+            receipt,
+        )
+        for argument_binding in (
+            '--arg repository "$REPOSITORY"',
+            '--arg workflowRun "$WORKFLOW_RUN_URL"',
+            '--arg workflowRunAttempt "$WORKFLOW_RUN_ATTEMPT"',
+            '--arg workflowRunId "$WORKFLOW_RUN_ID"',
+            '--arg workflowCommit "$WORKFLOW_COMMIT"',
+            '--arg mode "$DEPLOYMENT_MODE"',
+            '--arg publicUrl "$PAGE_URL"',
+            '--arg productVersion "$PRODUCT_VERSION"',
+            '--arg sourceRunId "$SOURCE_RUN_ID"',
+            '--arg sourceCommit "$SOURCE_COMMIT"',
+            '--arg archiveSha256 "$ARCHIVE_SHA256"',
+            '--arg payloadRoot "$PAYLOAD_ROOT"',
+            '--arg okfContentRoot "$OKF_CONTENT_ROOT"',
+            '--arg publicChecksumsSha256 "$PUBLIC_CHECKSUMS_SHA256"',
+        ):
+            with self.subTest(argument_binding=argument_binding):
+                self.assertIn(argument_binding, receipt)
+        for field_binding in (
+            "schemaVersion: $schemaVersion",
+            "repository: $repository",
+            "workflowRun: $workflowRun",
+            "workflowRunAttempt: $workflowRunAttempt",
+            "workflowRunId: $workflowRunId",
+            "workflowCommit: $workflowCommit",
+            "mode: $mode",
+            "publicUrl: $publicUrl",
+            "productVersion: $productVersion",
+            "sourceRunId: $sourceRunId",
+            "sourceCommit: $sourceCommit",
+            "archiveSha256: $archiveSha256",
+            "payloadRootSha256: $payloadRoot",
+            "okfContentRootSha256: $okfContentRoot",
+            "publicChecksumsSha256: $publicChecksumsSha256",
+        ):
+            with self.subTest(field_binding=field_binding):
+                self.assertIn(field_binding, receipt)
+        self.assertIn(
+            "> public-verification-evidence/public-verification-receipt.json",
+            receipt,
+        )
+        self.assertNotIn("validatedAt", receipt)
+        self.assertNotIn("date -u", receipt)
+
+        upload = verification.split(upload_name, 1)[1].split(
+            f"\n\n      {failure_upload_name}", 1
+        )[0]
+        self.assertNotIn("if: always()", upload)
+        self.assertIn(
+            "public-verification-evidence/public-verification-receipt.json",
+            upload,
+        )
+        self.assertIn("apps/public-explorer/test-results/", upload)
+        self.assertIn("if-no-files-found: error", upload)
+        self.assertIn("retention-days: 90", upload)
+
+    def test_failed_public_acceptance_uploads_diagnostics_only(self) -> None:
+        verification = PAGES_WORKFLOW.split("\n  public-verification:\n", 1)[1]
+        success_upload_name = "- name: Upload public verification evidence"
+        failure_upload_name = "- name: Upload failed public verification diagnostics"
+        summary_name = "- name: Record accepted deployment"
+        self.assertLess(
+            verification.index(success_upload_name),
+            verification.index(failure_upload_name),
+        )
+
+        failure_upload = verification.split(failure_upload_name, 1)[1].split(
+            f"\n\n      {summary_name}", 1
+        )[0]
+        self.assertIn("if: failure()", failure_upload)
+        self.assertIn(
+            "uses: actions/upload-artifact@"
+            "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            failure_upload,
+        )
+        self.assertIn("name: public-verification-failure-", failure_upload)
+        self.assertIn("path: apps/public-explorer/test-results/", failure_upload)
+        self.assertIn("if-no-files-found: warn", failure_upload)
+        self.assertIn("retention-days: 90", failure_upload)
+        self.assertNotIn("public-verification-receipt.json", failure_upload)
+        self.assertNotIn("if: always()", failure_upload)
 
 
 if __name__ == "__main__":

--- a/tests/contract/test_release_metadata.py
+++ b/tests/contract/test_release_metadata.py
@@ -7,7 +7,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.check_versions import is_valid_product_version
+from scripts.check_versions import (
+    is_valid_product_version,
+    release_metadata_errors,
+    release_readiness_errors,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -47,6 +51,100 @@ class ReleaseMetadataTests(unittest.TestCase):
         expected = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
         self.assertEqual(sbom["metadata"]["component"]["version"], expected)
         self.assertNotIn("Stage 0", sbom["metadata"]["properties"][0]["value"])
+
+    def test_bootstrap_version_does_not_claim_release_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.assertEqual(release_metadata_errors(root, "0.0.0"), [])
+
+    def test_release_readiness_is_an_explicit_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "changelog.d").mkdir()
+            (root / "changelog.d" / "NEXT.feature.md").write_text(
+                "- Continue feature delivery.\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                release_readiness_errors(root, "0.1.0", release_ready=False),
+                [],
+                "ordinary post-release feature branches must allow changelog fragments",
+            )
+            self.assertIn(
+                "VERSION 0.0.0 is the bootstrap candidate and cannot be released",
+                release_readiness_errors(root, "0.0.0", release_ready=True),
+            )
+            self.assertIn(
+                "CHANGELOG.md is missing",
+                release_readiness_errors(root, "0.1.0", release_ready=True),
+            )
+
+            (root / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+            (root / "changelog.d" / "README.md").write_text(
+                "Instructions\n",
+                encoding="utf-8",
+            )
+            errors = release_readiness_errors(root, "0.1.0", release_ready=True)
+            self.assertIn("unconsumed changelog fragments: NEXT.feature.md", errors)
+            self.assertIn("RELEASE_NOTES/0.1.0.md is missing", errors)
+
+    def test_supported_version_requires_complete_release_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "changelog.d").mkdir()
+            (root / "changelog.d" / "README.md").write_text("Instructions\n", encoding="utf-8")
+            (root / "RELEASE_NOTES").mkdir()
+            (root / "RELEASE_NOTES" / "0.1.0.md").write_text(
+                "# GIS AI GO v0.1.0\n",
+                encoding="utf-8",
+            )
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [0.1.0] - 2026-08-20\n\n"
+                "[0.1.0]: https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(release_metadata_errors(root, "0.1.0"), [])
+
+            (root / "changelog.d" / "QUAL-105.security.md").write_text(
+                "- Release gate.\n",
+                encoding="utf-8",
+            )
+            (root / "RELEASE_NOTES" / "0.1.0.md").unlink()
+            errors = release_metadata_errors(root, "0.1.0")
+            self.assertIn("RELEASE_NOTES/0.1.0.md is missing", errors)
+            self.assertIn("unconsumed changelog fragments: QUAL-105.security.md", errors)
+
+            (root / "RELEASE_NOTES" / "0.1.0.md").write_text("\n", encoding="utf-8")
+            self.assertIn(
+                "RELEASE_NOTES/0.1.0.md is empty",
+                release_metadata_errors(root, "0.1.0"),
+            )
+
+            (root / "changelog.d" / "README.md").unlink()
+            self.assertIn(
+                "changelog.d/README.md is missing",
+                release_metadata_errors(root, "0.1.0"),
+            )
+
+    def test_supported_version_rejects_undated_or_wrong_release_link(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "changelog.d").mkdir()
+            (root / "RELEASE_NOTES").mkdir()
+            (root / "RELEASE_NOTES" / "0.1.0.md").write_text("Notes\n", encoding="utf-8")
+            (root / "CHANGELOG.md").write_text(
+                "## [0.1.0]\n\n"
+                "[0.1.0]: https://github.com/chris-page-gov/gis-ai-go/commits/main\n",
+                encoding="utf-8",
+            )
+
+            errors = release_metadata_errors(root, "0.1.0")
+            self.assertIn("CHANGELOG.md has no dated [0.1.0] release section", errors)
+            self.assertIn("CHANGELOG.md has no exact [0.1.0] release link", errors)
 
 
 if __name__ == "__main__":

--- a/tests/contract/test_release_reproducibility.py
+++ b/tests/contract/test_release_reproducibility.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script() -> ModuleType:
+    path = ROOT / "scripts/check_release_reproducibility.py"
+    specification = importlib.util.spec_from_file_location(
+        "check_release_reproducibility", path
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("cannot load release reproducibility checker")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+CHECK = load_script()
+
+
+class ReleaseReproducibilityContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _write_outputs(self, root: Path, suffix: bytes = b"") -> None:
+        root.mkdir()
+        values = {
+            "artifact.tar": b"canonical tar bytes" + suffix,
+            "artifact.tar.sha256": b"0" * 64 + b"  artifact.tar\n" + suffix,
+            "archive-receipt.json": b'{"schema":"fixture"}\n' + suffix,
+        }
+        for name, value in values.items():
+            (root / name).write_bytes(value)
+
+    def test_cleanup_allowlist_is_exact_and_preserves_unrelated_files(self) -> None:
+        self.assertEqual(
+            tuple(path.as_posix() for path in CHECK.GENERATED_ROOTS),
+            (
+                "apps/public-explorer/dist",
+                "apps/public-explorer/public/catalogue",
+                "artifacts/okf",
+            ),
+        )
+        protected = self.root / "docs" / "owner-note.txt"
+        protected.parent.mkdir()
+        protected.write_text("retain\n", encoding="utf-8")
+
+        removed = CHECK.clean_generated_roots(self.root, "a" * 40, "0.1.0")
+
+        self.assertEqual(removed, [])
+        self.assertEqual(protected.read_text(encoding="utf-8"), "retain\n")
+        with self.assertRaisesRegex(ValueError, "not allowlisted"):
+            CHECK.resolve_cleanup_target(self.root, "docs")
+        with self.assertRaisesRegex(ValueError, "not allowlisted"):
+            CHECK.resolve_cleanup_target(self.root, "../outside")
+
+    def test_cleanup_rejects_an_unmarked_allowlisted_directory(self) -> None:
+        generated = self.root / "artifacts" / "okf"
+        generated.mkdir(parents=True)
+        owner_file = generated / "owner-note.txt"
+        owner_file.write_text("retain\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(ValueError, "generated marker is missing or invalid"):
+            CHECK.clean_generated_roots(self.root, "a" * 40, "0.1.0")
+
+        self.assertEqual(owner_file.read_text(encoding="utf-8"), "retain\n")
+
+    def test_compares_exactly_the_three_canonical_release_files(self) -> None:
+        first = self.root / "first"
+        second = self.root / "second"
+        self._write_outputs(first)
+        self._write_outputs(second)
+
+        digests = CHECK.compare_release_outputs(first, second)
+
+        self.assertEqual(tuple(digests), CHECK.RELEASE_OUTPUTS)
+        (second / "unexpected.txt").write_text("not a release output\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "exactly the three canonical files"):
+            CHECK.compare_release_outputs(first, second)
+
+    def test_rejects_a_byte_difference_in_each_release_output(self) -> None:
+        first = self.root / "first"
+        self._write_outputs(first)
+        for index, name in enumerate(CHECK.RELEASE_OUTPUTS):
+            with self.subTest(name=name):
+                second = self.root / f"second-{index}"
+                self._write_outputs(second)
+                (second / name).write_bytes((second / name).read_bytes() + b"changed")
+                with self.assertRaisesRegex(
+                    ValueError,
+                    rf"not byte-identical: {name.replace('.', r'\.')}",
+                ):
+                    CHECK.compare_release_outputs(first, second)
+
+    def test_build_command_cannot_reinvoke_the_complete_check(self) -> None:
+        self.assertEqual(CHECK.BUILD_COMMAND, ("pnpm", "run", "build:explorer"))
+        self.assertNotIn("check", CHECK.BUILD_COMMAND)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Completes the local and required-CI assurance needed before the separate `v0.1.0`
release pull request. This implements the QUAL-105 evidence gate without changing
the bootstrap `0.0.0` product version or redeploying GitHub Pages.

Relates to #7. The issue remains open until the supported release is tagged,
deployed and evidenced.

## Changes

- proves two clean locked builds produce byte-identical Pages archives, checksum
  ledgers and receipts;
- adds inert WebMCP-present coverage, visible keyboard-focus checks, complete axe
  A/AA tags and 400%-equivalent reflow evidence;
- makes successful public verification emit a canonical receipt and preserves
  separate diagnostics on failed browser acceptance;
- preserves rollback across product versions by deriving deployment identity from
  the selected attested archive;
- separates ordinary version synchronisation from release-only metadata checks,
  while required CI invokes release readiness whenever `VERSION` changes; and
- records explicit security, accessibility, provider, legal and hosting limits.

## Verification

- `pnpm run check`
  - 4 gateway tests
  - 16 Explorer build-policy tests
  - 42 Explorer unit/component tests
  - 82 repository Python tests and 2 execution-boundary tests
  - 27 Playwright browser tests
  - two byte-identical clean release builds
  - 8 schemas / 53 records, 291 links, 183 research hashes, 71 source IDs
  - 450-file secret/path scan, 9 diagrams and 145-component SBOM
- workflow and release-focused contracts: 26 passed
- workflow YAML parsing and `git diff --check`: passed
- immutable research tree: unchanged
- independent accessibility, integration and exact-snapshot Codex Security reviews:
  SHIP, no P0-P2 findings

## Deployment and rollback

This pull request does not deploy or publish a supported release. The live Pages
candidate remains on its already accepted source until a separate release workflow
selects a verified artefact. Roll back this change by reverting its squash commit;
the Pages workflow can continue to select an earlier attested archive, including an
archive carrying an earlier product version.
