### PR TITLE
docs(release): record v0.1.0 support evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,8 @@ Start every implementation task by reading, in order:
   and AI agents;
 - repository: `chris-page-gov/gis-ai-go`;
 - licence: MIT, copyright © 2026 Chris Page;
-- release being assembled: `v0.1.0`.
+- latest supported release:
+  [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0).
 
 “Locus Accord” is a superseded codename preserved only in historical research.
 `chris-page-gov/mcp-geo` is read-only evidence at commit
@@ -37,24 +38,31 @@ Stage 0 is complete at commit `983b1a102aa8038c9f50ae1b1894315c3ae0b89f`.
 The canonical OKF build, accessible static Explorer and reviewed public examples
 are merged through `DISC-101`, `DISC-102` and `DISC-103`. `DISC-104` is complete
 through [pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14),
-whose accepted implementation and deployed source commit is
-`a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified at
-<https://chris-page-gov.github.io/gis-ai-go/>. There is no MCP listener, live
-provider adapter, policy engine, identity integration or evidence store.
+whose accepted implementation commit is
+`a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
+at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
+recorded below. There is no MCP listener, live provider adapter, policy engine,
+identity integration or evidence store.
 
 The owner has authorised autonomous implementation in the open under
-[`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The active
-outcome is the `v0.1.0` public discovery product. The repository is public under the
-owner's personal `chris-page-gov` account. Pull-request assurance, security controls
-and branch protection govern development on `main`. `DISC-104` retained two
+[`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The repository
+is public under the owner's personal `chris-page-gov` account. Pull-request
+assurance, security controls and branch protection govern development on `main`.
+`DISC-104` retained two
 immutable, attested protected-main source artefacts, deployed both through GitHub's
 pinned official Pages transport, rolled back to the earlier artefact and restored
 the current one without rebuilding either product. All four public-browser
 acceptance suites passed. QUAL-105 then merged through
 [pull request 16](https://github.com/chris-page-gov/gis-ai-go/pull/16) at
 `24925fc7f77b416d557c719942c86eaa3578b4b1`, completing implementation release
-assurance without redeploying the `0.0.0` candidate. The active workstream is now
-assembling, tagging, deploying and verifying `v0.1.0`.
+assurance. Release [pull request 17](https://github.com/chris-page-gov/gis-ai-go/pull/17)
+merged as `f1bda209e6309bf4f14f7ab7f524c442e59917b8`; its attested artefact was deployed,
+verified in a real browser and published as the protected, immutable
+[`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+release. The [release evidence record](docs/operations/V0.1.0_RELEASE_EVIDENCE.md)
+is the durable hand-off. The active roadmap outcome is now `v0.2.0`: an open,
+read-only MCP and direct-API surface over the same governed catalogue and evidence
+model.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,18 +4,20 @@ Last updated: 20 August 2026
 
 ## Current outcome
 
-Deliver `v0.1.0`: an accessible public GIS AI GO discovery product with a canonical
-OKF bundle, reviewed public geospatial metadata examples with record-specific
-rights, linked machine-readable data and a reproducible GitHub Pages deployment.
+Deliver `v0.2.0`: expose the supported governed catalogue and evidence model through
+an open, read-only MCP and direct API without weakening the static `v0.1.0` product.
 
 ## Active workstream
 
-`v0.1.0 — Publish the first supported static discovery release`
+`v0.2.0 — Establish the open read-only MCP foundation`
 
-- synchronise version and release metadata;
-- verify and tag the exact protected-main release commit;
-- deploy its attested artefact and retain the passing public receipt; and
-- publish durable release assets and final evidence.
+- provision the milestone and issue-backed delivery slices;
+- implement a protocol-conformant, fail-closed catalogue gateway over canonical
+  records and deterministic fixtures;
+- retain policy, evidence, rate and complexity boundaries in every public contract;
+  and
+- prove non-App MCP client, direct API and static-product interoperability before
+  any public service or registry entry.
 
 ## Completed
 
@@ -62,17 +64,30 @@ rights, linked machine-readable data and a reproducible GitHub Pages deployment.
   at `24925fc7f77b416d557c719942c86eaa3578b4b1` with passing pull-request and
   protected-main assurance, provenance and CodeQL; and
 - two clean release builds are byte-identical, while browser, accessibility,
-  security and release-metadata gates have no unresolved P0-P2 findings.
+  security and release-metadata gates have no unresolved P0-P2 findings;
+- release [pull request 17](https://github.com/chris-page-gov/gis-ai-go/pull/17)
+  merged as protected-main commit
+  `f1bda209e6309bf4f14f7ab7f524c442e59917b8` with passing assurance,
+  provenance and CodeQL;
+- annotated tag `v0.1.0` is protected against update and deletion with no bypass;
+- the exact attested release artefact was deployed in
+  [run 32331337338](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32331337338),
+  deployment `5995702325`, and passed all four public-browser acceptance tests; and
+- [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+  is published as the immutable latest release with nine checksummed evidence
+  assets.
 
 ## Next
 
-1. Merge the synchronised `v0.1.0` release commit through protected `main`.
-2. Tag and verify that exact commit and its attested immutable artefact.
-3. Deploy the tagged artefact, retain public evidence and publish the GitHub Release.
+1. Close the completed `v0.1.0` milestone after this evidence reaches protected
+   `main`.
+2. Provision the `v0.2.0` milestone and bounded MCP delivery issues.
+3. Implement the first protocol and catalogue slice through the normal protected
+   pull-request gate.
 
 ## Current blockers
 
-- No blocker is known for the open `v0.1.0` discovery product.
+- No blocker is known for establishing the open `v0.2.0` foundation.
 - Protected PSGA and commercial deployments require separate rights, credentials
   and isolated infrastructure. They remain outside this release and do not block
   the open product.
@@ -87,6 +102,21 @@ rights, linked machine-readable data and a reproducible GitHub Pages deployment.
   canonical verification receipt after a successful deployed-browser gate;
 - QUAL-105 independent security and accessibility reviews: no P0-P2 finding or
   material evidence error remains;
+- supported release: immutable latest
+  [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0),
+  protected tag object `2f566c6e26dd17b13799e2976500e14701f04d11` and release commit
+  `f1bda209e6309bf4f14f7ab7f524c442e59917b8`;
+- release commit assurance and provenance: passing in
+  [run 32330917042](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32330917042);
+- release commit CodeQL for Actions, JavaScript/TypeScript and Python: passing in
+  [run 32330916721](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32330916721);
+- canonical release archive SHA-256
+  `acf072986dafc34795039e363d0d5d09af44432fa392ff3aee5525887e1081a4`,
+  payload root `80a649a5e4bebc36fb38c7b6d51d84056d1b2ff4c8b5f6b96c75bb6d03c6d245`
+  and OKF content root
+  `f6da572916ea850f6825e276867504a835bc783d76cea8038f72c8d1d42c2750`;
+- GitHub release and all nine assets pass GitHub release attestation verification,
+  while a fresh post-publication download passes the published checksum ledger;
 - canonical OKF content, Explorer, reviewed public examples and supported Pages
   transport: merged on protected `main` at
   `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;
@@ -131,4 +161,5 @@ rights, linked machine-readable data and a reproducible GitHub Pages deployment.
   bound to `a0e826384cf50d9d81b87489dbf3580e8e3602f7`;
 - public repository: verified with personal `noreply` commit identity;
 - deployed product: <https://chris-page-gov.github.io/gis-ai-go/>;
-- latest supported release: none.
+- latest supported release:
+  [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0).

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ boundary is deliberately broader than AI or MCP.
 
 ## Status
 
-**QUAL-105 is complete and `v0.1.0` is assembled for release.** The current public
-site at <https://chris-page-gov.github.io/gis-ai-go/> remains the verified `0.0.0`
-candidate until the tagged `v0.1.0` artefact is deployed and its public-verification
-receipt passes. Support will be declared only after the protected tag, verified
-deployment, immutable GitHub Release, durable checksummed assets and merged final
-evidence all exist and pass their gates.
+**[`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+is the first supported public discovery release.** Its exact protected-main artefact
+is deployed and verified at <https://chris-page-gov.github.io/gis-ai-go/>. The
+annotated tag is protected, the GitHub Release is immutable and its nine durable
+assets include checksums, receipts, provenance verification and the dependency SBOM.
+The [release evidence record](docs/operations/V0.1.0_RELEASE_EVIDENCE.md) binds the
+source, build, deployment and public-browser acceptance identities.
 
 The Explorer is a static, metadata-only product; there is no MCP service. Live status is in
 [`PROGRESS.md`](PROGRESS.md); current authority and boundaries are in
@@ -23,7 +24,8 @@ The Explorer is a static, metadata-only product; there is no MCP service. Live s
 - product: **GIS AI GO**
 - repository: `gis-ai-go`
 - provisional MCP Registry identifier: `io.github.chris-page-gov/gis-ai-go`
-- release being assembled: `v0.1.0`
+- latest supported release:
+  [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
 - licence: [MIT](LICENSE), copyright © 2026 Chris Page; identified
   [third-party material](THIRD_PARTY.md) retains its own terms
 
@@ -61,7 +63,7 @@ pnpm run check
 ```
 
 The check builds and type-checks the TypeScript boundary, runs TypeScript and Python
-unit tests, reproducibly builds and validates the public OKF candidate and Explorer,
+unit tests, reproducibly builds and validates the public OKF publication and Explorer,
 runs its real-browser accessibility and security journeys, validates other schemas
 and fixtures, checks local links, performs a baseline secret scan, renders diagrams
 and creates a CycloneDX SBOM in `artifacts/`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Current status
 
-GIS AI GO is a public open-source project and has no supported production release
-yet.
+GIS AI GO is a public open-source project. Its supported `v0.1.0` release is a
+static, metadata-only discovery product hosted on GitHub Pages.
 The current gateway and execution service remain fail-closed scaffolds. Do not
 connect unreviewed code to provider credentials, protected data or public listeners.
 The public Explorer is a static metadata-only build; it is not a provider client or
@@ -33,7 +33,12 @@ defects may use the public bug template.
   keyboard operation and machine-readable download integrity;
 - GitHub secret scanning, push protection, Dependabot security updates and CodeQL
   default setup are enabled for the public repository;
-- no security claim is made for later identity, policy or hosting designs.
+- the supported tag is protected against update and deletion by a no-bypass
+  ruleset; and
+- the immutable GitHub Release retains the checksummed archive, receipts,
+  attestation verification, release evidence and dependency SBOM;
+- no security claim is made for later identity, policy, provider or service designs.
 
 The custom and platform scans are baselines, not substitutes for dependency review
-or a dedicated security assessment before a supported release.
+or a dedicated security assessment before a later networked service, identity,
+policy or provider-integration release.

--- a/changelog.d/QUAL-105.changed.md
+++ b/changelog.d/QUAL-105.changed.md
@@ -1,0 +1,2 @@
+- Recorded the immutable `v0.1.0` Release, exact deployed evidence and first
+  supported static public discovery boundary.

--- a/docs/implementation/DELIVERY_AND_RELEASE.md
+++ b/docs/implementation/DELIVERY_AND_RELEASE.md
@@ -58,6 +58,11 @@ Create the GitHub release from the immutable tag. Attach or link the checksummed
 artefacts and evidence record. Do not describe a local scaffold, draft or synthetic
 test as a deployed capability.
 
+After immutable publication, merge a documentation-only evidence pull request that
+updates the canonical support status and links the release, deployment and public
+receipt. Then close the completed release issue and milestone. This evidence update
+must not move the tag, replace release assets or redeploy the accepted product.
+
 ## Deployment and rollback
 
 Before the first tag, a public acceptance candidate may deploy only from an attested
@@ -66,9 +71,9 @@ release deploys only the artefact built and attested from the exact verified rel
 commit, after that commit carries its immutable tag. Verify the exact deployed
 commit in a real browser/client, including identity, primary
 journeys, accessibility, console, security controls and rollback. The live Pages
-Explorer remains a release candidate until the exact `v0.1.0` tagged artefact passes
-deployment and public verification; the historical research viewer is never the
-product deployment.
+Explorer is the supported `v0.1.0` static discovery product. A future release
+remains a candidate until its exact tagged artefact passes deployment and public
+verification; the historical research viewer is never the product deployment.
 
 Prefer an ordinary revert or previous immutable artefact over history rewriting.
 Suspend a provider, tool, registry entry or protected tier independently when its

--- a/docs/implementation/ROADMAP.md
+++ b/docs/implementation/ROADMAP.md
@@ -4,7 +4,10 @@ The owner has authorised Codex to progress autonomously through the open-product
 roadmap. Each release advances only when its tests and publication evidence pass;
 this is an evidence gate, not a request for repeated permission.
 
-## `v0.1.0` — public discovery product
+## `v0.1.0` — public discovery product (released)
+
+Status: supported and immutable at
+[`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0).
 
 Outcome: a useful, accessible static product that people can browse without an MCP
 host or account.
@@ -23,7 +26,7 @@ Deliver:
 Gate: source/data rights review, exact-source integrity, browser journeys, WCAG 2.2
 AA acceptance, clean console, security checks, SBOM and rollback rehearsal.
 
-## `v0.2.0` — open read-only MCP
+## `v0.2.0` — open read-only MCP (next)
 
 Outcome: the same governed catalogue and evidence model is usable by MCP clients and
 direct API consumers without reducing the non-MCP product.

--- a/docs/operations/QUAL-105_VERIFICATION.md
+++ b/docs/operations/QUAL-105_VERIFICATION.md
@@ -1,10 +1,12 @@
 # QUAL-105 release-assurance verification record
 
-- status: verified on protected main; release evidence pending
+- status: complete for supported `v0.1.0`
 - reviewed on: 20 August 2026
 - work item: [QUAL-105](https://github.com/chris-page-gov/gis-ai-go/issues/7)
 - release target: `v0.1.0`
-- public candidate: <https://chris-page-gov.github.io/gis-ai-go/>
+- supported release:
+  [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+- public product: <https://chris-page-gov.github.io/gis-ai-go/>
 
 ## Outcome
 
@@ -17,7 +19,7 @@ The release remains a static, public, metadata-only discovery product. This gate
 does not claim an MCP listener, provider execution, identity integration, policy
 engine, protected-data integration or production service assurance.
 
-## Accepted baseline
+## Accepted pre-release baseline
 
 - DISC-104 deployment evidence is merged on protected `main` at
   `5cc1626c9e412393a520b463c6ba670ee51799f0`;
@@ -31,7 +33,7 @@ engine, protected-data integration or production service assurance.
 - on 20 August 2026, the repository had no open CodeQL, Dependabot or secret-scanning
   alerts.
 
-The live candidate reports source
+The pre-release candidate reported source
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`, version `0.0.0`, payload root
 `cbc0893a46a4674ef7d13aa4aebcbeb0355f9c8a08286a6500bfc954cb5d6ef6` and OKF
 content root `a620158911cc60259f0ceab2af0dfdd886783a50bfe98000d692fd534bd08ec0`.
@@ -40,7 +42,7 @@ content root `a620158911cc60259f0ceab2af0dfdd886783a50bfe98000d692fd534bd08ec0`.
 
 ### Release journeys and negative cases
 
-The candidate retains the complete catalogue, direct-route, back/forward, download,
+The release candidate retained the complete catalogue, direct-route, back/forward, download,
 hostile-state, CSP, network, forced-colours, reduced-motion and small-viewport
 browser suites. It adds a WebMCP-present case with inert sentinels and proves that
 the Explorer neither invokes, replaces nor mutates them. This is graceful non-use
@@ -73,9 +75,9 @@ and reports the common archive SHA-256 on success.
 
 DISC-104 proved the exact live commit, payload, OKF root, checksum ledger, primary
 journeys, clean console and publication-path-only network boundary across original
-deployment, rollback and restoration. The tagged release must repeat this public
-gate and retain a successful `public-verification-receipt.json` before the GitHub
-Release is published.
+deployment, rollback and restoration. The tagged release repeated this public gate
+and retained a successful `public-verification-receipt.json` before the immutable
+GitHub Release was published.
 
 ### Release evidence and metadata
 
@@ -87,7 +89,7 @@ feature branches with an unchanged version may retain their required changelog
 fragments. The public workflow must upload a canonical verification receipt even
 when the passing browser run produces no trace or failure file.
 
-## Candidate verification
+## Pre-release candidate verification
 
 The working-tree candidate passed:
 
@@ -124,6 +126,43 @@ Resulting main assurance and provenance passed in
 and main CodeQL passed in
 [run 32329061657](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32329061657).
 
+## Supported release evidence
+
+Release [pull request 17](https://github.com/chris-page-gov/gis-ai-go/pull/17)
+merged as protected-main commit
+`f1bda209e6309bf4f14f7ab7f524c442e59917b8`. Assurance and provenance passed in
+[run 32330917042](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32330917042),
+and CodeQL passed for Actions, JavaScript/TypeScript and Python in
+[run 32330916721](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32330916721).
+
+The annotated `v0.1.0` tag resolves through tag object
+`2f566c6e26dd17b13799e2976500e14701f04d11` to that exact release commit. A
+no-bypass tag ruleset blocks update and deletion. GitHub's immutable-release control
+is enabled, and
+[`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+is the immutable latest, non-prerelease release.
+
+The attested release archive has SHA-256
+`acf072986dafc34795039e363d0d5d09af44432fa392ff3aee5525887e1081a4`, payload
+root `80a649a5e4bebc36fb38c7b6d51d84056d1b2ff4c8b5f6b96c75bb6d03c6d245`
+and OKF content root
+`f6da572916ea850f6825e276867504a835bc783d76cea8038f72c8d1d42c2750`.
+[Attestation 41776630](https://github.com/chris-page-gov/gis-ai-go/attestations/41776630)
+binds the archive to the exact protected-main source and CI workflow.
+
+[Pages run 32331337338](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32331337338)
+deployed that verified payload as deployment `5995702325`. All four public-browser
+tests passed, and the public receipt records version `0.1.0`, the exact source
+commit, payload root, OKF root and public checksum-ledger digest
+`75d3a3c9ad8fad2cd7d5a8ee67851fd7655457aae9473ae717f0f4dbc67da815`.
+
+The immutable release contains exactly nine assets. GitHub release verification and
+all nine per-asset checks pass. A fresh post-publication download passed
+`RELEASE-ASSETS.sha256`; its ledger has SHA-256
+`8c062a5872dbc50760380f9826b153abbd14e10f015694b99b6af4f298ce89e4`.
+The top-level CycloneDX dependency SBOM contains 145 components, while the separate
+52-file publication inventory remains bound inside the canonical archive.
+
 ## Limitations and residual risks
 
 - The product is a static metadata catalogue, not an HMLR, ONS, Ordnance Survey or
@@ -142,11 +181,10 @@ and main CodeQL passed in
 - GitHub Pages supplies the hosting boundary. The application enforces its exact
   meta Content Security Policy, but the repository does not control response-header
   policies such as `frame-ancestors`.
-- Actions artefacts expire. Before support is declared, no-bypass `v*` tag protection
-  and GitHub release immutability must be enabled and verified. The release must
-  attach the canonical archive, checksum, receipt, SBOM, attestation verification
-  and public-verification evidence to that immutable GitHub Release.
+- Actions artefacts expire. The immutable release therefore retains the canonical
+  archive, checksum, receipt, SBOM, attestation verification and public-verification
+  evidence as durable assets.
 
-QUAL-105 remains open until the tagged `v0.1.0` artefact is deployed, its public
-receipt passes, the GitHub Release and durable assets exist, and final evidence is
-merged on protected `main`.
+The protected-main merge of this final record closes QUAL-105: the tagged artefact
+is deployed, its public receipt passes, and the immutable GitHub Release and durable
+assets exist.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -3,9 +3,9 @@
 This directory preserves the Stage 0 boundary, dependency baseline and verification
 as historical evidence. Current authority and status are in [`CONTEXT.md`](../../CONTEXT.md)
 and [`PROGRESS.md`](../../PROGRESS.md); ADR-0004 records progression beyond the local
-pause. The static Explorer remains the verified `0.0.0` public candidate while the
-tagged `v0.1.0` artefact and supported-release evidence are assembled. No MCP service
-exists.
+pause. The static Explorer is the supported
+[`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+public discovery product. No MCP service exists.
 
 - [Stage 0 boundary](STAGE_0_BOUNDARY.md)
 - [Dependency baseline](DEPENDENCIES.md)
@@ -15,3 +15,4 @@ exists.
 - [DISC-104 GitHub Pages runbook](DISC-104_RUNBOOK.md)
 - [DISC-104 GitHub Pages verification record](DISC-104_VERIFICATION.md)
 - [QUAL-105 release-assurance verification record](QUAL-105_VERIFICATION.md)
+- [`v0.1.0` supported-release evidence](V0.1.0_RELEASE_EVIDENCE.md)

--- a/docs/operations/V0.1.0_RELEASE_EVIDENCE.md
+++ b/docs/operations/V0.1.0_RELEASE_EVIDENCE.md
@@ -1,0 +1,107 @@
+# `v0.1.0` supported-release evidence
+
+- status: supported, public and immutable
+- released on: 20 August 2026
+- release: [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+- public product: <https://chris-page-gov.github.io/gis-ai-go/>
+- work item: [QUAL-105](https://github.com/chris-page-gov/gis-ai-go/issues/7)
+
+## Source and controls
+
+Release [pull request 17](https://github.com/chris-page-gov/gis-ai-go/pull/17)
+merged through the no-bypass protected `main` branch as
+`f1bda209e6309bf4f14f7ab7f524c442e59917b8`, tree
+`82266379198f3d7515981dd10cfe8d14b44fbeeb`. The author is Chris Page using the
+personal GitHub `noreply` identity; GitHub verified the merge commit signature.
+
+The annotated tag object
+`2f566c6e26dd17b13799e2976500e14701f04d11` peels to that exact release commit.
+Tag ruleset `21073388` blocks updates and deletion for `refs/tags/v*` with no bypass.
+The GitHub Release has ID `373487642`, is the latest non-prerelease release and is
+immutable. It was published at `2026-08-20T04:34:27Z`.
+
+## Assurance and build provenance
+
+- protected-main assurance and provenance:
+  [run 32330917042](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32330917042);
+- CodeQL for Actions, JavaScript/TypeScript and Python:
+  [run 32330916721](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32330916721);
+- Pages source artefact: `9392991975`, Actions transport digest
+  `sha256:b727ee694306c574dbdfb959000983c2212198984d578aa1803b32d0d23f0314`;
+- canonical archive SHA-256:
+  `acf072986dafc34795039e363d0d5d09af44432fa392ff3aee5525887e1081a4`;
+- payload root:
+  `80a649a5e4bebc36fb38c7b6d51d84056d1b2ff4c8b5f6b96c75bb6d03c6d245`;
+- OKF content root:
+  `f6da572916ea850f6825e276867504a835bc783d76cea8038f72c8d1d42c2750`;
+  and
+- [attestation 41776630](https://github.com/chris-page-gov/gis-ai-go/attestations/41776630),
+  verified against the exact repository, workflow, release commit, protected-main
+  ref and GitHub-hosted runner.
+
+The complete release gate passed type checking, gateway, build-policy, unit,
+component, Python contract, execution-boundary and 27 local browser tests. Two clean
+locked release builds produced byte-identical archives, checksums and receipts. The
+gate also validated schemas, source closure, links, immutable research hashes,
+secret and machine-path patterns, diagrams and the 145-component dependency SBOM.
+
+## Deployment and public acceptance
+
+[Pages run 32331337338](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32331337338)
+selected and verified the exact source artefact without rebuilding it. Deployment
+`5995702325` succeeded, followed by all four production-browser acceptance tests.
+The successful public-verification receipt binds:
+
+- version `0.1.0`;
+- source and workflow commit
+  `f1bda209e6309bf4f14f7ab7f524c442e59917b8`;
+- archive SHA-256
+  `acf072986dafc34795039e363d0d5d09af44432fa392ff3aee5525887e1081a4`;
+- payload root
+  `80a649a5e4bebc36fb38c7b6d51d84056d1b2ff4c8b5f6b96c75bb6d03c6d245`;
+- OKF content root
+  `f6da572916ea850f6825e276867504a835bc783d76cea8038f72c8d1d42c2750`;
+  and
+- public checksum-ledger SHA-256
+  `75d3a3c9ad8fad2cd7d5a8ee67851fd7655457aae9473ae717f0f4dbc67da815`.
+
+A final live check returned HTTP 200 and the same source, version, payload, OKF and
+publication-SBOM identities. The release does not depend on an agent-local preview.
+
+## Durable release assets
+
+The immutable release contains exactly nine assets:
+
+- canonical Pages archive, checksum and archive receipt;
+- saved GitHub build-attestation verification;
+- pre-deployment and public-verification receipts;
+- release evidence JSON;
+- 145-component CycloneDX dependency SBOM; and
+- `RELEASE-ASSETS.sha256`, which binds the other eight files.
+
+The release-assets ledger has SHA-256
+`8c062a5872dbc50760380f9826b153abbd14e10f015694b99b6af4f298ce89e4`.
+GitHub's signed release verification and every per-asset verification passed. Fresh
+downloads before and after publication were byte-identical to the reviewed files,
+and the post-publication copy passed every ledger row. The separate 52-file
+publication inventory remains inside and bound by the canonical archive.
+
+The public-verification receipt has SHA-256
+`b156247124d50d9ab2adcb282632c248ac368ad13202be24fdf7ab87f721b56c`, and the
+release evidence JSON has SHA-256
+`f5b912210ce3a71566d9fe6e641728df6c283af1793104db4cb0da11fab445e7`.
+The top-level dependency SBOM has SHA-256
+`216c37241e8cabb7074a723c41c52804a0d5a4b9feccffce04221f226aefbc84`; the
+distinct embedded publication inventory has SHA-256
+`828ce10a30ca7eefe46417158f5b3e16c78a99d4d3480caa28d84812ee5cfa08`.
+
+## Supported boundary
+
+`v0.1.0` supports the static public Explorer, canonical 36-record OKF publication,
+reviewed HMLR discovery examples, non-executing ONS and LandIS capability metadata,
+durable URLs and the linked JSON and JSON-LD downloads.
+
+It does not expose an MCP listener, provider execution, policy engine, identity
+integration, protected data, legal title boundary, transaction workflow or service
+level. Automated accessibility and security assurance is regression evidence, not
+a specialist accessibility audit, penetration test or provider endorsement.


### PR DESCRIPTION
## Summary

- record the immutable `v0.1.0` GitHub Release, protected tag, exact build and
  deployed public evidence;
- declare the bounded static discovery product supported while retaining the
  no-MCP, no-provider-execution and no-protected-data boundaries; and
- move canonical context and progress to the next `v0.2.0` roadmap outcome without
  claiming that any `v0.2.0` capability exists yet.

Closes #7.

## Verification

- complete `pnpm run check` passed: 4 gateway tests, 16 Explorer build-policy
  tests, 42 unit/component tests, 82 repository Python tests, 2 execution tests
  and 27 real-browser tests;
- two clean locked builds reproduced the immutable release archive SHA-256
  `acf072986dafc34795039e363d0d5d09af44432fa392ff3aee5525887e1081a4`;
- 293 local Markdown links, 183 immutable research hashes, 71 source identifiers,
  446 scanned text files, 9 diagrams and the 145-component dependency SBOM passed;
- GitHub release verification and all nine per-asset checks passed after a fresh
  post-publication download; and
- two independent final evidence reviews found no P0-P2 or material error.

## Deployment boundary and rollback

This is a documentation and tracking update only. It does not move the tag, replace
immutable release assets, change product code or data, or redeploy GitHub Pages.
If an asserted fact proves incorrect, revert this pull request through the normal
protected-main flow; the accepted `v0.1.0` artefact remains unchanged.
