### PR TITLE
feat(gateway): add inactive catalogue candidate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,8 +41,8 @@ through [pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14),
 whose accepted implementation commit is
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
 at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
-recorded below. There is no MCP listener, live provider adapter, policy engine,
-identity integration or evidence store.
+recorded below. There is no public MCP listener or catalogue API, live provider
+adapter, policy engine, identity integration or evidence store.
 
 The owner has authorised autonomous implementation in the open under
 [`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The repository
@@ -68,12 +68,24 @@ target advertises exactly `catalogue.search`, `catalogue.describe`,
 `evidence.inspect`, `selection.resolve` and `data.query`; the other seven profiles
 remain planned, and mutating `workflow.execute` is deferred to `v0.3.0`.
 
-MCP-201 establishes this lifecycle contract and a reusable catalogue foundation
-over the existing checksum-verified bundle, adopted by the static Explorer. This
-change does not create a service transport. There is still no MCP listener, direct API, live
-provider adapter, policy engine, identity integration or evidence store. The next
-slice will implement `catalogue.search` and `catalogue.describe` through one
-MCP/direct-API application path over that shared foundation.
+The first MCP-201 slice established this lifecycle contract and a reusable catalogue
+foundation over the existing checksum-verified bundle, adopted by the static
+Explorer. It reached protected `main` at
+`e5e6d4db5ac7036198cde64279e815f214f3defd`, with passing assurance and provenance
+in [run 32338916345](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916345),
+passing CodeQL in
+[run 32338916269](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916269)
+and [attestation 41792357](https://github.com/chris-page-gov/gis-ai-go/attestations/41792357).
+
+The current branch adds an inactive local gateway candidate: a fail-closed,
+checksum-verified immutable catalogue loader and one deterministic,
+transport-neutral `catalogue.search`/`catalogue.describe` application. Its HTTP
+listener is restricted to loopback and exposes only health, deliberately blocked
+readiness and its OpenAPI contract. It exposes no search or description route,
+starts no MCP listener, registers no MCP tool and is not publicly deployed.
+Activation is hard-blocked until EVID-204 supplies reviewed public policy and
+canonical inline evidence receipts. There is still no live provider adapter,
+policy engine, identity integration or evidence store.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -136,8 +136,10 @@ The supported target active set is exactly `catalogue.search`,
   and [attestation 41792357](https://github.com/chris-page-gov/gis-ai-go/attestations/41792357);
 - MCP-201 gateway candidate: exact implementation commit
   `442f788108106744e1e2ed7283e38c2a22aac5f1` passes the complete local gate and an
-  independent no-P0-P2 review; protected pull-request evidence remains pending and
-  the candidate exposes no catalogue operation, MCP tool or public deployment;
+  independent no-P0-P2 review; draft
+  [pull request 27](https://github.com/chris-page-gov/gis-ai-go/pull/27) is open with
+  protected checks pending, and the candidate exposes no catalogue operation, MCP
+  tool or public deployment;
 - current complete local gate: type checking, 38 gateway tests, 16 Explorer
   build-policy tests, 42 Explorer unit and component tests, 88 repository Python
   tests, 2 execution-boundary tests and 27 real-browser tests pass;

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -103,9 +103,8 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Next
 
-1. Pass the inactive gateway candidate through the complete local and protected
-   pull-request gates while keeping readiness blocked and the public product
-   unchanged.
+1. Pass the locally verified inactive gateway candidate through the protected
+   pull-request gate while keeping readiness blocked and the public product unchanged.
 2. EVID-204 must add reviewed public policy decisions and canonical inline evidence
    receipts to the shared application path.
 3. Add and verify the protocol-conformant MCP listener and direct catalogue routes,
@@ -135,11 +134,12 @@ The supported target active set is exactly `catalogue.search`,
   passing CodeQL in
   [run 32338916269](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916269)
   and [attestation 41792357](https://github.com/chris-page-gov/gis-ai-go/attestations/41792357);
-- MCP-201 gateway candidate: local implementation and verification remain pending
-  protected pull-request evidence; the candidate exposes no catalogue operation,
-  MCP tool or public deployment;
-- QUAL-105 complete local gate: type checking, 4 gateway tests, 16 Explorer
-  build-policy tests, 42 Explorer unit and component tests, 82 repository Python
+- MCP-201 gateway candidate: exact implementation commit
+  `442f788108106744e1e2ed7283e38c2a22aac5f1` passes the complete local gate and an
+  independent no-P0-P2 review; protected pull-request evidence remains pending and
+  the candidate exposes no catalogue operation, MCP tool or public deployment;
+- current complete local gate: type checking, 38 gateway tests, 16 Explorer
+  build-policy tests, 42 Explorer unit and component tests, 88 repository Python
   tests, 2 execution-boundary tests and 27 real-browser tests pass;
 - QUAL-105 reproducibility: two complete clean locked builds produce byte-identical
   Pages archives, checksums and receipts; the public workflow now emits a mandatory

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,15 +15,17 @@ The supported target active set is exactly `catalogue.search`,
 
 - use the accepted lifecycle boundary from
   [`ADR-0009`](docs/decisions/ADR-0009-read-only-mcp-tool-lifecycle.md);
-- build MCP and direct API over the catalogue foundation already adopted by the
-  static Explorer;
-- advertise only implemented, enabled, public and read-only tools;
-- implement `catalogue.search` and `catalogue.describe` as the first end-to-end
-  runtime slice;
+- pass the inactive loopback gateway candidate through the protected pull-request
+  gate without changing the supported public product;
+- retain the checksum-verified immutable catalogue loader and deterministic,
+  transport-neutral `catalogue.search`/`catalogue.describe` application;
+- expose only health, blocked readiness and OpenAPI while policy and inline
+  evidence are unavailable;
+- advertise no tool and mount no catalogue API operation in this candidate;
 - retain policy, evidence, rate and complexity boundaries in every public contract;
   and
-- prove non-App MCP client, direct API and static-product interoperability before
-  any public service or registry entry.
+- require EVID-204 and later non-App MCP, direct API and static-product
+  interoperability evidence before any public service or registry entry.
 
 ## Completed
 
@@ -86,31 +88,56 @@ The supported target active set is exactly `catalogue.search`,
   [pull request 18](https://github.com/chris-page-gov/gis-ai-go/pull/18) at
   `80ac89d89e04751045693cecff4a3a714d121ebe`;
 - [`ADR-0009`](docs/decisions/ADR-0009-read-only-mcp-tool-lifecycle.md) defines the
-  exact read-only tool lifecycle and supported five-tool `v0.2.0` target; and
+  exact read-only tool lifecycle and supported five-tool `v0.2.0` target;
+- the first MCP-201 contract slice reached protected `main` at
+  `e5e6d4db5ac7036198cde64279e815f214f3defd`, with passing assurance and provenance
+  in [run 32338916345](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916345),
+  passing CodeQL in
+  [run 32338916269](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916269)
+  and [attestation 41792357](https://github.com/chris-page-gov/gis-ai-go/attestations/41792357);
+- that slice defines closed catalogue search, description and problem schemas,
+  query-analysis bounds and the shared catalogue core without activating a tool;
+  and
 - the existing Explorer adopts a reusable shared catalogue foundation without
   gaining any dependency on a running service.
 
 ## Next
 
-1. Implement the direct API and MCP `catalogue.search`/`catalogue.describe` slice
-   through the normal protected pull-request gate.
-2. Add policy decisions and immutable evidence receipts to the same application
-   path before treating its results as material service evidence.
-3. Activate `evidence.inspect`, `selection.resolve` and `data.query` only after
+1. Pass the inactive gateway candidate through the complete local and protected
+   pull-request gates while keeping readiness blocked and the public product
+   unchanged.
+2. EVID-204 must add reviewed public policy decisions and canonical inline evidence
+   receipts to the shared application path.
+3. Add and verify the protocol-conformant MCP listener and direct catalogue routes,
+   then activate `catalogue.search` and `catalogue.describe` only when their full
+   policy, evidence, lifecycle and interoperability gates pass.
+4. Activate `evidence.inspect`, `selection.resolve` and `data.query` only after
    their separate evidence gates pass; keep the other seven profiles planned.
 
 ## Current blockers
 
-- No blocker is known for establishing the open `v0.2.0` foundation.
-- The lifecycle and shared catalogue foundation do not create a listener, API,
-  provider adapter or evidence store; those remain implementation work rather than
-  blockers.
+- No blocker is known for merging the deliberately inactive local gateway
+  candidate.
+- Activating or publishing a catalogue service is hard-blocked until EVID-204 adds
+  reviewed public policy and canonical inline evidence receipts. The current
+  candidate has no activation override.
+- The candidate has no MCP listener, catalogue API operation, provider adapter or
+  evidence store; those remain implementation work, not implied capabilities.
 - Protected PSGA and commercial deployments require separate rights, credentials
   and isolated infrastructure. They remain outside this release and do not block
   the open product.
 
 ## Latest evidence
 
+- MCP-201 shared catalogue contract: protected-main commit
+  `e5e6d4db5ac7036198cde64279e815f214f3defd`, passing assurance and provenance in
+  [run 32338916345](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916345),
+  passing CodeQL in
+  [run 32338916269](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916269)
+  and [attestation 41792357](https://github.com/chris-page-gov/gis-ai-go/attestations/41792357);
+- MCP-201 gateway candidate: local implementation and verification remain pending
+  protected pull-request evidence; the candidate exposes no catalogue operation,
+  MCP tool or public deployment;
 - QUAL-105 complete local gate: type checking, 4 gateway tests, 16 Explorer
   build-policy tests, 42 Explorer unit and component tests, 82 repository Python
   tests, 2 execution-boundary tests and 27 real-browser tests pass;

--- a/apps/mcp-gateway/README.md
+++ b/apps/mcp-gateway/README.md
@@ -8,12 +8,16 @@ It is an implementation workbench, not a supported or deployed service.
 - `loadCatalogueSnapshot` loads the generated public catalogue only after its exact
   inventory, checksum ledger, manifest, build receipt, content root and public-bundle
   identity agree. It rejects links, unsafe paths, unexpected files, changed files and
-  over-limit inputs, then returns one immutable snapshot with an explicit freshness
-  warning when its review date has passed.
+  over-limit inputs. Directory enumeration is streamed and file reads are bounded to
+  the recorded length plus one byte with identity checks before and after reading.
+  It then returns one immutable snapshot with an explicit freshness warning when its
+  review date has passed.
 - `createCatalogueApplication` binds deterministic `catalogue.search` and
   `catalogue.describe` functions to that snapshot. The transport-neutral functions
-  use closed request, result and problem envelopes, bounded inputs and cursors bound
-  to both the catalogue content root and normalised search criteria.
+  use closed request, result and problem envelopes, bounded inputs and outputs, and
+  cursors bound to both the catalogue content root and normalised search criteria.
+  A snapshot that cannot fit the public result schema is rejected rather than
+  truncated.
 - the HTTP candidate listens only on `127.0.0.1:8787` and exposes `GET /healthz`,
   `GET /readyz` and `GET /openapi.json`. Readiness always returns `503` with zero
   active tools and zero active API operations.

--- a/apps/mcp-gateway/README.md
+++ b/apps/mcp-gateway/README.md
@@ -1,5 +1,54 @@
-# MCP gateway boundary
+# MCP gateway
 
-This package pins the official TypeScript server SDK line and exposes Stage 0 metadata
-only. It starts no listener, registers no tools and makes no provider or policy calls.
-Live execution is rejected by `assertStageZeroRequest` and covered by unit tests.
+This package contains an inactive, local-only candidate for the GIS AI GO gateway.
+It is an implementation workbench, not a supported or deployed service.
+
+## Implemented candidate components
+
+- `loadCatalogueSnapshot` loads the generated public catalogue only after its exact
+  inventory, checksum ledger, manifest, build receipt, content root and public-bundle
+  identity agree. It rejects links, unsafe paths, unexpected files, changed files and
+  over-limit inputs, then returns one immutable snapshot with an explicit freshness
+  warning when its review date has passed.
+- `createCatalogueApplication` binds deterministic `catalogue.search` and
+  `catalogue.describe` functions to that snapshot. The transport-neutral functions
+  use closed request, result and problem envelopes, bounded inputs and cursors bound
+  to both the catalogue content root and normalised search criteria.
+- the HTTP candidate listens only on `127.0.0.1:8787` and exposes `GET /healthz`,
+  `GET /readyz` and `GET /openapi.json`. Readiness always returns `503` with zero
+  active tools and zero active API operations.
+
+The cursor digest detects corruption; it conveys no identity, authentication or
+authority.
+
+## Deliberate activation block
+
+The application functions are not mounted on HTTP routes. There is no
+`catalogue.search` or `catalogue.describe` endpoint, MCP listener, MCP tool
+registration, public deployment, provider call, policy engine or evidence store.
+There is no environment-variable or command-line activation override.
+
+Activation remains hard-blocked as
+`inline-evidence-and-public-policy-unavailable`. EVID-204 must add reviewed public
+policy decisions and canonical inline evidence receipts before a later reviewed
+change may mount or advertise either operation.
+
+## Local verification
+
+From the repository root:
+
+```bash
+pnpm --filter @gis-ai-go/mcp-gateway run test
+```
+
+To inspect the deliberately blocked HTTP surface after building the candidate:
+
+```bash
+pnpm run build:okf
+pnpm --filter @gis-ai-go/contracts run build
+pnpm --filter @gis-ai-go/mcp-gateway run build
+pnpm --filter @gis-ai-go/mcp-gateway run start:http
+```
+
+See the [candidate boundary](../../docs/operations/MCP-201_GATEWAY_CANDIDATE.md)
+and [verification record](../../docs/operations/MCP-201_VERIFICATION.md).

--- a/apps/mcp-gateway/openapi/catalogue-api.openapi.json
+++ b/apps/mcp-gateway/openapi/catalogue-api.openapi.json
@@ -1,0 +1,167 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "GIS AI GO gateway candidate",
+    "summary": "Inactive local gateway candidate over the governed public catalogue",
+    "description": "This contract exposes health, blocked readiness and itself. It mounts no catalogue operation.",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://127.0.0.1:8787",
+      "description": "Local candidate only"
+    }
+  ],
+  "security": [],
+  "x-gis-ai-go-lifecycle": "candidate-blocked",
+  "x-gis-ai-go-active-catalogue-operations": [],
+  "x-gis-ai-go-blocked-by": "inline-evidence-and-public-policy-unavailable",
+  "paths": {
+    "/healthz": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Check that the local candidate process is running",
+        "responses": {
+          "200": {
+            "description": "The process is running and the catalogue snapshot loaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Health"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "operationId": "readinessCheck",
+        "summary": "Report the deliberate activation block",
+        "responses": {
+          "503": {
+            "description": "No catalogue operation is active",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Readiness"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "operationId": "openApiContract",
+        "summary": "Read this candidate contract",
+        "responses": {
+          "200": {
+            "description": "The exact local candidate OpenAPI document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CatalogueIdentity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "version",
+          "revision",
+          "content_root_sha256",
+          "record_count",
+          "stale",
+          "warnings"
+        ],
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$"
+          },
+          "content_root_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "record_count": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "stale": {
+            "type": "boolean"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Health": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "product",
+          "lifecycle",
+          "catalogue"
+        ],
+        "properties": {
+          "status": {
+            "const": "ok"
+          },
+          "product": {
+            "const": "GIS AI GO"
+          },
+          "lifecycle": {
+            "const": "candidate-blocked"
+          },
+          "catalogue": {
+            "$ref": "#/components/schemas/CatalogueIdentity"
+          }
+        }
+      },
+      "Readiness": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "reason",
+          "active_tools",
+          "active_api_operations"
+        ],
+        "properties": {
+          "status": {
+            "const": "blocked"
+          },
+          "reason": {
+            "const": "inline-evidence-and-public-policy-unavailable"
+          },
+          "active_tools": {
+            "type": "array",
+            "maxItems": 0
+          },
+          "active_api_operations": {
+            "type": "array",
+            "maxItems": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "pnpm run build && node --test dist/test/*.test.js"
+    "prepare:test": "pnpm --dir ../.. run build:okf && pnpm --filter @gis-ai-go/contracts run build",
+    "test": "pnpm run prepare:test && pnpm run build && node --test dist/test/*.test.js",
+    "start:http": "node dist/src/http-main.js ../../artifacts/okf"
   },
   "dependencies": {
+    "@gis-ai-go/contracts": "workspace:*",
     "@modelcontextprotocol/server": "2.0.0"
   }
 }

--- a/apps/mcp-gateway/src/activation.ts
+++ b/apps/mcp-gateway/src/activation.ts
@@ -1,0 +1,23 @@
+export const ACTIVATION_BLOCK_REASON =
+  "inline-evidence-and-public-policy-unavailable" as const;
+
+export interface BlockedCatalogueActivation {
+  readonly state: "blocked";
+  readonly reason: typeof ACTIVATION_BLOCK_REASON;
+  readonly activeTools: readonly [];
+  readonly activeApiOperations: readonly [];
+}
+
+/**
+ * The only production activation state in this candidate.
+ *
+ * EVID-204 must replace this closed value with a reviewed policy decision and
+ * inline receipt factory before any catalogue operation is mounted or advertised.
+ * There is deliberately no environment-variable or command-line override.
+ */
+export const catalogueActivation: BlockedCatalogueActivation = Object.freeze({
+  state: "blocked",
+  reason: ACTIVATION_BLOCK_REASON,
+  activeTools: Object.freeze([]) as readonly [],
+  activeApiOperations: Object.freeze([]) as readonly [],
+});

--- a/apps/mcp-gateway/src/catalogue-application.ts
+++ b/apps/mcp-gateway/src/catalogue-application.ts
@@ -1,0 +1,996 @@
+import {
+  ACCESS_STATES,
+  AUTHORITY_CLASSES,
+  FRESHNESS_STATUSES,
+  RECORD_STATUSES,
+  RECORD_TYPES,
+  RIGHTS_STATES,
+  analyseCatalogueQuery,
+  deriveFacetOptions,
+  searchRecords,
+  type AccessState,
+  type AuthorityClass,
+  type CatalogueRecord,
+  type ExplorerState,
+  type FacetOptions,
+  type FreshnessStatus,
+  type JsonValue,
+  type RecordType,
+  type RightsState,
+} from "@gis-ai-go/contracts";
+
+import type { CatalogueSnapshot } from "./catalogue-snapshot.js";
+import {
+  InvalidCatalogueCursorError,
+  decodeCatalogueCursor,
+  encodeCatalogueCursor,
+  sha256CanonicalJson,
+} from "./cursor.js";
+import {
+  assertCatalogueProblemContext,
+  throwCatalogueProblem,
+  type CatalogueProblemContext,
+  type CatalogueProblemFieldCode,
+} from "./problem.js";
+
+const SEARCH_REQUEST_KEYS = ["cursor", "facets", "limit", "query"] as const;
+const FACET_KEYS = ["access", "authority", "freshness", "rights", "tags", "types"] as const;
+const DESCRIBE_REQUEST_KEYS = ["include", "record_id"] as const;
+const DESCRIBE_INCLUDES = ["relationships", "sources"] as const;
+const DEFAULT_LIMIT = 20;
+const MAX_CURSOR_LENGTH = 1_024;
+const RESULT_SEMVER = /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u;
+const RESULT_SHA40 = /^[0-9a-f]{40}$/u;
+const RESULT_SHA256 = /^[0-9a-f]{64}$/u;
+const RESULT_DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u;
+const PROBLEM_CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/u;
+const SOURCE_NATIVE_STRING_UNSAFE =
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+const SOURCE_NATIVE_KEY_UNSAFE =
+  /[\u0000-\u001f\u007f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+const SOURCE_NATIVE_DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+type DescribeInclude = (typeof DESCRIBE_INCLUDES)[number];
+
+export interface CatalogueSearchFacets {
+  readonly types?: readonly RecordType[];
+  readonly authority?: readonly AuthorityClass[];
+  readonly access?: readonly AccessState[];
+  readonly rights?: readonly RightsState[];
+  readonly freshness?: readonly FreshnessStatus[];
+  readonly tags?: readonly string[];
+}
+
+export interface CatalogueSearchRequest {
+  readonly query?: string;
+  readonly facets?: CatalogueSearchFacets;
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+export interface CatalogueDescribeRequest {
+  readonly record_id: string;
+  readonly include?: readonly DescribeInclude[];
+}
+
+export interface CatalogueIdentity {
+  readonly id: string;
+  readonly version: string;
+  readonly revision: string;
+  readonly content_root_sha256: string;
+  readonly record_count: number;
+  readonly reviewed_at: string;
+  readonly stale_after: string;
+}
+
+export interface CatalogueRecordSummary {
+  readonly id: string;
+  readonly type: CatalogueRecord["type"];
+  readonly title: string;
+  readonly description: string;
+  readonly authority: CatalogueRecord["authority"]["class"];
+  readonly access: CatalogueRecord["access"]["state"];
+  readonly rights: CatalogueRecord["rights"]["state"];
+  readonly freshness: CatalogueRecord["freshness"]["status"];
+  readonly status: CatalogueRecord["status"];
+  readonly tags: readonly string[];
+}
+
+export interface CatalogueRecordDetail {
+  readonly id: string;
+  readonly type: CatalogueRecord["type"];
+  readonly title: string;
+  readonly description: string;
+  readonly authority: {
+    readonly class: CatalogueRecord["authority"]["class"];
+    readonly statement: string;
+    readonly source: string;
+  };
+  readonly publication: {
+    readonly classification: "public";
+    readonly contains_personal_data: false;
+    readonly contains_protected_data: false;
+  };
+  readonly access: {
+    readonly tier: "open";
+    readonly state: CatalogueRecord["access"]["state"];
+    readonly authentication: string;
+  };
+  readonly rights: {
+    readonly state: CatalogueRecord["rights"]["state"];
+    readonly record_licence: string;
+    readonly described_resource_licence: string;
+    readonly attribution: string;
+  };
+  readonly freshness: {
+    readonly observed_at: string;
+    readonly reviewed_at: string;
+    readonly stale_after: string;
+    readonly status: CatalogueRecord["freshness"]["status"];
+  };
+  readonly status: CatalogueRecord["status"];
+  readonly source_refs: readonly string[];
+  readonly limitations: readonly string[];
+  readonly tags: readonly string[];
+  readonly details: Readonly<Record<string, JsonValue>>;
+}
+
+export interface CatalogueSearchResult {
+  readonly schema: "gis-ai-go.catalogue-result.v1";
+  readonly operation: "catalogue.search";
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly catalogue: CatalogueIdentity;
+  readonly warnings: readonly string[];
+  readonly data: {
+    readonly records: readonly CatalogueRecordSummary[];
+    readonly facets: FacetOptions;
+    readonly page: {
+      readonly limit: number;
+      readonly returned: number;
+      readonly matched: number;
+      readonly next_cursor: string | null;
+    };
+  };
+}
+
+export interface CatalogueDescribeResult {
+  readonly schema: "gis-ai-go.catalogue-result.v1";
+  readonly operation: "catalogue.describe";
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly catalogue: CatalogueIdentity;
+  readonly warnings: readonly string[];
+  readonly data: {
+    readonly record: CatalogueRecordDetail;
+    readonly included: {
+      readonly relationships?: readonly {
+        readonly relation: "source";
+        readonly record_id: string;
+      }[];
+      readonly sources?: readonly {
+        readonly id: string;
+        readonly title: string;
+        readonly authority: CatalogueRecord["authority"]["class"];
+        readonly access: CatalogueRecord["access"]["state"];
+        readonly rights: CatalogueRecord["rights"]["state"];
+        readonly freshness: CatalogueRecord["freshness"]["status"];
+      }[];
+    };
+  };
+}
+
+export interface CatalogueApplication {
+  readonly search: (
+    request: unknown,
+    context: CatalogueProblemContext,
+  ) => CatalogueSearchResult;
+  readonly describe: (
+    request: unknown,
+    context: CatalogueProblemContext,
+  ) => CatalogueDescribeResult;
+}
+
+interface NormalisedSearchRequest {
+  readonly query: string;
+  readonly facets: {
+    readonly types: readonly RecordType[];
+    readonly authority: readonly AuthorityClass[];
+    readonly access: readonly AccessState[];
+    readonly rights: readonly RightsState[];
+    readonly freshness: readonly FreshnessStatus[];
+    readonly tags: readonly string[];
+  };
+  readonly limit: number;
+  readonly cursor: string | null;
+}
+
+interface ResultFacetCount {
+  readonly value: string;
+  readonly count: number;
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function resultContractFailure(path: string, message: string): never {
+  throw new Error(`Catalogue result contract rejected at ${path}: ${message}`);
+}
+
+function assertResultText(
+  value: unknown,
+  path: string,
+  maximum: number,
+  minimum = 1,
+): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    codePointLength(value) < minimum ||
+    codePointLength(value) > maximum
+  ) {
+    resultContractFailure(
+      path,
+      `expected from ${minimum} to ${maximum} Unicode characters`,
+    );
+  }
+}
+
+function assertControlledResultValue(
+  value: unknown,
+  path: string,
+  allowed: readonly string[],
+): asserts value is string {
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    resultContractFailure(path, "value is outside the closed result vocabulary");
+  }
+}
+
+function assertResultDateTime(value: unknown, path: string): void {
+  if (
+    typeof value !== "string" ||
+    !RESULT_DATE_TIME.test(value) ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    resultContractFailure(path, "expected an RFC 3339 date-time");
+  }
+}
+
+function assertResultStringArray(
+  value: unknown,
+  path: string,
+  minimumItems: number,
+  maximumItems: number,
+  maximumItemLength: number,
+): asserts value is readonly string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length < minimumItems ||
+    value.length > maximumItems
+  ) {
+    resultContractFailure(
+      path,
+      `expected from ${minimumItems} to ${maximumItems} unique strings`,
+    );
+  }
+  value.forEach((item, index) =>
+    assertResultText(item, `${path}[${index}]`, maximumItemLength),
+  );
+  if (new Set(value).size !== value.length) {
+    resultContractFailure(path, "strings must be unique");
+  }
+}
+
+function assertSourceNativeValue(
+  value: unknown,
+  path: string,
+  ancestors: WeakSet<object>,
+): void {
+  if (value === null || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      resultContractFailure(path, "number must be finite");
+    }
+    return;
+  }
+  if (typeof value === "string") {
+    if (
+      codePointLength(value) > 65_536 ||
+      SOURCE_NATIVE_STRING_UNSAFE.test(value)
+    ) {
+      resultContractFailure(path, "string exceeds the source-native result boundary");
+    }
+    return;
+  }
+  if (typeof value !== "object" || value === undefined) {
+    resultContractFailure(path, "value is not JSON-compatible");
+  }
+  if (ancestors.has(value)) {
+    resultContractFailure(path, "cyclic values are not permitted");
+  }
+  ancestors.add(value);
+
+  if (Array.isArray(value)) {
+    if (value.length > 10_000) {
+      resultContractFailure(path, "array exceeds 10000 items");
+    }
+    value.forEach((item, index) =>
+      assertSourceNativeValue(item, `${path}[${index}]`, ancestors),
+    );
+    ancestors.delete(value);
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    resultContractFailure(path, "object must be a plain JSON object");
+  }
+  const entries = Object.entries(value);
+  if (entries.length > 256) {
+    resultContractFailure(path, "object exceeds 256 properties");
+  }
+  entries.forEach(([key, member], index) => {
+    if (
+      codePointLength(key) < 1 ||
+      codePointLength(key) > 256 ||
+      SOURCE_NATIVE_KEY_UNSAFE.test(key) ||
+      SOURCE_NATIVE_DANGEROUS_KEYS.has(key)
+    ) {
+      resultContractFailure(
+        `${path}.property[${index}]`,
+        "property name is outside the source-native result boundary",
+      );
+    }
+    assertSourceNativeValue(member, `${path}.property[${index}].value`, ancestors);
+  });
+  ancestors.delete(value);
+}
+
+function assertResultRecord(record: CatalogueRecord, path: string): void {
+  assertResultText(record.id, `${path}.id`, 512);
+  assertControlledResultValue(record.type, `${path}.type`, RECORD_TYPES);
+  assertResultText(record.title, `${path}.title`, 512);
+  assertResultText(record.description, `${path}.description`, 4_096);
+  assertControlledResultValue(
+    record.authority.class,
+    `${path}.authority.class`,
+    AUTHORITY_CLASSES,
+  );
+  assertResultText(record.authority.statement, `${path}.authority.statement`, 4_096);
+  assertResultText(record.authority.source, `${path}.authority.source`, 512);
+  if (
+    record.publication.classification !== "public" ||
+    record.publication.containsPersonalData !== false ||
+    record.publication.containsProtectedData !== false
+  ) {
+    resultContractFailure(`${path}.publication`, "publication boundary is not public-only");
+  }
+  if (record.access.tier !== "open") {
+    resultContractFailure(`${path}.access.tier`, "access tier must be open");
+  }
+  assertControlledResultValue(record.access.state, `${path}.access.state`, ACCESS_STATES);
+  assertResultText(record.access.authentication, `${path}.access.authentication`, 512);
+  assertControlledResultValue(record.rights.state, `${path}.rights.state`, RIGHTS_STATES);
+  assertResultText(record.rights.recordLicence, `${path}.rights.recordLicence`, 2_048);
+  assertResultText(
+    record.rights.describedResourceLicence,
+    `${path}.rights.describedResourceLicence`,
+    2_048,
+  );
+  assertResultText(record.rights.attribution, `${path}.rights.attribution`, 8_192);
+  assertResultDateTime(record.freshness.observedAt, `${path}.freshness.observedAt`);
+  assertResultDateTime(record.freshness.reviewedAt, `${path}.freshness.reviewedAt`);
+  assertResultDateTime(record.freshness.staleAfter, `${path}.freshness.staleAfter`);
+  assertControlledResultValue(
+    record.freshness.status,
+    `${path}.freshness.status`,
+    FRESHNESS_STATUSES,
+  );
+  assertControlledResultValue(record.status, `${path}.status`, RECORD_STATUSES);
+  assertResultStringArray(record.sourceRefs, `${path}.sourceRefs`, 1, 100, 512);
+  assertResultStringArray(record.limitations, `${path}.limitations`, 1, 50, 2_048);
+  assertResultStringArray(record.tags, `${path}.tags`, 0, 50, 128);
+  assertSourceNativeValue(record.details, `${path}.details`, new WeakSet<object>());
+}
+
+function assertFacetCounts(
+  values: readonly ResultFacetCount[],
+  path: string,
+  maximumItems: number,
+  allowedValues?: readonly string[],
+): void {
+  if (!Array.isArray(values) || values.length > maximumItems) {
+    resultContractFailure(path, `facet exceeds ${maximumItems} options`);
+  }
+  const identities = new Set<string>();
+  values.forEach((facet, index) => {
+    const itemPath = `${path}[${index}]`;
+    if (allowedValues === undefined) {
+      assertResultText(facet.value, `${itemPath}.value`, 128);
+    } else {
+      assertControlledResultValue(facet.value, `${itemPath}.value`, allowedValues);
+    }
+    if (
+      !Number.isInteger(facet.count) ||
+      facet.count < 0 ||
+      facet.count > 10_000
+    ) {
+      resultContractFailure(`${itemPath}.count`, "facet count must be from 0 to 10000");
+    }
+    if (identities.has(facet.value)) {
+      resultContractFailure(path, "facet options must be unique");
+    }
+    identities.add(facet.value);
+  });
+}
+
+function assertResultFacetBounds(facets: FacetOptions): void {
+  assertFacetCounts(facets.types, "$.data.facets.types", 5, RECORD_TYPES);
+  assertFacetCounts(facets.authority, "$.data.facets.authority", 3, AUTHORITY_CLASSES);
+  assertFacetCounts(facets.access, "$.data.facets.access", 3, ACCESS_STATES);
+  assertFacetCounts(facets.rights, "$.data.facets.rights", 3, RIGHTS_STATES);
+  assertFacetCounts(facets.freshness, "$.data.facets.freshness", 2, FRESHNESS_STATUSES);
+  assertFacetCounts(facets.tags, "$.data.facets.tags", 100);
+}
+
+/**
+ * Reject any snapshot that could project beyond the closed catalogue-result schema.
+ *
+ * The shared catalogue parser intentionally supports richer in-process display
+ * values, so the gateway must enforce its narrower transport boundary explicitly.
+ */
+export function assertCatalogueResultSnapshotBounds(snapshot: CatalogueSnapshot): void {
+  assertResultText(snapshot.bundle.id, "$.catalogue.id", 512);
+  if (!RESULT_SEMVER.test(snapshot.version)) {
+    resultContractFailure("$.catalogue.version", "expected a semantic version");
+  }
+  if (!RESULT_SHA40.test(snapshot.revision)) {
+    resultContractFailure("$.catalogue.revision", "expected a lowercase Git SHA");
+  }
+  if (!RESULT_SHA256.test(snapshot.contentRootSha256)) {
+    resultContractFailure(
+      "$.catalogue.content_root_sha256",
+      "expected a lowercase SHA-256 digest",
+    );
+  }
+  if (
+    !Number.isInteger(snapshot.recordCount) ||
+    snapshot.recordCount < 1 ||
+    snapshot.recordCount > 10_000 ||
+    snapshot.recordCount !== snapshot.bundle.records.length
+  ) {
+    resultContractFailure(
+      "$.catalogue.record_count",
+      "record count must match from 1 to 10000 records",
+    );
+  }
+  assertResultDateTime(snapshot.bundle.reviewedAt, "$.catalogue.reviewed_at");
+  assertResultDateTime(snapshot.bundle.staleAfter, "$.catalogue.stale_after");
+  assertResultStringArray(snapshot.warnings, "$.warnings", 0, 20, 1_024);
+
+  if (snapshot.recordsById.size !== snapshot.bundle.records.length) {
+    resultContractFailure("$.data.records", "record index does not match the bundle");
+  }
+  snapshot.bundle.records.forEach((record, index) => {
+    assertResultRecord(record, `$.data.records[${index}]`);
+    if (snapshot.recordsById.get(record.id) !== record) {
+      resultContractFailure(
+        `$.data.records[${index}].id`,
+        "record index does not reference the canonical bundle record",
+      );
+    }
+  });
+  assertResultFacetBounds(deriveFacetOptions(snapshot.bundle.records));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isProblemBoundedText(value: string, maximum: number): boolean {
+  return (
+    codePointLength(value) >= 1 &&
+    codePointLength(value) <= maximum &&
+    !PROBLEM_CONTROL_CHARACTER.test(value)
+  );
+}
+
+function fieldFailure(
+  context: CatalogueProblemContext,
+  path: string,
+  code: CatalogueProblemFieldCode,
+  message: string,
+): never {
+  throwCatalogueProblem("invalid_request", context, {
+    detail: message,
+    errors: [{ path, code, message }],
+  });
+}
+
+function unknownPropertyFailure(
+  context: CatalogueProblemContext,
+  parentPath: string,
+  unknownKey: string,
+): never {
+  const candidatePath = `${parentPath}.${unknownKey}`;
+  const candidateMessage = `Remove the unknown property ${unknownKey}.`;
+  const canReflectIdentity =
+    isProblemBoundedText(candidatePath, 256) &&
+    isProblemBoundedText(candidateMessage, 512);
+  fieldFailure(
+    context,
+    canReflectIdentity ? candidatePath : parentPath,
+    "unknown_property",
+    canReflectIdentity ? candidateMessage : "Remove the unknown property.",
+  );
+}
+
+function assertClosedObject(
+  value: unknown,
+  path: string,
+  allowedKeys: readonly string[],
+  context: CatalogueProblemContext,
+): Record<string, unknown> {
+  if (!isPlainObject(value)) {
+    fieldFailure(context, path, "invalid_type", "Use a JSON object.");
+  }
+  const unknownKey = Object.keys(value).find((key) => !allowedKeys.includes(key));
+  if (unknownKey !== undefined) {
+    unknownPropertyFailure(context, path, unknownKey);
+  }
+  return value;
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function sortedUniqueValues<const T extends string>(
+  value: unknown,
+  path: string,
+  allowed: readonly T[],
+  maximum: number,
+  context: CatalogueProblemContext,
+): readonly T[] {
+  if (!Array.isArray(value)) {
+    fieldFailure(context, path, "invalid_type", "Use an array of controlled values.");
+  }
+  if (value.length < 1 || value.length > maximum) {
+    fieldFailure(
+      context,
+      path,
+      "out_of_range",
+      `Supply between 1 and ${maximum} values.`,
+    );
+  }
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || !allowed.includes(item as T)) {
+      fieldFailure(
+        context,
+        `${path}[${index}]`,
+        "invalid_value",
+        "Use a value from the governed catalogue facet.",
+      );
+    }
+  }
+  const typed = value as T[];
+  if (new Set(typed).size !== typed.length) {
+    fieldFailure(context, path, "not_unique", "Facet values must be unique.");
+  }
+  return [...typed].sort();
+}
+
+function normaliseFacets(
+  value: unknown,
+  snapshot: CatalogueSnapshot,
+  context: CatalogueProblemContext,
+): NormalisedSearchRequest["facets"] {
+  if (value === undefined) {
+    return { types: [], authority: [], access: [], rights: [], freshness: [], tags: [] };
+  }
+  const facets = assertClosedObject(value, "$.facets", FACET_KEYS, context);
+  if (Object.keys(facets).length === 0) {
+    fieldFailure(context, "$.facets", "required", "Supply at least one facet.");
+  }
+  const availableTags = deriveFacetOptions(snapshot.bundle.records).tags.map(
+    ({ value: tag }) => tag,
+  );
+  return {
+    types: hasOwn(facets, "types")
+      ? sortedUniqueValues(facets.types, "$.facets.types", RECORD_TYPES, 5, context)
+      : [],
+    authority: hasOwn(facets, "authority")
+      ? sortedUniqueValues(
+          facets.authority,
+          "$.facets.authority",
+          AUTHORITY_CLASSES,
+          3,
+          context,
+        )
+      : [],
+    access: hasOwn(facets, "access")
+      ? sortedUniqueValues(facets.access, "$.facets.access", ACCESS_STATES, 3, context)
+      : [],
+    rights: hasOwn(facets, "rights")
+      ? sortedUniqueValues(facets.rights, "$.facets.rights", RIGHTS_STATES, 3, context)
+      : [],
+    freshness: hasOwn(facets, "freshness")
+      ? sortedUniqueValues(
+          facets.freshness,
+          "$.facets.freshness",
+          FRESHNESS_STATUSES,
+          2,
+          context,
+        )
+      : [],
+    tags: hasOwn(facets, "tags")
+      ? sortedUniqueValues(facets.tags, "$.facets.tags", availableTags, 50, context)
+      : [],
+  };
+}
+
+function normaliseSearchRequest(
+  value: unknown,
+  snapshot: CatalogueSnapshot,
+  context: CatalogueProblemContext,
+): NormalisedSearchRequest {
+  const request = assertClosedObject(value, "$", SEARCH_REQUEST_KEYS, context);
+
+  let query = "";
+  if (hasOwn(request, "query")) {
+    if (typeof request.query !== "string") {
+      fieldFailure(context, "$.query", "invalid_type", "Use a string query.");
+    }
+    if (request.query.length === 0) {
+      fieldFailure(context, "$.query", "out_of_range", "Query must not be empty.");
+    }
+    const analysis = analyseCatalogueQuery(request.query);
+    if (analysis.exceedsCharacterLimit) {
+      fieldFailure(
+        context,
+        "$.query",
+        "out_of_range",
+        "Query must not exceed 256 Unicode characters.",
+      );
+    }
+    if (analysis.exceedsTermLimit) {
+      throwCatalogueProblem("complexity_limit_exceeded", context, {
+        detail: "Query must not exceed 10 normalised terms.",
+        errors: [
+          {
+            path: "$.query",
+            code: "out_of_range",
+            message: "Use no more than 10 normalised terms.",
+          },
+        ],
+      });
+    }
+    query = analysis.normalised;
+  }
+
+  let limit = DEFAULT_LIMIT;
+  if (hasOwn(request, "limit")) {
+    if (!Number.isInteger(request.limit)) {
+      fieldFailure(context, "$.limit", "invalid_type", "Use an integer page size.");
+    }
+    if ((request.limit as number) < 1 || (request.limit as number) > 100) {
+      fieldFailure(context, "$.limit", "out_of_range", "Use an integer from 1 to 100.");
+    }
+    limit = request.limit as number;
+  }
+
+  let cursor: string | null = null;
+  if (hasOwn(request, "cursor")) {
+    if (typeof request.cursor !== "string") {
+      fieldFailure(context, "$.cursor", "invalid_type", "Use an opaque string cursor.");
+    }
+    if (request.cursor.length < 1 || request.cursor.length > MAX_CURSOR_LENGTH) {
+      fieldFailure(
+        context,
+        "$.cursor",
+        "out_of_range",
+        `Cursor must contain from 1 to ${MAX_CURSOR_LENGTH} characters.`,
+      );
+    }
+    cursor = request.cursor;
+  }
+
+  return {
+    query,
+    facets: normaliseFacets(request.facets, snapshot, context),
+    limit,
+    cursor,
+  };
+}
+
+function catalogueIdentity(snapshot: CatalogueSnapshot): CatalogueIdentity {
+  return {
+    id: snapshot.bundle.id,
+    version: snapshot.version,
+    revision: snapshot.revision,
+    content_root_sha256: snapshot.contentRootSha256,
+    record_count: snapshot.recordCount,
+    reviewed_at: snapshot.bundle.reviewedAt,
+    stale_after: snapshot.bundle.staleAfter,
+  };
+}
+
+function summary(record: CatalogueRecord): CatalogueRecordSummary {
+  return {
+    id: record.id,
+    type: record.type,
+    title: record.title,
+    description: record.description,
+    authority: record.authority.class,
+    access: record.access.state,
+    rights: record.rights.state,
+    freshness: record.freshness.status,
+    status: record.status,
+    tags: [...record.tags],
+  };
+}
+
+function cloneJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(cloneJson);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, member]) => [key, cloneJson(member)]),
+    );
+  }
+  return value;
+}
+
+function detail(record: CatalogueRecord): CatalogueRecordDetail {
+  return {
+    id: record.id,
+    type: record.type,
+    title: record.title,
+    description: record.description,
+    authority: {
+      class: record.authority.class,
+      statement: record.authority.statement,
+      source: record.authority.source,
+    },
+    publication: {
+      classification: record.publication.classification,
+      contains_personal_data: record.publication.containsPersonalData,
+      contains_protected_data: record.publication.containsProtectedData,
+    },
+    access: {
+      tier: record.access.tier,
+      state: record.access.state,
+      authentication: record.access.authentication,
+    },
+    rights: {
+      state: record.rights.state,
+      record_licence: record.rights.recordLicence,
+      described_resource_licence: record.rights.describedResourceLicence,
+      attribution: record.rights.attribution,
+    },
+    freshness: {
+      observed_at: record.freshness.observedAt,
+      reviewed_at: record.freshness.reviewedAt,
+      stale_after: record.freshness.staleAfter,
+      status: record.freshness.status,
+    },
+    status: record.status,
+    source_refs: [...record.sourceRefs],
+    limitations: [...record.limitations],
+    tags: [...record.tags],
+    details: Object.fromEntries(
+      Object.entries(record.details).map(([key, member]) => [key, cloneJson(member)]),
+    ),
+  };
+}
+
+function searchState(request: NormalisedSearchRequest): ExplorerState {
+  return {
+    view: "cards",
+    query: request.query,
+    types: request.facets.types,
+    authority: request.facets.authority,
+    access: request.facets.access,
+    rights: request.facets.rights,
+    freshness: request.facets.freshness,
+    tags: request.facets.tags,
+    selectedRecordId: null,
+  };
+}
+
+function criteriaDigest(request: NormalisedSearchRequest): string {
+  return sha256CanonicalJson({
+    facets: request.facets,
+    limit: request.limit,
+    query: request.query,
+  });
+}
+
+function searchCatalogueFromValidatedSnapshot(
+  snapshot: CatalogueSnapshot,
+  input: unknown,
+  context: CatalogueProblemContext,
+): CatalogueSearchResult {
+  const request = normaliseSearchRequest(input, snapshot, context);
+  const state = searchState(request);
+  const matched = searchRecords(snapshot.bundle.records, state);
+  const digest = criteriaDigest(request);
+  const binding = {
+    contentRootSha256: snapshot.contentRootSha256,
+    criteriaSha256: digest,
+    limit: request.limit,
+  };
+
+  let offset = 0;
+  if (request.cursor !== null) {
+    try {
+      offset = decodeCatalogueCursor(request.cursor, binding);
+    } catch (error) {
+      if (!(error instanceof InvalidCatalogueCursorError)) throw error;
+      throwCatalogueProblem("invalid_cursor", context, { detail: error.message });
+    }
+    if (offset >= matched.length) {
+      throwCatalogueProblem("invalid_cursor", context, {
+        detail: "The cursor points beyond the available results.",
+      });
+    }
+  }
+
+  const pageRecords = matched.slice(offset, offset + request.limit);
+  const nextOffset = offset + pageRecords.length;
+  const nextCursor =
+    nextOffset < matched.length
+      ? encodeCatalogueCursor(
+          {
+            contentRootSha256: snapshot.contentRootSha256,
+            criteriaSha256: digest,
+          },
+          offset + request.limit,
+        )
+      : null;
+
+  return {
+    schema: "gis-ai-go.catalogue-result.v1",
+    operation: "catalogue.search",
+    request_id: context.requestId,
+    trace_id: context.traceId,
+    catalogue: catalogueIdentity(snapshot),
+    warnings: [...snapshot.warnings],
+    data: {
+      records: pageRecords.map(summary),
+      facets: deriveFacetOptions(snapshot.bundle.records, state),
+      page: {
+        limit: request.limit,
+        returned: pageRecords.length,
+        matched: matched.length,
+        next_cursor: nextCursor,
+      },
+    },
+  };
+}
+
+export function searchCatalogue(
+  snapshot: CatalogueSnapshot,
+  input: unknown,
+  context: CatalogueProblemContext,
+): CatalogueSearchResult {
+  assertCatalogueProblemContext(context);
+  assertCatalogueResultSnapshotBounds(snapshot);
+  return searchCatalogueFromValidatedSnapshot(snapshot, input, context);
+}
+
+function normaliseDescribeRequest(
+  value: unknown,
+  context: CatalogueProblemContext,
+): { readonly recordId: string; readonly include: ReadonlySet<DescribeInclude> } {
+  const request = assertClosedObject(value, "$", DESCRIBE_REQUEST_KEYS, context);
+  if (!hasOwn(request, "record_id")) {
+    fieldFailure(context, "$.record_id", "required", "Supply a catalogue record ID.");
+  }
+  if (typeof request.record_id !== "string") {
+    fieldFailure(context, "$.record_id", "invalid_type", "Use a string catalogue record ID.");
+  }
+  if (request.record_id.length === 0 || Array.from(request.record_id).length > 512) {
+    fieldFailure(
+      context,
+      "$.record_id",
+      "out_of_range",
+      "Record ID must contain from 1 to 512 Unicode characters.",
+    );
+  }
+
+  let include: readonly DescribeInclude[] = DESCRIBE_INCLUDES;
+  if (hasOwn(request, "include")) {
+    include = sortedUniqueValues(
+      request.include,
+      "$.include",
+      DESCRIBE_INCLUDES,
+      DESCRIBE_INCLUDES.length,
+      context,
+    );
+  }
+  return { recordId: request.record_id, include: new Set(include) };
+}
+
+function recordNotFoundDetail(recordId: string): string {
+  const candidate = `No catalogue record has the exact ID ${recordId}.`;
+  return isProblemBoundedText(candidate, 1_024)
+    ? candidate
+    : "No catalogue record has the supplied exact ID.";
+}
+
+function describeCatalogueFromValidatedSnapshot(
+  snapshot: CatalogueSnapshot,
+  input: unknown,
+  context: CatalogueProblemContext,
+): CatalogueDescribeResult {
+  const request = normaliseDescribeRequest(input, context);
+  const record = snapshot.recordsById.get(request.recordId);
+  if (record === undefined) {
+    throwCatalogueProblem("record_not_found", context, {
+      detail: recordNotFoundDetail(request.recordId),
+    });
+  }
+
+  const sourceIds = [...record.sourceRefs].sort();
+  const relationships = sourceIds.map((recordId) => ({
+    relation: "source" as const,
+    record_id: recordId,
+  }));
+  const sources = sourceIds.map((recordId) => {
+    const source = snapshot.recordsById.get(recordId);
+    if (source === undefined) {
+      throw new Error(`Validated catalogue source ${recordId} is unavailable`);
+    }
+    return {
+      id: source.id,
+      title: source.title,
+      authority: source.authority.class,
+      access: source.access.state,
+      rights: source.rights.state,
+      freshness: source.freshness.status,
+    };
+  });
+
+  return {
+    schema: "gis-ai-go.catalogue-result.v1",
+    operation: "catalogue.describe",
+    request_id: context.requestId,
+    trace_id: context.traceId,
+    catalogue: catalogueIdentity(snapshot),
+    warnings: [...snapshot.warnings],
+    data: {
+      record: detail(record),
+      included: {
+        ...(request.include.has("relationships") ? { relationships } : {}),
+        ...(request.include.has("sources") ? { sources } : {}),
+      },
+    },
+  };
+}
+
+export function describeCatalogue(
+  snapshot: CatalogueSnapshot,
+  input: unknown,
+  context: CatalogueProblemContext,
+): CatalogueDescribeResult {
+  assertCatalogueProblemContext(context);
+  assertCatalogueResultSnapshotBounds(snapshot);
+  return describeCatalogueFromValidatedSnapshot(snapshot, input, context);
+}
+
+/** Bind the two catalogue operations to one immutable, transport-neutral snapshot. */
+export function createCatalogueApplication(snapshot: CatalogueSnapshot): CatalogueApplication {
+  assertCatalogueResultSnapshotBounds(snapshot);
+  return Object.freeze({
+    search: (request: unknown, context: CatalogueProblemContext) => {
+      assertCatalogueProblemContext(context);
+      return searchCatalogueFromValidatedSnapshot(snapshot, request, context);
+    },
+    describe: (request: unknown, context: CatalogueProblemContext) => {
+      assertCatalogueProblemContext(context);
+      return describeCatalogueFromValidatedSnapshot(snapshot, request, context);
+    },
+  });
+}

--- a/apps/mcp-gateway/src/catalogue-snapshot.ts
+++ b/apps/mcp-gateway/src/catalogue-snapshot.ts
@@ -1,0 +1,817 @@
+import { createHash } from "node:crypto";
+import { constants, type Stats } from "node:fs";
+import { lstat, open, opendir, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
+
+import {
+  parseCatalogueJson,
+  type CatalogueBundle,
+  type CatalogueRecord,
+} from "@gis-ai-go/contracts";
+
+const GENERATED_MARKER = "gis-ai-go-okf-builder.v1\n";
+const MARKER_PATH = ".okf-generated";
+const CHECKSUM_PATH = "CHECKSUMS.sha256";
+const BUNDLE_PATH = "okf-bundle.json";
+const MANIFEST_PATH = "manifest.json";
+const RECEIPT_PATH = "build-receipt.json";
+const EXPECTED_BUNDLE_ID =
+  "https://chris-page-gov.github.io/gis-ai-go/id/bundle/public-discovery";
+
+const MAX_FILES = 1_000;
+const MAX_DIRECTORIES = 1_000;
+const MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+const MAX_BUNDLE_BYTES = 8 * 1024 * 1024;
+const MAX_CONTROL_FILE_BYTES = 8 * 1024 * 1024;
+const MAX_CHECKSUM_BYTES = 2 * 1024 * 1024;
+const MAX_RELATIVE_PATH_LENGTH = 1_024;
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const SHA40 = /^[0-9a-f]{40}$/u;
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+
+interface ScannedFile {
+  readonly absolutePath: string;
+  readonly size: number;
+  readonly device: number;
+  readonly inode: number;
+  readonly mode: number;
+  readonly modifiedAtMilliseconds: number;
+  readonly changedAtMilliseconds: number;
+}
+
+interface Inventory {
+  readonly files: ReadonlyMap<string, ScannedFile>;
+  readonly directories: ReadonlySet<string>;
+  readonly totalBytes: number;
+}
+
+interface ChecksumEntry {
+  readonly path: string;
+  readonly sha256: string;
+}
+
+interface ManifestFile {
+  readonly path: string;
+  readonly bytes: number;
+  readonly sha256: string;
+}
+
+interface ParsedManifest {
+  readonly version: string;
+  readonly revision: string;
+  readonly recordCount: number;
+  readonly recordIds: readonly string[];
+  readonly files: readonly ManifestFile[];
+}
+
+interface ParsedReceipt {
+  readonly version: string;
+  readonly revision: string;
+  readonly profile: string;
+  readonly profileStatus: string;
+  readonly recordCount: number;
+  readonly outputCount: number;
+  readonly contentRootSha256: string;
+  readonly manifestSha256: string;
+}
+
+export interface CatalogueSnapshot {
+  readonly root: string;
+  readonly bundle: CatalogueBundle;
+  readonly recordsById: ReadonlyMap<string, CatalogueRecord>;
+  readonly version: string;
+  readonly revision: string;
+  readonly contentRootSha256: string;
+  readonly manifestSha256: string;
+  readonly recordCount: number;
+  readonly stale: boolean;
+  readonly stalenessWarning: string | null;
+  readonly warnings: readonly string[];
+}
+
+export interface LoadCatalogueSnapshotOptions {
+  readonly now?: Date;
+}
+
+class FrozenRecordMap implements ReadonlyMap<string, CatalogueRecord> {
+  readonly #records: Map<string, CatalogueRecord>;
+
+  constructor(records: readonly CatalogueRecord[]) {
+    this.#records = new Map(records.map((record) => [record.id, record]));
+    Object.freeze(this);
+  }
+
+  get size(): number {
+    return this.#records.size;
+  }
+
+  get(key: string): CatalogueRecord | undefined {
+    return this.#records.get(key);
+  }
+
+  has(key: string): boolean {
+    return this.#records.has(key);
+  }
+
+  entries(): MapIterator<[string, CatalogueRecord]> {
+    return this.#records.entries();
+  }
+
+  keys(): MapIterator<string> {
+    return this.#records.keys();
+  }
+
+  values(): MapIterator<CatalogueRecord> {
+    return this.#records.values();
+  }
+
+  forEach(
+    callbackfn: (
+      value: CatalogueRecord,
+      key: string,
+      map: ReadonlyMap<string, CatalogueRecord>,
+    ) => void,
+    thisArg?: unknown,
+  ): void {
+    for (const [key, value] of this.#records) {
+      callbackfn.call(thisArg, value, key, this);
+    }
+  }
+
+  [Symbol.iterator](): MapIterator<[string, CatalogueRecord]> {
+    return this.entries();
+  }
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fail(message: string): never {
+  throw new Error(`Catalogue snapshot rejected: ${message}`);
+}
+
+function safeRelativePath(value: string, label: string): string {
+  if (
+    value.length === 0 ||
+    value.length > MAX_RELATIVE_PATH_LENGTH ||
+    value.includes("\\") ||
+    value.startsWith("/") ||
+    posix.normalize(value) !== value
+  ) {
+    fail(`${label} is not a canonical safe relative path`);
+  }
+  const segments = value.split("/");
+  if (segments.some((segment) => !SAFE_PATH_SEGMENT.test(segment))) {
+    fail(`${label} contains an unsafe path segment`);
+  }
+  return value;
+}
+
+function decodeUtf8(bytes: Uint8Array, label: string): string {
+  let value: string;
+  try {
+    value = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch (error) {
+    throw new Error(`Catalogue snapshot rejected: ${label} is not valid UTF-8`, {
+      cause: error,
+    });
+  }
+  if (!Buffer.from(value, "utf8").equals(Buffer.from(bytes))) {
+    fail(`${label} is not canonical UTF-8`);
+  }
+  return value;
+}
+
+function expectObject(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const canonical = [...expected].sort();
+  if (actual.length !== canonical.length || actual.some((key, index) => key !== canonical[index])) {
+    fail(`${label} has missing or unexpected fields`);
+  }
+}
+
+function expectString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function expectDigest(value: unknown, label: string): string {
+  const digest = expectString(value, label);
+  if (!SHA256.test(digest)) {
+    fail(`${label} must be a lowercase SHA-256 digest`);
+  }
+  return digest;
+}
+
+function expectInteger(value: unknown, label: string, minimum = 0): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < minimum) {
+    fail(`${label} must be an integer of at least ${minimum}`);
+  }
+  return value;
+}
+
+function parseJsonObject(bytes: Uint8Array, label: string): Record<string, unknown> {
+  let value: unknown;
+  try {
+    value = JSON.parse(decodeUtf8(bytes, label)) as unknown;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Catalogue snapshot rejected:")) {
+      throw error;
+    }
+    throw new Error(`Catalogue snapshot rejected: ${label} is not valid JSON`, { cause: error });
+  }
+  return expectObject(value, label);
+}
+
+async function assertCanonicalRoot(inputRoot: string): Promise<string> {
+  if (!isAbsolute(inputRoot)) {
+    fail("catalogue root must be an absolute path");
+  }
+  const root = resolve(inputRoot);
+  let cursor = root;
+  while (true) {
+    let stats;
+    try {
+      stats = await lstat(cursor);
+    } catch (error) {
+      throw new Error("Catalogue snapshot rejected: catalogue root or ancestor is inaccessible", {
+        cause: error,
+      });
+    }
+    if (stats.isSymbolicLink()) {
+      fail("catalogue root and its ancestors must not be symbolic links");
+    }
+    if (!stats.isDirectory()) {
+      fail("catalogue root and its ancestors must be directories");
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+  if ((await realpath(root)) !== root) {
+    fail("catalogue root must resolve without aliases or symbolic links");
+  }
+  return root;
+}
+
+function relativeFromRoot(root: string, absolutePath: string): string {
+  return relative(root, absolutePath).split(sep).join("/");
+}
+
+async function scanInventory(root: string): Promise<Inventory> {
+  const files = new Map<string, ScannedFile>();
+  const directories = new Set<string>();
+  const pendingDirectories = [root];
+  let totalBytes = 0;
+
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop()!;
+    const directoryHandle = await opendir(directory);
+    try {
+      while (true) {
+        const entry = await directoryHandle.read();
+        if (entry === null) {
+          break;
+        }
+        if (entry.name !== MARKER_PATH && !SAFE_PATH_SEGMENT.test(entry.name)) {
+          fail("catalogue inventory contains an unsafe entry name");
+        }
+        const absolutePath = join(directory, entry.name);
+        const entryPath = relativeFromRoot(root, absolutePath);
+        const stats = await lstat(absolutePath);
+        if (stats.isSymbolicLink()) {
+          fail("catalogue inventory contains a symbolic link");
+        }
+        if (stats.isDirectory()) {
+          directories.add(entryPath);
+          if (directories.size > MAX_DIRECTORIES) {
+            fail(`catalogue inventory exceeds ${MAX_DIRECTORIES} directories`);
+          }
+          pendingDirectories.push(absolutePath);
+          continue;
+        }
+        if (!stats.isFile()) {
+          fail("catalogue inventory contains a non-regular entry");
+        }
+        files.set(entryPath, {
+          absolutePath,
+          size: stats.size,
+          device: stats.dev,
+          inode: stats.ino,
+          mode: stats.mode,
+          modifiedAtMilliseconds: stats.mtimeMs,
+          changedAtMilliseconds: stats.ctimeMs,
+        });
+        if (files.size > MAX_FILES) {
+          fail(`catalogue inventory exceeds ${MAX_FILES} files`);
+        }
+        totalBytes += stats.size;
+        if (!Number.isSafeInteger(totalBytes) || totalBytes > MAX_TOTAL_BYTES) {
+          fail(`catalogue inventory exceeds ${MAX_TOTAL_BYTES} bytes`);
+        }
+      }
+    } finally {
+      await directoryHandle.close();
+    }
+  }
+  return { files, directories, totalBytes };
+}
+
+function hasStableScannedMetadata(
+  stats: Stats,
+  file: ScannedFile,
+): boolean {
+  return (
+    stats.isFile() &&
+    stats.size === file.size &&
+    stats.dev === file.device &&
+    stats.ino === file.inode &&
+    stats.mode === file.mode &&
+    stats.mtimeMs === file.modifiedAtMilliseconds &&
+    stats.ctimeMs === file.changedAtMilliseconds
+  );
+}
+
+async function readScannedFile(file: ScannedFile, maximumBytes: number): Promise<Buffer> {
+  if (file.size > maximumBytes) {
+    fail(`catalogue control file exceeds ${maximumBytes} bytes`);
+  }
+  let handle;
+  try {
+    handle = await open(file.absolutePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const beforeRead = await handle.stat();
+    if (!hasStableScannedMetadata(beforeRead, file)) {
+      fail("catalogue inventory changed while it was being verified");
+    }
+    const readCapacity = file.size + 1;
+    if (!Number.isSafeInteger(readCapacity) || readCapacity > maximumBytes + 1) {
+      fail(`catalogue control file exceeds ${maximumBytes} bytes`);
+    }
+    const bytes = Buffer.allocUnsafe(readCapacity);
+    let bytesRead = 0;
+    while (bytesRead < bytes.byteLength) {
+      const result = await handle.read(
+        bytes,
+        bytesRead,
+        bytes.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (result.bytesRead === 0) {
+        break;
+      }
+      bytesRead += result.bytesRead;
+    }
+    const afterRead = await handle.stat();
+    if (!hasStableScannedMetadata(afterRead, file)) {
+      fail("catalogue inventory changed while it was being verified");
+    }
+    if (bytesRead !== file.size) {
+      fail("catalogue file size changed while it was being verified");
+    }
+    return bytes.subarray(0, bytesRead);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Catalogue snapshot rejected:")) {
+      throw error;
+    }
+    throw new Error("Catalogue snapshot rejected: catalogue file could not be read safely", {
+      cause: error,
+    });
+  } finally {
+    await handle?.close();
+  }
+}
+
+function requireInventoryFile(inventory: Inventory, path: string): ScannedFile {
+  const file = inventory.files.get(path);
+  if (!file) {
+    fail(`catalogue inventory is missing ${path}`);
+  }
+  return file;
+}
+
+function parseChecksums(text: string): readonly ChecksumEntry[] {
+  if (!text.endsWith("\n") || text.length === 0) {
+    fail(`${CHECKSUM_PATH} must end with one canonical newline`);
+  }
+  const lines = text.slice(0, -1).split("\n");
+  if (lines.length > MAX_FILES - 2) {
+    fail(`${CHECKSUM_PATH} contains too many entries`);
+  }
+  const entries = lines.map((line, index): ChecksumEntry => {
+    const match = /^([0-9a-f]{64})  (.+)$/u.exec(line);
+    if (!match?.[1] || !match[2]) {
+      fail(`${CHECKSUM_PATH} row ${index + 1} is malformed`);
+    }
+    const path = safeRelativePath(match[2], `${CHECKSUM_PATH} row ${index + 1}`);
+    if (path === MARKER_PATH || path === CHECKSUM_PATH) {
+      fail(`${CHECKSUM_PATH} must not checksum itself or the generated marker`);
+    }
+    return { sha256: match[1], path };
+  });
+  const sortedPaths = entries.map((entry) => entry.path).toSorted();
+  if (
+    entries.some((entry, index) => entry.path !== sortedPaths[index]) ||
+    new Set(sortedPaths).size !== sortedPaths.length
+  ) {
+    fail(`${CHECKSUM_PATH} paths must be sorted and unique`);
+  }
+  const canonical = entries.map((entry) => `${entry.sha256}  ${entry.path}\n`).join("");
+  if (canonical !== text) {
+    fail(`${CHECKSUM_PATH} is not in canonical form`);
+  }
+  return entries;
+}
+
+function expectedDirectories(paths: readonly string[]): ReadonlySet<string> {
+  const expected = new Set<string>();
+  for (const path of paths) {
+    let parent = posix.dirname(path);
+    while (parent !== ".") {
+      expected.add(parent);
+      parent = posix.dirname(parent);
+    }
+  }
+  return expected;
+}
+
+function assertExactInventory(inventory: Inventory, entries: readonly ChecksumEntry[]): void {
+  const expectedFiles = new Set([
+    MARKER_PATH,
+    CHECKSUM_PATH,
+    ...entries.map((entry) => entry.path),
+  ]);
+  if (
+    expectedFiles.size !== inventory.files.size ||
+    [...inventory.files.keys()].some((path) => !expectedFiles.has(path))
+  ) {
+    fail("catalogue inventory has missing or unexpected files");
+  }
+  const expectedDirs = expectedDirectories([...expectedFiles]);
+  if (
+    expectedDirs.size !== inventory.directories.size ||
+    [...inventory.directories].some((path) => !expectedDirs.has(path))
+  ) {
+    fail("catalogue inventory has missing or unexpected directories");
+  }
+}
+
+function parseManifest(bytes: Uint8Array): ParsedManifest {
+  const value = parseJsonObject(bytes, MANIFEST_PATH);
+  expectExactKeys(
+    value,
+    ["schema", "version", "revision", "recordCount", "recordIds", "files"],
+    MANIFEST_PATH,
+  );
+  if (value.schema !== "gis-ai-go-okf-manifest.v1") {
+    fail(`${MANIFEST_PATH}.schema is not supported`);
+  }
+  const version = expectString(value.version, `${MANIFEST_PATH}.version`);
+  if (!SEMVER.test(version)) {
+    fail(`${MANIFEST_PATH}.version must be semantic`);
+  }
+  const revision = expectString(value.revision, `${MANIFEST_PATH}.revision`);
+  if (!SHA40.test(revision)) {
+    fail(`${MANIFEST_PATH}.revision must be a lowercase Git SHA`);
+  }
+  const recordCount = expectInteger(value.recordCount, `${MANIFEST_PATH}.recordCount`, 1);
+  if (!Array.isArray(value.recordIds) || value.recordIds.length !== recordCount) {
+    fail(`${MANIFEST_PATH}.recordIds must match recordCount`);
+  }
+  const recordIds = value.recordIds.map((item, index) =>
+    expectString(item, `${MANIFEST_PATH}.recordIds[${index}]`),
+  );
+  if (new Set(recordIds).size !== recordIds.length) {
+    fail(`${MANIFEST_PATH}.recordIds must be unique`);
+  }
+  if (!Array.isArray(value.files) || value.files.length > MAX_FILES) {
+    fail(`${MANIFEST_PATH}.files must be a bounded array`);
+  }
+  const files = value.files.map((item, index): ManifestFile => {
+    const file = expectObject(item, `${MANIFEST_PATH}.files[${index}]`);
+    expectExactKeys(file, ["path", "bytes", "sha256"], `${MANIFEST_PATH}.files[${index}]`);
+    return {
+      path: safeRelativePath(
+        expectString(file.path, `${MANIFEST_PATH}.files[${index}].path`),
+        `${MANIFEST_PATH}.files[${index}].path`,
+      ),
+      bytes: expectInteger(file.bytes, `${MANIFEST_PATH}.files[${index}].bytes`),
+      sha256: expectDigest(file.sha256, `${MANIFEST_PATH}.files[${index}].sha256`),
+    };
+  });
+  const paths = files.map((file) => file.path);
+  if (
+    paths.some((path, index) => path !== paths.toSorted()[index]) ||
+    new Set(paths).size !== paths.length
+  ) {
+    fail(`${MANIFEST_PATH}.files must be sorted and unique`);
+  }
+  return { version, revision, recordCount, recordIds, files };
+}
+
+function parseReceipt(bytes: Uint8Array): ParsedReceipt {
+  const value = parseJsonObject(bytes, RECEIPT_PATH);
+  expectExactKeys(
+    value,
+    [
+      "schema",
+      "builder",
+      "builderVersion",
+      "version",
+      "revision",
+      "profile",
+      "profileStatus",
+      "sourceLockSha256",
+      "inputRootSha256",
+      "inputs",
+      "recordCount",
+      "outputCount",
+      "checksumScope",
+      "contentRootScope",
+      "contentRootSha256",
+      "manifestSha256",
+      "determinism",
+    ],
+    RECEIPT_PATH,
+  );
+  if (value.schema !== "gis-ai-go-okf-build-receipt.v1") {
+    fail(`${RECEIPT_PATH}.schema is not supported`);
+  }
+  if (value.builder !== "scripts/build_okf.py") {
+    fail(`${RECEIPT_PATH}.builder is not supported`);
+  }
+  const builderVersion = expectString(value.builderVersion, `${RECEIPT_PATH}.builderVersion`);
+  if (!SEMVER.test(builderVersion)) {
+    fail(`${RECEIPT_PATH}.builderVersion must be semantic`);
+  }
+  const version = expectString(value.version, `${RECEIPT_PATH}.version`);
+  if (!SEMVER.test(version)) {
+    fail(`${RECEIPT_PATH}.version must be semantic`);
+  }
+  const revision = expectString(value.revision, `${RECEIPT_PATH}.revision`);
+  if (!SHA40.test(revision)) {
+    fail(`${RECEIPT_PATH}.revision must be a lowercase Git SHA`);
+  }
+  const profile = expectString(value.profile, `${RECEIPT_PATH}.profile`);
+  const profileStatus = expectString(value.profileStatus, `${RECEIPT_PATH}.profileStatus`);
+  expectDigest(value.sourceLockSha256, `${RECEIPT_PATH}.sourceLockSha256`);
+  const inputRootSha256 = expectDigest(value.inputRootSha256, `${RECEIPT_PATH}.inputRootSha256`);
+  if (!Array.isArray(value.inputs) || value.inputs.length > MAX_FILES) {
+    fail(`${RECEIPT_PATH}.inputs must be a bounded array`);
+  }
+  const inputRows = value.inputs.map((item, index) => {
+    const input = expectObject(item, `${RECEIPT_PATH}.inputs[${index}]`);
+    expectExactKeys(
+      input,
+      ["bytes", "path", "role", "sha256"],
+      `${RECEIPT_PATH}.inputs[${index}]`,
+    );
+    return {
+      bytes: expectInteger(input.bytes, `${RECEIPT_PATH}.inputs[${index}].bytes`),
+      path: safeRelativePath(
+        expectString(input.path, `${RECEIPT_PATH}.inputs[${index}].path`),
+        `${RECEIPT_PATH}.inputs[${index}].path`,
+      ),
+      role: expectString(input.role, `${RECEIPT_PATH}.inputs[${index}].role`),
+      sha256: expectDigest(input.sha256, `${RECEIPT_PATH}.inputs[${index}].sha256`),
+    };
+  });
+  const inputPaths = inputRows.map((input) => input.path);
+  if (
+    inputPaths.some((path, index) => path !== inputPaths.toSorted()[index]) ||
+    new Set(inputPaths).size !== inputPaths.length
+  ) {
+    fail(`${RECEIPT_PATH}.inputs must be sorted and unique`);
+  }
+  const computedInputRoot = sha256(
+    Buffer.from(inputRows.map((input) => `${input.sha256}  ${input.path}\n`).join(""), "utf8"),
+  );
+  if (computedInputRoot !== inputRootSha256) {
+    fail(`${RECEIPT_PATH}.inputRootSha256 does not match its input inventory`);
+  }
+  if (
+    value.checksumScope !==
+    "All generated files except .okf-generated and CHECKSUMS.sha256, including build-receipt.json."
+  ) {
+    fail(`${RECEIPT_PATH}.checksumScope is not supported`);
+  }
+  if (
+    value.contentRootScope !==
+    "All generated payload files except .okf-generated, CHECKSUMS.sha256 and build-receipt.json."
+  ) {
+    fail(`${RECEIPT_PATH}.contentRootScope is not supported`);
+  }
+  const determinism = expectObject(value.determinism, `${RECEIPT_PATH}.determinism`);
+  expectExactKeys(
+    determinism,
+    ["canonicalJson", "pathOrder", "wallClockIncluded", "checkoutPathIncluded"],
+    `${RECEIPT_PATH}.determinism`,
+  );
+  if (
+    determinism.canonicalJson !== "sorted-key UTF-8 JSON with two-space indent and final newline" ||
+    determinism.pathOrder !== "lexicographic" ||
+    determinism.wallClockIncluded !== false ||
+    determinism.checkoutPathIncluded !== false
+  ) {
+    fail(`${RECEIPT_PATH}.determinism does not describe the supported builder`);
+  }
+  return {
+    version,
+    revision,
+    profile,
+    profileStatus,
+    recordCount: expectInteger(value.recordCount, `${RECEIPT_PATH}.recordCount`, 1),
+    outputCount: expectInteger(value.outputCount, `${RECEIPT_PATH}.outputCount`, 1),
+    contentRootSha256: expectDigest(
+      value.contentRootSha256,
+      `${RECEIPT_PATH}.contentRootSha256`,
+    ),
+    manifestSha256: expectDigest(value.manifestSha256, `${RECEIPT_PATH}.manifestSha256`),
+  };
+}
+
+function assertManifestInventory(
+  manifest: ParsedManifest,
+  entries: readonly ChecksumEntry[],
+  inventory: Inventory,
+  verifiedDigests: ReadonlyMap<string, string>,
+): void {
+  const ledgerPaths = new Set(entries.map((entry) => entry.path));
+  const expectedManifestPaths = new Set(
+    entries
+      .map((entry) => entry.path)
+      .filter((path) => path !== MANIFEST_PATH && path !== RECEIPT_PATH),
+  );
+  if (
+    manifest.files.length !== expectedManifestPaths.size ||
+    manifest.files.some((file) => !expectedManifestPaths.has(file.path)) ||
+    !ledgerPaths.has(MANIFEST_PATH) ||
+    !ledgerPaths.has(RECEIPT_PATH)
+  ) {
+    fail(`${MANIFEST_PATH}.files does not match the checksum-locked payload inventory`);
+  }
+  for (const file of manifest.files) {
+    const scanned = requireInventoryFile(inventory, file.path);
+    if (scanned.size !== file.bytes || verifiedDigests.get(file.path) !== file.sha256) {
+      fail(`${MANIFEST_PATH}.files metadata does not match the verified payload`);
+    }
+  }
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (value === null || typeof value !== "object" || seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child, seen);
+  }
+  return Object.freeze(value);
+}
+
+/**
+ * Load one checksum-locked public catalogue without following filesystem links.
+ *
+ * Any ambiguity in the root, inventory, integrity ledgers or publication
+ * contract rejects the complete snapshot. No partial catalogue is returned.
+ */
+export async function loadCatalogueSnapshot(
+  inputRoot: string,
+  options: LoadCatalogueSnapshotOptions = {},
+): Promise<CatalogueSnapshot> {
+  const now = options.now ?? new Date();
+  if (!Number.isFinite(now.getTime())) {
+    fail("load time must be a valid Date");
+  }
+  const root = await assertCanonicalRoot(inputRoot);
+  const inventory = await scanInventory(root);
+
+  const markerBytes = await readScannedFile(
+    requireInventoryFile(inventory, MARKER_PATH),
+    Buffer.byteLength(GENERATED_MARKER),
+  );
+  if (!markerBytes.equals(Buffer.from(GENERATED_MARKER, "utf8"))) {
+    fail("generated marker is missing or invalid");
+  }
+  const checksumBytes = await readScannedFile(
+    requireInventoryFile(inventory, CHECKSUM_PATH),
+    MAX_CHECKSUM_BYTES,
+  );
+  const entries = parseChecksums(decodeUtf8(checksumBytes, CHECKSUM_PATH));
+  assertExactInventory(inventory, entries);
+
+  const required = new Set([BUNDLE_PATH, MANIFEST_PATH, RECEIPT_PATH]);
+  const controlBytes = new Map<string, Buffer>();
+  const verifiedDigests = new Map<string, string>();
+  for (const entry of entries) {
+    const scanned = requireInventoryFile(inventory, entry.path);
+    const maximum =
+      entry.path === BUNDLE_PATH
+        ? MAX_BUNDLE_BYTES
+        : required.has(entry.path)
+          ? MAX_CONTROL_FILE_BYTES
+          : MAX_TOTAL_BYTES;
+    const bytes = await readScannedFile(scanned, maximum);
+    const actualDigest = sha256(bytes);
+    if (actualDigest !== entry.sha256) {
+      fail(`checksum mismatch for ${entry.path}`);
+    }
+    verifiedDigests.set(entry.path, actualDigest);
+    if (required.has(entry.path)) {
+      controlBytes.set(entry.path, bytes);
+    }
+  }
+  for (const path of required) {
+    if (!controlBytes.has(path)) {
+      fail(`${CHECKSUM_PATH} is missing required control file ${path}`);
+    }
+  }
+
+  const manifest = parseManifest(controlBytes.get(MANIFEST_PATH)!);
+  const receipt = parseReceipt(controlBytes.get(RECEIPT_PATH)!);
+  assertManifestInventory(manifest, entries, inventory, verifiedDigests);
+
+  const manifestSha256 = verifiedDigests.get(MANIFEST_PATH)!;
+  if (receipt.manifestSha256 !== manifestSha256) {
+    fail(`${RECEIPT_PATH}.manifestSha256 does not match ${MANIFEST_PATH}`);
+  }
+  const computedContentRoot = sha256(
+    Buffer.from(
+      entries
+        .filter((entry) => entry.path !== RECEIPT_PATH)
+        .map((entry) => `${entry.sha256}  ${entry.path}\n`)
+        .join(""),
+      "utf8",
+    ),
+  );
+  if (receipt.contentRootSha256 !== computedContentRoot) {
+    fail(`${RECEIPT_PATH}.contentRootSha256 does not match the canonical payload inventory`);
+  }
+  if (receipt.outputCount !== entries.length) {
+    fail(`${RECEIPT_PATH}.outputCount does not match the checksum inventory`);
+  }
+
+  const bundle = parseCatalogueJson(decodeUtf8(controlBytes.get(BUNDLE_PATH)!, BUNDLE_PATH));
+  if (bundle.id !== EXPECTED_BUNDLE_ID) {
+    fail(`${BUNDLE_PATH}.id is not the GIS AI GO public discovery bundle`);
+  }
+  if (
+    bundle.version !== manifest.version ||
+    bundle.version !== receipt.version ||
+    bundle.revision !== manifest.revision ||
+    bundle.revision !== receipt.revision ||
+    bundle.recordCount !== manifest.recordCount ||
+    bundle.recordCount !== receipt.recordCount ||
+    bundle.profile !== receipt.profile ||
+    bundle.profileStatus !== receipt.profileStatus
+  ) {
+    fail("bundle, manifest and receipt identity fields do not agree");
+  }
+  const recordIds = bundle.records.map((record) => record.id);
+  if (
+    recordIds.length !== manifest.recordIds.length ||
+    recordIds.some((recordId, index) => recordId !== manifest.recordIds[index])
+  ) {
+    fail(`${MANIFEST_PATH}.recordIds does not match ${BUNDLE_PATH}`);
+  }
+
+  const frozenBundle = deepFreeze(bundle);
+  const recordsById = new FrozenRecordMap(frozenBundle.records);
+  const stale = now.getTime() >= Date.parse(frozenBundle.staleAfter);
+  const stalenessWarning = stale
+    ? `Catalogue freshness review expired at ${frozenBundle.staleAfter}; ` +
+      "results are a governed snapshot, not current source authority."
+    : null;
+  const warnings = deepFreeze(stalenessWarning === null ? [] : [stalenessWarning]);
+
+  return Object.freeze({
+    root,
+    bundle: frozenBundle,
+    recordsById,
+    version: frozenBundle.version,
+    revision: frozenBundle.revision,
+    contentRootSha256: computedContentRoot,
+    manifestSha256,
+    recordCount: frozenBundle.recordCount,
+    stale,
+    stalenessWarning,
+    warnings,
+  });
+}

--- a/apps/mcp-gateway/src/cursor.ts
+++ b/apps/mcp-gateway/src/cursor.ts
@@ -1,0 +1,212 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+
+export const CATALOGUE_CURSOR_VERSION = 1 as const;
+
+export interface CatalogueCursorPayload {
+  readonly content_root_sha256: string;
+  readonly criteria_sha256: string;
+  readonly offset: number;
+  readonly v: typeof CATALOGUE_CURSOR_VERSION;
+}
+
+export interface CatalogueCursorBinding {
+  readonly contentRootSha256: string;
+  readonly criteriaSha256: string;
+  readonly limit: number;
+}
+
+export class InvalidCatalogueCursorError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "InvalidCatalogueCursorError";
+  }
+}
+
+/**
+ * Serialise the bounded JSON values used for cursor criteria deterministically.
+ *
+ * The cursor payload itself contains only strings and integers. Supporting arrays
+ * and plain objects here lets the application hash its semantic search criteria
+ * without depending on property insertion order.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("Canonical JSON does not support non-finite numbers");
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("Canonical JSON requires a plain object");
+    }
+    const object = value as Record<string, unknown>;
+    const members = Object.keys(object)
+      .sort()
+      .map((key) => {
+        const member = object[key];
+        if (member === undefined) {
+          throw new TypeError("Canonical JSON does not support undefined values");
+        }
+        return `${JSON.stringify(key)}:${canonicalJson(member)}`;
+      });
+    return `{${members.join(",")}}`;
+  }
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+
+export function sha256CanonicalJson(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value), "utf8").digest("hex");
+}
+
+function assertSha256(value: string, field: string): void {
+  if (!SHA256.test(value)) {
+    throw new TypeError(`${field} must be a lowercase SHA-256 digest`);
+  }
+}
+
+function cursorPayload(
+  binding: Omit<CatalogueCursorBinding, "limit">,
+  offset: number,
+): CatalogueCursorPayload {
+  assertSha256(binding.contentRootSha256, "contentRootSha256");
+  assertSha256(binding.criteriaSha256, "criteriaSha256");
+  if (!Number.isSafeInteger(offset) || offset <= 0) {
+    throw new TypeError("Cursor offset must be a positive safe integer");
+  }
+  return {
+    content_root_sha256: binding.contentRootSha256,
+    criteria_sha256: binding.criteriaSha256,
+    offset,
+    v: CATALOGUE_CURSOR_VERSION,
+  };
+}
+
+/** Encode a page boundary as an opaque deterministic cursor. */
+export function encodeCatalogueCursor(
+  binding: Omit<CatalogueCursorBinding, "limit">,
+  offset: number,
+): string {
+  const json = canonicalJson(cursorPayload(binding, offset));
+  const body = Buffer.from(json, "utf8").toString("base64url");
+  const digest = createHash("sha256").update(json, "utf8").digest("hex");
+  return `${body}.${digest}`;
+}
+
+function invalid(message: string): never {
+  throw new InvalidCatalogueCursorError(message);
+}
+
+function parsePayload(value: unknown, canonical: string): CatalogueCursorPayload {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    invalid("The cursor payload is not an object");
+  }
+  const object = value as Record<string, unknown>;
+  const actualKeys = Object.keys(object).sort();
+  const expectedKeys = ["content_root_sha256", "criteria_sha256", "offset", "v"];
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    invalid("The cursor payload has an unexpected shape");
+  }
+  if (canonicalJson(object) !== canonical) {
+    invalid("The cursor payload is not canonical JSON");
+  }
+  if (object.v !== CATALOGUE_CURSOR_VERSION) {
+    invalid("The cursor version is not supported");
+  }
+  if (typeof object.content_root_sha256 !== "string" || !SHA256.test(object.content_root_sha256)) {
+    invalid("The cursor content root is invalid");
+  }
+  if (typeof object.criteria_sha256 !== "string" || !SHA256.test(object.criteria_sha256)) {
+    invalid("The cursor criteria digest is invalid");
+  }
+  if (!Number.isSafeInteger(object.offset) || (object.offset as number) <= 0) {
+    invalid("The cursor offset is invalid");
+  }
+  return {
+    content_root_sha256: object.content_root_sha256,
+    criteria_sha256: object.criteria_sha256,
+    offset: object.offset as number,
+    v: CATALOGUE_CURSOR_VERSION,
+  };
+}
+
+/**
+ * Decode and verify a cursor against the exact catalogue and semantic criteria.
+ *
+ * The digest is deliberately a corruption check rather than an authentication
+ * mechanism. All payload fields are server-validated and the cursor conveys no
+ * authority.
+ */
+export function decodeCatalogueCursor(token: string, binding: CatalogueCursorBinding): number {
+  assertSha256(binding.contentRootSha256, "contentRootSha256");
+  assertSha256(binding.criteriaSha256, "criteriaSha256");
+  if (!Number.isSafeInteger(binding.limit) || binding.limit < 1 || binding.limit > 100) {
+    throw new TypeError("Cursor page limit must be an integer from 1 to 100");
+  }
+
+  const parts = token.split(".");
+  const body = parts[0];
+  const suppliedDigest = parts[1];
+  if (
+    parts.length !== 2 ||
+    body === undefined ||
+    suppliedDigest === undefined ||
+    !BASE64URL.test(body) ||
+    !SHA256.test(suppliedDigest)
+  ) {
+    invalid("The cursor encoding is invalid");
+  }
+
+  let bytes: Buffer;
+  let json: string;
+  try {
+    bytes = Buffer.from(body, "base64url");
+    if (bytes.toString("base64url") !== body) {
+      invalid("The cursor base64url encoding is not canonical");
+    }
+    json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch (error) {
+    if (error instanceof InvalidCatalogueCursorError) throw error;
+    invalid("The cursor payload is not valid UTF-8");
+  }
+
+  const expectedDigest = createHash("sha256").update(bytes).digest();
+  const actualDigest = Buffer.from(suppliedDigest, "hex");
+  if (
+    actualDigest.length !== expectedDigest.length ||
+    !timingSafeEqual(actualDigest, expectedDigest)
+  ) {
+    invalid("The cursor corruption digest does not match");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json) as unknown;
+  } catch {
+    invalid("The cursor payload is not valid JSON");
+  }
+  const payload = parsePayload(parsed, json);
+  if (payload.content_root_sha256 !== binding.contentRootSha256) {
+    invalid("The cursor belongs to a different catalogue revision");
+  }
+  if (payload.criteria_sha256 !== binding.criteriaSha256) {
+    invalid("The cursor belongs to different search criteria");
+  }
+  if (payload.offset % binding.limit !== 0) {
+    invalid("The cursor offset is not aligned to the page size");
+  }
+  return payload.offset;
+}

--- a/apps/mcp-gateway/src/http-app.ts
+++ b/apps/mcp-gateway/src/http-app.ts
@@ -1,0 +1,177 @@
+import { randomBytes } from "node:crypto";
+
+import { catalogueActivation } from "./activation.js";
+import type { CatalogueSnapshot } from "./catalogue-snapshot.js";
+import { gatewayMetadata } from "./metadata.js";
+import { catalogueOpenApiDocument, type OpenApiDocument } from "./openapi.js";
+import {
+  createCatalogueProblem,
+  isCanonicalCatalogueProblemInstance,
+  type CatalogueProblemContext,
+} from "./problem.js";
+
+const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
+const MAX_URL_LENGTH = 4_096;
+const MAX_ACCEPT_LENGTH = 1_024;
+
+export const DEFAULT_ALLOWED_HOSTS = Object.freeze([
+  "127.0.0.1:8787",
+  "localhost:8787",
+] as const);
+
+export const DEFAULT_ALLOWED_ORIGINS = Object.freeze([
+  "http://127.0.0.1:8787",
+  "http://localhost:8787",
+] as const);
+
+export interface GatewayHttpOptions {
+  readonly snapshot: CatalogueSnapshot;
+  readonly openApiDocument?: OpenApiDocument;
+  readonly allowedHosts?: readonly string[];
+  readonly allowedOrigins?: readonly string[];
+  readonly createTraceId?: () => string;
+}
+
+function jsonResponse(value: unknown, status: number, contentType = "application/json"): Response {
+  return new Response(`${JSON.stringify(value)}\n`, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": `${contentType}; charset=utf-8`,
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function acceptsJson(value: string | null): boolean {
+  if (value === null || value.trim() === "") return true;
+  if (value.length > MAX_ACCEPT_LENGTH) return false;
+  return value.split(",").some((entry) => {
+    const [mediaTypePart, ...parameters] = entry.trim().toLowerCase().split(";");
+    const mediaType = mediaTypePart?.trim();
+    if (mediaType !== "application/json" && mediaType !== "application/*" && mediaType !== "*/*") {
+      return false;
+    }
+    return !parameters.some((parameter) => /^\s*q\s*=\s*0(?:\.0*)?\s*$/u.test(parameter));
+  });
+}
+
+function requestId(request: Request): string {
+  const candidate = request.headers.get("x-request-id");
+  return candidate !== null && REQUEST_ID.test(candidate)
+    ? candidate
+    : randomBytes(16).toString("hex");
+}
+
+function problemResponse(
+  code: Parameters<typeof createCatalogueProblem>[0],
+  context: CatalogueProblemContext,
+  detail: string,
+): Response {
+  const problem = createCatalogueProblem(code, context, { detail });
+  return jsonResponse(problem, problem.status, "application/problem+json");
+}
+
+function catalogueIdentity(snapshot: CatalogueSnapshot): Readonly<Record<string, unknown>> {
+  return Object.freeze({
+    version: snapshot.version,
+    revision: snapshot.revision,
+    content_root_sha256: snapshot.contentRootSha256,
+    record_count: snapshot.recordCount,
+    stale: snapshot.stale,
+    warnings: snapshot.warnings,
+  });
+}
+
+export function createGatewayHttpHandler(
+  options: GatewayHttpOptions,
+): (request: Request) => Promise<Response> {
+  const allowedHosts = new Set(options.allowedHosts ?? DEFAULT_ALLOWED_HOSTS);
+  const allowedOrigins = new Set(options.allowedOrigins ?? DEFAULT_ALLOWED_ORIGINS);
+  const openApiDocument = options.openApiDocument ?? catalogueOpenApiDocument;
+  const createTraceId = options.createTraceId ?? (() => randomBytes(16).toString("hex"));
+
+  if (allowedHosts.size === 0 || allowedOrigins.size === 0) {
+    throw new TypeError("The gateway requires explicit allowed hosts and origins");
+  }
+
+  return async (request: Request): Promise<Response> => {
+    const traceId = createTraceId();
+    if (!/^[0-9a-f]{32}$/u.test(traceId)) {
+      throw new TypeError("Trace identifiers must be 16-byte lowercase hexadecimal values");
+    }
+    const parsedUrl = new URL(request.url);
+    const context: CatalogueProblemContext = {
+      requestId: requestId(request),
+      traceId,
+      ...(isCanonicalCatalogueProblemInstance(parsedUrl.pathname)
+        ? { instance: parsedUrl.pathname }
+        : {}),
+    };
+
+    if (request.url.length > MAX_URL_LENGTH) {
+      return problemResponse("invalid_request", context, "The request URL is too long.");
+    }
+    const host = request.headers.get("host");
+    if (host === null || !allowedHosts.has(host.toLowerCase())) {
+      return problemResponse("invalid_request", context, "The request Host header is not allowed.");
+    }
+    const origin = request.headers.get("origin");
+    if (origin !== null && !allowedOrigins.has(origin)) {
+      return problemResponse(
+        "invalid_request",
+        context,
+        "The request Origin header is not allowed.",
+      );
+    }
+    if (request.method !== "GET") {
+      return problemResponse(
+        "invalid_request",
+        context,
+        "This candidate accepts GET requests only.",
+      );
+    }
+    if (!acceptsJson(request.headers.get("accept"))) {
+      return problemResponse(
+        "not_acceptable",
+        context,
+        "The response is available only as JSON.",
+      );
+    }
+
+    if (parsedUrl.search !== "") {
+      return problemResponse("invalid_request", context, "Query parameters are not supported.");
+    }
+
+    switch (parsedUrl.pathname) {
+      case "/healthz":
+        return jsonResponse(
+          {
+            status: "ok",
+            product: gatewayMetadata.product,
+            lifecycle: gatewayMetadata.lifecycle,
+            catalogue: catalogueIdentity(options.snapshot),
+          },
+          200,
+        );
+      case "/readyz":
+        return jsonResponse(
+          {
+            status: catalogueActivation.state,
+            reason: catalogueActivation.reason,
+            active_tools: catalogueActivation.activeTools,
+            active_api_operations: catalogueActivation.activeApiOperations,
+          },
+          503,
+        );
+      case "/openapi.json":
+        return jsonResponse(openApiDocument, 200);
+      default:
+        return problemResponse(
+          "invalid_request",
+          context,
+          "The requested route is not part of this candidate.",
+        );
+    }
+  };
+}

--- a/apps/mcp-gateway/src/http-main.ts
+++ b/apps/mcp-gateway/src/http-main.ts
@@ -1,0 +1,20 @@
+import { resolve } from "node:path";
+
+import { loadCatalogueSnapshot } from "./catalogue-snapshot.js";
+import { createGatewayNodeServer } from "./http-server.js";
+
+const HOST = "127.0.0.1";
+const PORT = 8_787;
+async function main(): Promise<void> {
+  const catalogueRoot = resolve(process.argv[2] ?? "../../artifacts/okf");
+  const snapshot = await loadCatalogueSnapshot(catalogueRoot);
+  const server = createGatewayNodeServer(snapshot);
+
+  server.listen(PORT, HOST, () => {
+    process.stdout.write(
+      `GIS AI GO blocked gateway candidate listening on http://${HOST}:${PORT}\n`,
+    );
+  });
+}
+
+await main();

--- a/apps/mcp-gateway/src/http-server.ts
+++ b/apps/mcp-gateway/src/http-server.ts
@@ -1,0 +1,114 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+
+import type { CatalogueSnapshot } from "./catalogue-snapshot.js";
+import { createGatewayHttpHandler } from "./http-app.js";
+
+const MAX_URL_LENGTH = 4_096;
+
+function writeResponse(response: ServerResponse, result: Response): Promise<void> {
+  response.statusCode = result.status;
+  result.headers.forEach((value, name) => response.setHeader(name, value));
+  return result.arrayBuffer().then((body) => {
+    response.setHeader("content-length", body.byteLength);
+    response.end(Buffer.from(body));
+  });
+}
+
+function requestUrl(request: IncomingMessage): URL | undefined {
+  const host = request.headers.host;
+  const target = request.url;
+  if (
+    host === undefined ||
+    target === undefined ||
+    target.length > MAX_URL_LENGTH ||
+    !target.startsWith("/") ||
+    target.startsWith("//") ||
+    target.includes("\\") ||
+    target.includes("#")
+  ) {
+    return undefined;
+  }
+  try {
+    return new URL(target, `http://${host}`);
+  } catch {
+    return undefined;
+  }
+}
+
+function applicationHeaders(request: IncomingMessage): Headers {
+  const headers = new Headers();
+  for (const name of ["host", "origin", "accept", "x-request-id"] as const) {
+    const value = request.headers[name];
+    if (typeof value === "string") headers.set(name, value);
+  }
+  return headers;
+}
+
+function headerOccurrences(request: IncomingMessage, expectedName: string): number {
+  let count = 0;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === expectedName) count += 1;
+  }
+  return count;
+}
+
+function rejectRequest(response: ServerResponse): void {
+  response.writeHead(400, {
+    "cache-control": "no-store",
+    "content-length": "0",
+    "x-content-type-options": "nosniff",
+  });
+  response.end();
+}
+
+/** Create the bounded Node adapter without binding a network interface. */
+export function createGatewayNodeServer(snapshot: CatalogueSnapshot): Server {
+  const handle = createGatewayHttpHandler({ snapshot });
+  const server = createServer(
+    {
+      headersTimeout: 5_000,
+      keepAliveTimeout: 5_000,
+      maxHeaderSize: 16_384,
+      rejectNonStandardBodyWrites: true,
+      requestTimeout: 5_000,
+      requireHostHeader: true,
+    },
+    (request, response) => {
+      const url = requestUrl(request);
+      if (
+        url === undefined ||
+        headerOccurrences(request, "host") !== 1 ||
+        request.headers["transfer-encoding"] !== undefined ||
+        request.headers["content-length"] !== undefined
+      ) {
+        rejectRequest(response);
+        return;
+      }
+      const fetchRequest = new Request(url, {
+        method: request.method ?? "GET",
+        headers: applicationHeaders(request),
+      });
+      void handle(fetchRequest)
+        .then((result) => writeResponse(response, result))
+        .catch(() => {
+          if (!response.headersSent) {
+            response.writeHead(500, {
+              "cache-control": "no-store",
+              "content-length": "0",
+              "x-content-type-options": "nosniff",
+            });
+          }
+          response.end();
+        });
+    },
+  );
+  server.maxHeadersCount = 64;
+  server.maxRequestsPerSocket = 100;
+  server.setTimeout(5_000, (socket) => socket.destroy());
+  return server;
+}

--- a/apps/mcp-gateway/src/index.ts
+++ b/apps/mcp-gateway/src/index.ts
@@ -1,23 +1,9 @@
-export interface StageZeroRequest {
-  readonly synthetic: boolean;
-  readonly networkAccess: boolean;
-}
-
-export const gatewayMetadata = Object.freeze({
-  product: "GIS AI GO",
-  repository: "gis-ai-go",
-  registryId: "io.github.chris-page-gov/gis-ai-go",
-  protocolTarget: "2026-07-28",
-  stage: 0,
-  liveProviderCalls: false,
-} as const);
-
-export function assertStageZeroRequest(request: StageZeroRequest): typeof gatewayMetadata {
-  if (!request.synthetic) {
-    throw new Error("Stage 0 accepts synthetic requests only");
-  }
-  if (request.networkAccess) {
-    throw new Error("Stage 0 forbids network and provider access");
-  }
-  return gatewayMetadata;
-}
+export * from "./activation.js";
+export * from "./catalogue-application.js";
+export * from "./catalogue-snapshot.js";
+export * from "./cursor.js";
+export * from "./http-app.js";
+export * from "./http-server.js";
+export * from "./metadata.js";
+export * from "./openapi.js";
+export * from "./problem.js";

--- a/apps/mcp-gateway/src/metadata.ts
+++ b/apps/mcp-gateway/src/metadata.ts
@@ -1,0 +1,13 @@
+import { catalogueActivation } from "./activation.js";
+
+export const gatewayMetadata = Object.freeze({
+  product: "GIS AI GO",
+  repository: "chris-page-gov/gis-ai-go",
+  registryId: "io.github.chris-page-gov/gis-ai-go",
+  version: "0.1.0",
+  protocolTarget: "2026-07-28",
+  lifecycle: "candidate-blocked",
+  liveProviderCalls: false,
+  activeTools: catalogueActivation.activeTools,
+  activeApiOperations: catalogueActivation.activeApiOperations,
+} as const);

--- a/apps/mcp-gateway/src/openapi.ts
+++ b/apps/mcp-gateway/src/openapi.ts
@@ -1,0 +1,14 @@
+import openApiDocument from "../openapi/catalogue-api.openapi.json" with { type: "json" };
+
+export type OpenApiDocument = Readonly<typeof openApiDocument>;
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (value === null || typeof value !== "object" || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child, seen);
+  }
+  return Object.freeze(value);
+}
+
+export const catalogueOpenApiDocument: OpenApiDocument = deepFreeze(openApiDocument);

--- a/apps/mcp-gateway/src/problem.ts
+++ b/apps/mcp-gateway/src/problem.ts
@@ -1,0 +1,280 @@
+export const CATALOGUE_PROBLEM_CODES = [
+  "invalid_request",
+  "invalid_cursor",
+  "record_not_found",
+  "not_acceptable",
+  "rate_limited",
+  "complexity_limit_exceeded",
+  "service_unavailable",
+  "internal_error",
+] as const;
+
+export type CatalogueProblemCode = (typeof CATALOGUE_PROBLEM_CODES)[number];
+
+export const CATALOGUE_PROBLEM_FIELD_CODES = [
+  "required",
+  "invalid_type",
+  "invalid_value",
+  "out_of_range",
+  "not_unique",
+  "unknown_property",
+] as const;
+
+export type CatalogueProblemFieldCode = (typeof CATALOGUE_PROBLEM_FIELD_CODES)[number];
+
+export interface CatalogueProblemFieldError {
+  readonly path: string;
+  readonly code: CatalogueProblemFieldCode;
+  readonly message: string;
+}
+
+export interface CatalogueProblem {
+  readonly schema: "gis-ai-go.catalogue-problem.v1";
+  readonly type: string;
+  readonly title: string;
+  readonly status: number;
+  readonly code: CatalogueProblemCode;
+  readonly detail?: string;
+  readonly instance?: string;
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly retry_after_seconds?: number;
+  readonly errors?: readonly CatalogueProblemFieldError[];
+}
+
+export interface CatalogueProblemContext {
+  readonly requestId: string;
+  readonly traceId: string;
+  readonly instance?: string;
+}
+
+export interface CatalogueProblemOptions {
+  readonly detail?: string;
+  readonly retryAfterSeconds?: number;
+  readonly errors?: readonly CatalogueProblemFieldError[];
+}
+
+interface ProblemDefinition {
+  readonly type: string;
+  readonly title: string;
+  readonly status: number;
+}
+
+const DEFINITIONS: Readonly<Record<CatalogueProblemCode, ProblemDefinition>> = Object.freeze({
+  invalid_request: {
+    type: "urn:gis-ai-go:problem:invalid-request",
+    title: "Invalid request",
+    status: 400,
+  },
+  invalid_cursor: {
+    type: "urn:gis-ai-go:problem:invalid-cursor",
+    title: "Invalid cursor",
+    status: 400,
+  },
+  record_not_found: {
+    type: "urn:gis-ai-go:problem:record-not-found",
+    title: "Catalogue record not found",
+    status: 404,
+  },
+  not_acceptable: {
+    type: "urn:gis-ai-go:problem:not-acceptable",
+    title: "Representation not acceptable",
+    status: 406,
+  },
+  rate_limited: {
+    type: "urn:gis-ai-go:problem:rate-limited",
+    title: "Rate limit exceeded",
+    status: 429,
+  },
+  complexity_limit_exceeded: {
+    type: "urn:gis-ai-go:problem:complexity-limit-exceeded",
+    title: "Complexity limit exceeded",
+    status: 422,
+  },
+  service_unavailable: {
+    type: "urn:gis-ai-go:problem:service-unavailable",
+    title: "Service unavailable",
+    status: 503,
+  },
+  internal_error: {
+    type: "urn:gis-ai-go:problem:internal-error",
+    title: "Internal error",
+    status: 500,
+  },
+});
+
+const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u;
+const TRACE_ID = /^[0-9a-f]{32}$/u;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/u;
+const INSTANCE_PATH = /^\/(?:[A-Za-z0-9._~:/-]|%[0-9A-F]{2})*$/u;
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function isBoundedText(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): value is string {
+  return (
+    typeof value === "string" &&
+    codePointLength(value) >= minimum &&
+    codePointLength(value) <= maximum &&
+    !CONTROL_CHARACTER.test(value)
+  );
+}
+
+function assertBoundedText(
+  value: unknown,
+  field: string,
+  minimum: number,
+  maximum: number,
+): asserts value is string {
+  if (!isBoundedText(value, minimum, maximum)) {
+    throw new TypeError(
+      `${field} must contain ${minimum} to ${maximum} Unicode characters without controls`,
+    );
+  }
+}
+
+/** Check the exact canonical path invariant used by catalogue problem instances. */
+export function isCanonicalCatalogueProblemInstance(value: unknown): value is string {
+  if (!isBoundedText(value, 1, 2_048)) return false;
+
+  let canonicalPath: string;
+  try {
+    canonicalPath = decodeURIComponent(value)
+      .split("/")
+      .map((segment) => encodeURIComponent(segment).replaceAll("%3A", ":"))
+      .join("/");
+  } catch {
+    return false;
+  }
+  return INSTANCE_PATH.test(value) && canonicalPath === value;
+}
+
+/** Validate the request and trace identity shared by success and problem envelopes. */
+export function assertCatalogueProblemContext(context: CatalogueProblemContext): void {
+  if (
+    typeof context.requestId !== "string" ||
+    codePointLength(context.requestId) > 128 ||
+    !REQUEST_ID.test(context.requestId)
+  ) {
+    throw new TypeError("requestId does not match the catalogue problem contract");
+  }
+  if (typeof context.traceId !== "string" || !TRACE_ID.test(context.traceId)) {
+    throw new TypeError("traceId must contain exactly 32 lowercase hexadecimal characters");
+  }
+  if (
+    context.instance !== undefined &&
+    !isCanonicalCatalogueProblemInstance(context.instance)
+  ) {
+    throw new TypeError(
+      "instance must be a bounded canonical absolute path without a query or fragment",
+    );
+  }
+}
+
+function assertErrors(errors: readonly CatalogueProblemFieldError[]): void {
+  if (!Array.isArray(errors) || errors.length < 1 || errors.length > 20) {
+    throw new TypeError("errors must contain from 1 to 20 field errors");
+  }
+  const identities = new Set<string>();
+  for (const [index, error] of errors.entries()) {
+    if (typeof error !== "object" || error === null || Array.isArray(error)) {
+      throw new TypeError(`errors[${index}] must be a field error object`);
+    }
+    const keys = Object.keys(error).sort();
+    if (keys.length !== 3 || keys[0] !== "code" || keys[1] !== "message" || keys[2] !== "path") {
+      throw new TypeError(`errors[${index}] has an unexpected shape`);
+    }
+    assertBoundedText(error.path, `errors[${index}].path`, 1, 256);
+    assertBoundedText(error.message, `errors[${index}].message`, 1, 512);
+    if (!(CATALOGUE_PROBLEM_FIELD_CODES as readonly unknown[]).includes(error.code)) {
+      throw new TypeError(`errors[${index}].code is not controlled`);
+    }
+    const identity = JSON.stringify([error.path, error.code, error.message]);
+    if (identities.has(identity)) {
+      throw new TypeError("errors must be unique");
+    }
+    identities.add(identity);
+  }
+}
+
+function assertOptions(options: CatalogueProblemOptions): void {
+  if (options.detail !== undefined) {
+    assertBoundedText(options.detail, "detail", 1, 1_024);
+  }
+  if (
+    options.retryAfterSeconds !== undefined &&
+    (!Number.isInteger(options.retryAfterSeconds) ||
+      options.retryAfterSeconds < 1 ||
+      options.retryAfterSeconds > 3_600)
+  ) {
+    throw new TypeError("retryAfterSeconds must be an integer from 1 to 3600");
+  }
+  if (options.errors !== undefined) {
+    assertErrors(options.errors);
+  }
+}
+
+function optionalFields(
+  context: CatalogueProblemContext,
+  options: CatalogueProblemOptions,
+): Partial<CatalogueProblem> {
+  return {
+    ...(options.detail === undefined ? {} : { detail: options.detail }),
+    ...(context.instance === undefined ? {} : { instance: context.instance }),
+    ...(options.retryAfterSeconds === undefined
+      ? {}
+      : { retry_after_seconds: options.retryAfterSeconds }),
+    ...(options.errors === undefined ? {} : { errors: options.errors }),
+  };
+}
+
+/** Create the one RFC 9457-compatible problem shape used by every transport. */
+export function createCatalogueProblem(
+  code: CatalogueProblemCode,
+  context: CatalogueProblemContext,
+  options: CatalogueProblemOptions = {},
+): CatalogueProblem {
+  if (!(CATALOGUE_PROBLEM_CODES as readonly unknown[]).includes(code)) {
+    throw new TypeError("code is not a controlled catalogue problem code");
+  }
+  assertCatalogueProblemContext(context);
+  assertOptions(options);
+  const definition = DEFINITIONS[code];
+  return {
+    schema: "gis-ai-go.catalogue-problem.v1",
+    type: definition.type,
+    title: definition.title,
+    status: definition.status,
+    code,
+    request_id: context.requestId,
+    trace_id: context.traceId,
+    ...optionalFields(context, options),
+  };
+}
+
+export class CatalogueProblemError extends Error {
+  public readonly problem: CatalogueProblem;
+
+  public constructor(problem: CatalogueProblem) {
+    super(problem.detail ?? problem.title);
+    this.name = "CatalogueProblemError";
+    this.problem = problem;
+  }
+}
+
+export function isCatalogueProblemError(error: unknown): error is CatalogueProblemError {
+  return error instanceof CatalogueProblemError;
+}
+
+export function throwCatalogueProblem(
+  code: CatalogueProblemCode,
+  context: CatalogueProblemContext,
+  options: CatalogueProblemOptions = {},
+): never {
+  throw new CatalogueProblemError(createCatalogueProblem(code, context, options));
+}

--- a/apps/mcp-gateway/test/catalogue-application.test.ts
+++ b/apps/mcp-gateway/test/catalogue-application.test.ts
@@ -1,0 +1,547 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  parseCatalogue,
+  type CatalogueBundle,
+  type CatalogueRecord,
+  type JsonValue,
+} from "@gis-ai-go/contracts";
+
+import {
+  assertCatalogueResultSnapshotBounds,
+  createCatalogueApplication,
+  type CatalogueSearchResult,
+} from "../src/catalogue-application.js";
+import {
+  loadCatalogueSnapshot,
+  type CatalogueSnapshot,
+} from "../src/catalogue-snapshot.js";
+import {
+  CatalogueProblemError,
+  createCatalogueProblem,
+  isCanonicalCatalogueProblemInstance,
+  type CatalogueProblemCode,
+} from "../src/problem.js";
+
+const SOURCE_CATALOGUE = fileURLToPath(
+  new URL("../../../../artifacts/okf/", import.meta.url),
+);
+const CONTEXT = Object.freeze({
+  requestId: "request-catalogue-test",
+  traceId: "0123456789abcdef0123456789abcdef",
+});
+const SNAPSHOT = await loadCatalogueSnapshot(SOURCE_CATALOGUE, {
+  now: new Date("2026-08-20T12:00:00Z"),
+});
+const APPLICATION = createCatalogueApplication(SNAPSHOT);
+const MUTATION_RECORD_ID = "hmlr:dataset:price-paid-data";
+
+function snapshotForBundle(bundle: CatalogueBundle): CatalogueSnapshot {
+  return Object.freeze({
+    ...SNAPSHOT,
+    bundle,
+    recordsById: new Map(bundle.records.map((record) => [record.id, record])),
+    recordCount: bundle.records.length,
+  });
+}
+
+function parserValidSnapshotWithRecord(
+  overrides: Partial<CatalogueRecord>,
+): CatalogueSnapshot {
+  const records = SNAPSHOT.bundle.records.map((record) =>
+    record.id === MUTATION_RECORD_ID ? { ...record, ...overrides } : record,
+  );
+  return snapshotForBundle(parseCatalogue({ ...SNAPSHOT.bundle, records }));
+}
+
+function uncheckedSnapshotWithRecord(
+  overrides: Partial<CatalogueRecord>,
+): CatalogueSnapshot {
+  const records = SNAPSHOT.bundle.records.map((record) =>
+    record.id === MUTATION_RECORD_ID ? { ...record, ...overrides } : record,
+  );
+  const bundle = { ...SNAPSHOT.bundle, records } satisfies CatalogueBundle;
+  return snapshotForBundle(bundle);
+}
+
+function expectProblem(run: () => unknown, code: CatalogueProblemCode): CatalogueProblemError {
+  let captured: CatalogueProblemError | undefined;
+  assert.throws(run, (error: unknown) => {
+    assert.ok(error instanceof CatalogueProblemError);
+    assert.equal(error.problem.code, code);
+    assert.equal(error.problem.request_id, CONTEXT.requestId);
+    assert.equal(error.problem.trace_id, CONTEXT.traceId);
+    captured = error;
+    return true;
+  });
+  assert.ok(captured);
+  return captured;
+}
+
+function firstIds(result: CatalogueSearchResult): readonly string[] {
+  return result.data.records.map(({ id }) => id);
+}
+
+test("search returns governed Price Paid and INSPIRE summaries with controlled facets", () => {
+  const pricePaid = APPLICATION.search(
+    { query: "Price Paid", facets: { types: ["dataset"] } },
+    CONTEXT,
+  );
+  assert.equal(pricePaid.operation, "catalogue.search");
+  assert.equal(pricePaid.catalogue.content_root_sha256, SNAPSHOT.contentRootSha256);
+  assert.equal(pricePaid.catalogue.record_count, SNAPSHOT.recordCount);
+  assert.equal(pricePaid.data.records[0]?.id, "hmlr:dataset:price-paid-data");
+  assert.equal(pricePaid.data.records[0]?.authority, "source-authoritative");
+  assert.equal(pricePaid.data.records[0]?.rights, "open-with-conditions");
+  assert.ok(pricePaid.data.facets.types.some(({ value }) => value === "dataset"));
+
+  const inspire = APPLICATION.search(
+    { query: "INSPIRE", facets: { tags: ["inspire"] }, limit: 100 },
+    CONTEXT,
+  );
+  assert.ok(firstIds(inspire).includes("hmlr:dataset:inspire-index-polygons"));
+  assert.ok(
+    firstIds(inspire).includes("hmlr:dataset:local-land-charges-inspire"),
+  );
+  assert.equal(inspire.data.page.returned, inspire.data.records.length);
+  assert.equal(inspire.data.page.next_cursor, null);
+});
+
+test("application creation rejects parser-valid records outside the result contract", () => {
+  const base = SNAPSHOT.recordsById.get(MUTATION_RECORD_ID);
+  assert.ok(base);
+
+  const cases: readonly [string, Partial<CatalogueRecord>][] = [
+    ["title", { title: "t".repeat(513) }],
+    ["description", { description: "d".repeat(4_097) }],
+    [
+      "authority.statement",
+      { authority: { ...base.authority, statement: "s".repeat(4_097) } },
+    ],
+    [
+      "authority.source",
+      { authority: { ...base.authority, source: "s".repeat(513) } },
+    ],
+    [
+      "access.authentication",
+      { access: { ...base.access, authentication: "a".repeat(513) } },
+    ],
+    [
+      "rights.recordLicence",
+      { rights: { ...base.rights, recordLicence: "r".repeat(2_049) } },
+    ],
+    [
+      "rights.describedResourceLicence",
+      {
+        rights: {
+          ...base.rights,
+          describedResourceLicence: "r".repeat(2_049),
+        },
+      },
+    ],
+    [
+      "rights.attribution",
+      { rights: { ...base.rights, attribution: "a".repeat(8_193) } },
+    ],
+    ["limitations", { limitations: Array.from({ length: 51 }, (_, index) => `l-${index}`) }],
+    ["limitations[0]", { limitations: ["l".repeat(2_049)] }],
+    ["tags", { tags: Array.from({ length: 51 }, (_, index) => `tag-${index}`) }],
+    ["tags[0]", { tags: ["t".repeat(129)] }],
+  ];
+
+  for (const [path, overrides] of cases) {
+    const snapshot = parserValidSnapshotWithRecord(overrides);
+    assert.throws(() => createCatalogueApplication(snapshot), (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^Catalogue result contract rejected at /u);
+      assert.ok(error.message.includes(path));
+      return true;
+    });
+  }
+});
+
+test("result bounds reject excessive source references, facets and source-native details", () => {
+  const base = SNAPSHOT.recordsById.get(MUTATION_RECORD_ID);
+  assert.ok(base);
+
+  const sourceRefs = Array.from({ length: 101 }, (_, index) => `source:${index}`);
+  assert.throws(
+    () => createCatalogueApplication(uncheckedSnapshotWithRecord({ sourceRefs })),
+    /sourceRefs/u,
+  );
+
+  const tooManyProperties = Object.fromEntries(
+    Array.from({ length: 257 }, (_, index) => [`property${index}`, index]),
+  );
+  const detailCases: readonly Readonly<Record<string, JsonValue>>[] = [
+    tooManyProperties,
+    { ["k".repeat(257)]: true },
+    { text: "x".repeat(65_537) },
+    { values: Array.from({ length: 10_001 }, () => null) },
+  ];
+  for (const details of detailCases) {
+    assert.throws(
+      () => createCatalogueApplication(uncheckedSnapshotWithRecord({ details })),
+      /details/u,
+    );
+  }
+
+  const records = SNAPSHOT.bundle.records.map((record, recordIndex) => ({
+    ...record,
+    tags: Array.from({ length: 3 }, (_, tagIndex) =>
+      `facet-${recordIndex}-${tagIndex}`,
+    ),
+  }));
+  const facetSnapshot = snapshotForBundle(
+    parseCatalogue({ ...SNAPSHOT.bundle, records }),
+  );
+  assert.throws(
+    () => assertCatalogueResultSnapshotBounds(facetSnapshot),
+    /facets\.tags.*100 options/u,
+  );
+});
+
+test("pagination is deterministic and rejects tampering or replay", () => {
+  const first = APPLICATION.search({ query: "HMLR", limit: 1 }, CONTEXT);
+  assert.equal(first.data.records.length, 1);
+  assert.ok(first.data.page.matched > 1);
+  assert.ok(first.data.page.next_cursor);
+  const cursor = first.data.page.next_cursor;
+
+  const second = APPLICATION.search({ query: "hmlr", limit: 1, cursor }, CONTEXT);
+  assert.equal(second.data.records.length, 1);
+  assert.notEqual(second.data.records[0]?.id, first.data.records[0]?.id);
+  assert.equal(second.data.page.matched, first.data.page.matched);
+
+  const alteredFinalCharacter = cursor.endsWith("0") ? "1" : "0";
+  expectProblem(
+    () =>
+      APPLICATION.search(
+        { query: "HMLR", limit: 1, cursor: `${cursor.slice(0, -1)}${alteredFinalCharacter}` },
+        CONTEXT,
+      ),
+    "invalid_cursor",
+  );
+  expectProblem(
+    () => APPLICATION.search({ query: "INSPIRE", limit: 1, cursor }, CONTEXT),
+    "invalid_cursor",
+  );
+
+  const changedSnapshot = Object.freeze({
+    ...SNAPSHOT,
+    contentRootSha256: "f".repeat(64),
+  }) satisfies CatalogueSnapshot;
+  const changedApplication = createCatalogueApplication(changedSnapshot);
+  expectProblem(
+    () => changedApplication.search({ query: "HMLR", limit: 1, cursor }, CONTEXT),
+    "invalid_cursor",
+  );
+});
+
+test("query limits count normalised terms and Unicode code points", () => {
+  const tenTerms = "one two three four five six seven eight nine ten";
+  assert.doesNotThrow(() => APPLICATION.search({ query: tenTerms }, CONTEXT));
+
+  const elevenTerms = `${tenTerms} eleven`;
+  const tooManyTerms = expectProblem(
+    () => APPLICATION.search({ query: elevenTerms }, CONTEXT),
+    "complexity_limit_exceeded",
+  );
+  assert.equal(tooManyTerms.problem.errors?.[0]?.path, "$.query");
+
+  const astralCharacter = "𐐀";
+  assert.doesNotThrow(() =>
+    APPLICATION.search({ query: astralCharacter.repeat(256) }, CONTEXT),
+  );
+  expectProblem(
+    () => APPLICATION.search({ query: astralCharacter.repeat(257) }, CONTEXT),
+    "invalid_request",
+  );
+});
+
+test("closed requests reject unknown properties, facet values and tags", () => {
+  const safeUnknown = expectProblem(
+    () => APPLICATION.search({ provider: "hmlr" }, CONTEXT),
+    "invalid_request",
+  );
+  assert.equal(safeUnknown.problem.errors?.[0]?.path, "$.provider");
+  assert.equal(
+    safeUnknown.problem.errors?.[0]?.message,
+    "Remove the unknown property provider.",
+  );
+  expectProblem(
+    () => APPLICATION.search({ facets: { types: ["collection"] } }, CONTEXT),
+    "invalid_request",
+  );
+  expectProblem(
+    () => APPLICATION.search({ facets: { tags: ["not-a-governed-tag"] } }, CONTEXT),
+    "invalid_request",
+  );
+  expectProblem(
+    () => APPLICATION.search({ facets: { types: ["dataset", "dataset"] } }, CONTEXT),
+    "invalid_request",
+  );
+});
+
+test("hostile unknown property identities remain controlled catalogue problems", () => {
+  const hostileKeys = ["x".repeat(300), "unsafe\nproperty"] as const;
+  for (const key of hostileKeys) {
+    const root = expectProblem(
+      () => APPLICATION.search({ [key]: true }, CONTEXT),
+      "invalid_request",
+    );
+    assert.equal(root.problem.detail, "Remove the unknown property.");
+    assert.deepEqual(root.problem.errors, [
+      {
+        path: "$",
+        code: "unknown_property",
+        message: "Remove the unknown property.",
+      },
+    ]);
+
+    const nested = expectProblem(
+      () => APPLICATION.search({ facets: { [key]: true } }, CONTEXT),
+      "invalid_request",
+    );
+    assert.equal(nested.problem.errors?.[0]?.path, "$.facets");
+    assert.equal(nested.problem.errors?.[0]?.message, "Remove the unknown property.");
+  }
+});
+
+test("the central problem factory accepts schema boundaries and rejects invalid envelopes", () => {
+  const boundary = createCatalogueProblem(
+    "rate_limited",
+    {
+      requestId: `r${"a".repeat(127)}`,
+      traceId: "f".repeat(32),
+      instance: "/".repeat(2_048),
+    },
+    {
+      detail: "𐐀".repeat(1_024),
+      retryAfterSeconds: 3_600,
+      errors: Array.from({ length: 20 }, (_, index) => ({
+        path: `$.field${index}`,
+        code: "invalid_value" as const,
+        message: index === 0 ? "m".repeat(512) : `Invalid value ${index}.`,
+      })),
+    },
+  );
+  assert.equal(boundary.status, 429);
+  assert.equal(boundary.type, "urn:gis-ai-go:problem:rate-limited");
+  assert.equal(boundary.errors?.length, 20);
+  assert.equal(isCanonicalCatalogueProblemInstance("/catalogue/records:hmlr"), true);
+  assert.equal(isCanonicalCatalogueProblemInstance("/%41"), false);
+  assert.equal(isCanonicalCatalogueProblemInstance("/%2f"), false);
+  assert.equal(isCanonicalCatalogueProblemInstance("/%ZZ"), false);
+  assert.equal(isCanonicalCatalogueProblemInstance("not/a/path"), false);
+
+  const validContext = { requestId: "request-1", traceId: "a".repeat(32) };
+  const invalidRuns: readonly (() => unknown)[] = [
+    () => createCatalogueProblem("invalid_request", { ...validContext, requestId: "" }),
+    () =>
+      createCatalogueProblem("invalid_request", {
+        ...validContext,
+        requestId: `r${"a".repeat(128)}`,
+      }),
+    () => createCatalogueProblem("invalid_request", { ...validContext, traceId: "A".repeat(32) }),
+    () =>
+      createCatalogueProblem("invalid_request", {
+        ...validContext,
+        instance: "/".repeat(2_049),
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", {
+        ...validContext,
+        instance: "not a URI",
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", {
+        ...validContext,
+        instance: "/requests/not canonical",
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", {
+        ...validContext,
+        instance: "/requests/%6fver-encoded",
+      }),
+    () => createCatalogueProblem("invalid_request", validContext, { detail: "" }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        detail: "d".repeat(1_025),
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        detail: "unsafe\u0000detail",
+      }),
+    () =>
+      createCatalogueProblem("rate_limited", validContext, { retryAfterSeconds: 0 }),
+    () =>
+      createCatalogueProblem("rate_limited", validContext, { retryAfterSeconds: 3_601 }),
+    () =>
+      createCatalogueProblem("rate_limited", validContext, { retryAfterSeconds: 1.5 }),
+    () => createCatalogueProblem("invalid_request", validContext, { errors: [] }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        errors: Array.from({ length: 21 }, (_, index) => ({
+          path: `$.field${index}`,
+          code: "invalid_value" as const,
+          message: `Invalid value ${index}.`,
+        })),
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        errors: [
+          { path: "$.field", code: "invalid_value", message: "Invalid." },
+          { path: "$.field", code: "invalid_value", message: "Invalid." },
+        ],
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        errors: [{ path: "", code: "invalid_value", message: "Invalid." }],
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        errors: [{ path: "$.field", code: "invalid_value", message: "" }],
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        errors: [
+          { path: "$.field", code: "not-controlled" as never, message: "Invalid." },
+        ],
+      }),
+    () =>
+      createCatalogueProblem("invalid_request", validContext, {
+        errors: [
+          {
+            path: "$.field",
+            code: "invalid_value",
+            message: "Invalid.",
+            unexpected: true,
+          } as never,
+        ],
+      }),
+  ];
+  for (const run of invalidRuns) assert.throws(run, TypeError);
+});
+
+test("success envelopes reject invalid request and trace identities", () => {
+  const invalidContexts = [
+    { requestId: "unsafe request", traceId: "a".repeat(32) },
+    { requestId: "request-1", traceId: "A".repeat(32) },
+  ] as const;
+
+  for (const context of invalidContexts) {
+    assert.throws(() => APPLICATION.search({}, context), TypeError);
+    assert.throws(
+      () => APPLICATION.describe({ record_id: "hmlr:dataset:price-paid-data" }, context),
+      TypeError,
+    );
+  }
+});
+
+test("semantically equivalent search criteria produce byte-equivalent values", () => {
+  const first = APPLICATION.search(
+    {
+      query: "  PRICE   paid ",
+      facets: {
+        types: ["source", "dataset"],
+        rights: ["metadata-citation", "open-with-conditions"],
+      },
+      limit: 5,
+    },
+    CONTEXT,
+  );
+  const second = APPLICATION.search(
+    {
+      limit: 5,
+      facets: {
+        rights: ["open-with-conditions", "metadata-citation"],
+        types: ["dataset", "source"],
+      },
+      query: "price paid",
+    },
+    CONTEXT,
+  );
+  assert.deepEqual(first, second);
+  assert.equal(JSON.stringify(first), JSON.stringify(second));
+});
+
+test("describe preserves full governed fields and stable source expansions", () => {
+  const result = APPLICATION.describe(
+    { record_id: "hmlr:dataset:price-paid-data" },
+    CONTEXT,
+  );
+  assert.equal(result.operation, "catalogue.describe");
+  assert.equal(result.data.record.id, "hmlr:dataset:price-paid-data");
+  assert.equal(result.data.record.authority.class, "source-authoritative");
+  assert.equal(result.data.record.publication.contains_personal_data, false);
+  assert.equal(result.data.record.publication.contains_protected_data, false);
+  assert.equal(result.data.record.access.tier, "open");
+  assert.equal(result.data.record.rights.state, "open-with-conditions");
+  assert.match(result.data.record.rights.attribution, /Land Registry/u);
+  assert.ok(result.data.record.limitations.length > 0);
+  assert.ok(result.data.record.source_refs.length > 0);
+  assert.equal("sourceRefs" in result.data.record, false);
+  assert.equal("recordLicence" in result.data.record.rights, false);
+  assert.equal(result.data.record.details.sourceNativeId, "hmlr:dataset:price-paid-data");
+
+  const relationshipIds = result.data.included.relationships?.map(({ record_id: id }) => id);
+  const sourceIds = result.data.included.sources?.map(({ id }) => id);
+  assert.deepEqual(relationshipIds, [...(relationshipIds ?? [])].sort());
+  assert.deepEqual(sourceIds, relationshipIds);
+  assert.ok(result.data.included.sources?.every((source) => source.title.length > 0));
+});
+
+test("describe include order is canonical and IDs are exact and case-sensitive", () => {
+  const sourcesFirst = APPLICATION.describe(
+    {
+      record_id: "hmlr:dataset:inspire-index-polygons",
+      include: ["sources", "relationships"],
+    },
+    CONTEXT,
+  );
+  const relationshipsFirst = APPLICATION.describe(
+    {
+      include: ["relationships", "sources"],
+      record_id: "hmlr:dataset:inspire-index-polygons",
+    },
+    CONTEXT,
+  );
+  assert.deepEqual(sourcesFirst, relationshipsFirst);
+  assert.equal(JSON.stringify(sourcesFirst), JSON.stringify(relationshipsFirst));
+
+  const sourcesOnly = APPLICATION.describe(
+    { record_id: "hmlr:dataset:inspire-index-polygons", include: ["sources"] },
+    CONTEXT,
+  );
+  assert.equal("sources" in sourcesOnly.data.included, true);
+  assert.equal("relationships" in sourcesOnly.data.included, false);
+
+  expectProblem(
+    () => APPLICATION.describe({ record_id: "HMLR:DATASET:INSPIRE-INDEX-POLYGONS" }, CONTEXT),
+    "record_not_found",
+  );
+  expectProblem(
+    () => APPLICATION.describe({ record_id: "missing:record" }, CONTEXT),
+    "record_not_found",
+  );
+
+  const safeMissingId = "s".repeat(512);
+  const safeMissing = expectProblem(
+    () => APPLICATION.describe({ record_id: safeMissingId }, CONTEXT),
+    "record_not_found",
+  );
+  assert.ok(safeMissing.problem.detail?.includes(safeMissingId));
+
+  const hostileMissing = expectProblem(
+    () => APPLICATION.describe({ record_id: "missing\nrecord" }, CONTEXT),
+    "record_not_found",
+  );
+  assert.equal(
+    hostileMissing.problem.detail,
+    "No catalogue record has the supplied exact ID.",
+  );
+  assert.equal(hostileMissing.problem.detail?.includes("missing\nrecord"), false);
+});

--- a/apps/mcp-gateway/test/catalogue-snapshot.test.ts
+++ b/apps/mcp-gateway/test/catalogue-snapshot.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  cp,
+  mkdtemp,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  truncate,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { loadCatalogueSnapshot } from "../src/catalogue-snapshot.js";
+
+const SOURCE_CATALOGUE = fileURLToPath(
+  new URL("../../../../artifacts/okf/", import.meta.url),
+);
+
+async function withCatalogueCopy(run: (root: string) => Promise<void>): Promise<void> {
+  const temporaryBase = await realpath(tmpdir());
+  const workspace = await mkdtemp(join(temporaryBase, "gis-ai-go-catalogue-"));
+  const root = join(workspace, "okf");
+  await cp(SOURCE_CATALOGUE, root, { recursive: true });
+  try {
+    await run(root);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function refreshLedgerDigest(root: string, relativePath: string): Promise<void> {
+  const checksumPath = join(root, "CHECKSUMS.sha256");
+  const replacement = digest(await readFile(join(root, relativePath)));
+  const rows = (await readFile(checksumPath, "utf8"))
+    .trimEnd()
+    .split("\n")
+    .map((row) => (row.endsWith(`  ${relativePath}`) ? `${replacement}  ${relativePath}` : row));
+  await writeFile(checksumPath, `${rows.join("\n")}\n`, "utf8");
+}
+
+test("loads the checksum-verified catalogue as a deeply immutable snapshot", async () => {
+  const snapshot = await loadCatalogueSnapshot(SOURCE_CATALOGUE, {
+    now: new Date("2026-08-20T12:00:00Z"),
+  });
+
+  assert.equal(
+    snapshot.bundle.id,
+    "https://chris-page-gov.github.io/gis-ai-go/id/bundle/public-discovery",
+  );
+  assert.equal(snapshot.recordsById.size, snapshot.recordCount);
+  assert.equal(snapshot.recordsById.get("LR-Q003")?.id, "LR-Q003");
+  assert.match(snapshot.contentRootSha256, /^[0-9a-f]{64}$/u);
+  assert.match(snapshot.manifestSha256, /^[0-9a-f]{64}$/u);
+  assert.equal(snapshot.stale, false);
+  assert.equal(snapshot.stalenessWarning, null);
+  assert.deepEqual(snapshot.warnings, []);
+  assert.equal(Object.isFrozen(snapshot), true);
+  assert.equal(Object.isFrozen(snapshot.bundle), true);
+  assert.equal(Object.isFrozen(snapshot.bundle.records), true);
+  assert.equal(Object.isFrozen(snapshot.bundle.records[0]?.details), true);
+  assert.equal("set" in snapshot.recordsById, false);
+  assert.throws(() => {
+    (snapshot.bundle.records as unknown as CatalogueRecordMutation[]).push({ id: "rogue" });
+  }, TypeError);
+});
+
+interface CatalogueRecordMutation {
+  readonly id: string;
+}
+
+test("returns one explicit warning after the catalogue freshness boundary", async () => {
+  const snapshot = await loadCatalogueSnapshot(SOURCE_CATALOGUE, {
+    now: new Date("2026-11-20T00:00:00Z"),
+  });
+  assert.equal(snapshot.stale, true);
+  assert.match(snapshot.stalenessWarning ?? "", /governed snapshot, not current source authority/u);
+  assert.deepEqual(snapshot.warnings, [snapshot.stalenessWarning]);
+  assert.equal(Object.isFrozen(snapshot.warnings), true);
+});
+
+test("rejects checksum corruption", async () => {
+  await withCatalogueCopy(async (root) => {
+    const bundlePath = join(root, "okf-bundle.json");
+    await writeFile(bundlePath, Buffer.concat([await readFile(bundlePath), Buffer.from("\n")]));
+    await assert.rejects(loadCatalogueSnapshot(root), /checksum mismatch for okf-bundle\.json/u);
+  });
+});
+
+test("rejects both unexpected and missing inventory entries", async (t) => {
+  await t.test("unexpected file", async () => {
+    await withCatalogueCopy(async (root) => {
+      await writeFile(join(root, "unexpected.txt"), "not governed\n", "utf8");
+      await assert.rejects(loadCatalogueSnapshot(root), /missing or unexpected files/u);
+    });
+  });
+  await t.test("missing file", async () => {
+    await withCatalogueCopy(async (root) => {
+      await unlink(join(root, "index.md"));
+      await assert.rejects(loadCatalogueSnapshot(root), /missing or unexpected files/u);
+    });
+  });
+});
+
+test("streams and rejects an oversized single-directory inventory", async () => {
+  await withCatalogueCopy(async (root) => {
+    const oversizedDirectory = join(root, "oversized");
+    await mkdir(oversizedDirectory);
+    for (let index = 0; index < 1_100; index += 1) {
+      await mkdir(join(oversizedDirectory, `entry-${index.toString().padStart(4, "0")}`));
+    }
+
+    await assert.rejects(
+      loadCatalogueSnapshot(root),
+      /catalogue inventory exceeds 1000 directories/u,
+    );
+  });
+});
+
+test("rejects same-inode growth with an exact-length bounded read", async () => {
+  await withCatalogueCopy(async (root) => {
+    const markerPath = join(root, ".okf-generated");
+    const markerBefore = await stat(markerPath);
+    const markerSize = markerBefore.size;
+    const probe = await open(markerPath, "r");
+
+    type BoundedRead = (
+      this: { readonly fd: number },
+      buffer: Buffer,
+      offset: number,
+      length: number,
+      position: number,
+    ) => Promise<{ bytesRead: number; buffer: Buffer }>;
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as { read: BoundedRead };
+    const originalRead = fileHandlePrototype.read;
+    await probe.close();
+
+    let growthInjected = false;
+    let requestedLength: number | undefined;
+    let bufferLength: number | undefined;
+    fileHandlePrototype.read = async function (buffer, offset, length, position) {
+      if (!growthInjected) {
+        growthInjected = true;
+        requestedLength = length;
+        bufferLength = buffer.byteLength;
+        await truncate(markerPath, markerSize + 8 * 1024 * 1024);
+      }
+      return originalRead.call(this, buffer, offset, length, position);
+    };
+
+    try {
+      await assert.rejects(
+        loadCatalogueSnapshot(root),
+        /catalogue inventory changed while it was being verified/u,
+      );
+    } finally {
+      fileHandlePrototype.read = originalRead;
+    }
+
+    assert.equal(growthInjected, true);
+    assert.equal(requestedLength, markerSize + 1);
+    assert.equal(bufferLength, markerSize + 1);
+    const markerAfter = await stat(markerPath);
+    assert.equal(markerAfter.ino, markerBefore.ino);
+    assert.equal(markerAfter.size, markerSize + 8 * 1024 * 1024);
+  });
+});
+
+test("rejects symbolic links in the root path and inventory", async (t) => {
+  await t.test("root alias", async () => {
+    await withCatalogueCopy(async (root) => {
+      const alias = join(dirname(root), "catalogue-alias");
+      await symlink(root, alias, "dir");
+      await assert.rejects(
+        loadCatalogueSnapshot(alias),
+        /root and its ancestors must not be symbolic links/u,
+      );
+    });
+  });
+  await t.test("inventory entry", async () => {
+    await withCatalogueCopy(async (root) => {
+      const indexPath = join(root, "index.md");
+      await unlink(indexPath);
+      await symlink("THIRD_PARTY.md", indexPath, "file");
+      await assert.rejects(loadCatalogueSnapshot(root), /inventory contains a symbolic link/u);
+    });
+  });
+});
+
+test("rejects a checksum-valid receipt whose manifest cross-link is false", async () => {
+  await withCatalogueCopy(async (root) => {
+    const receiptPath = join(root, "build-receipt.json");
+    const receipt = JSON.parse(await readFile(receiptPath, "utf8")) as Record<string, unknown>;
+    receipt.manifestSha256 = "0".repeat(64);
+    await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+    await refreshLedgerDigest(root, "build-receipt.json");
+
+    await assert.rejects(
+      loadCatalogueSnapshot(root),
+      /manifestSha256 does not match manifest\.json/u,
+    );
+  });
+});

--- a/apps/mcp-gateway/test/cursor.test.ts
+++ b/apps/mcp-gateway/test/cursor.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  InvalidCatalogueCursorError,
+  canonicalJson,
+  decodeCatalogueCursor,
+  encodeCatalogueCursor,
+  sha256CanonicalJson,
+} from "../src/cursor.js";
+
+const ROOT = "a".repeat(64);
+const OTHER_ROOT = "b".repeat(64);
+const CRITERIA = sha256CanonicalJson({ facets: { tags: ["hmlr"] }, limit: 5, query: "land" });
+const OTHER_CRITERIA = sha256CanonicalJson({
+  facets: { tags: ["hmlr"] },
+  limit: 5,
+  query: "price",
+});
+
+test("canonical JSON and cursor encoding are independent of object insertion order", () => {
+  assert.equal(
+    canonicalJson({ z: [3, 2, 1], a: { right: true, left: null } }),
+    canonicalJson({ a: { left: null, right: true }, z: [3, 2, 1] }),
+  );
+
+  const binding = { contentRootSha256: ROOT, criteriaSha256: CRITERIA };
+  const first = encodeCatalogueCursor(binding, 5);
+  const second = encodeCatalogueCursor(binding, 5);
+  assert.equal(first, second);
+  assert.equal(first.includes("="), false);
+  assert.equal(
+    decodeCatalogueCursor(first, { ...binding, limit: 5 }),
+    5,
+  );
+});
+
+test("rejects corruption and replay against changed criteria or catalogue bytes", () => {
+  const token = encodeCatalogueCursor(
+    { contentRootSha256: ROOT, criteriaSha256: CRITERIA },
+    10,
+  );
+  const changedFinalCharacter = token.endsWith("0") ? "1" : "0";
+  const tampered = `${token.slice(0, -1)}${changedFinalCharacter}`;
+
+  assert.throws(
+    () =>
+      decodeCatalogueCursor(tampered, {
+        contentRootSha256: ROOT,
+        criteriaSha256: CRITERIA,
+        limit: 5,
+      }),
+    InvalidCatalogueCursorError,
+  );
+  assert.throws(
+    () =>
+      decodeCatalogueCursor(token, {
+        contentRootSha256: ROOT,
+        criteriaSha256: OTHER_CRITERIA,
+        limit: 5,
+      }),
+    /different search criteria/u,
+  );
+  assert.throws(
+    () =>
+      decodeCatalogueCursor(token, {
+        contentRootSha256: OTHER_ROOT,
+        criteriaSha256: CRITERIA,
+        limit: 5,
+      }),
+    /different catalogue revision/u,
+  );
+});
+
+test("rejects non-canonical payloads and offsets that are not page aligned", () => {
+  const nonCanonicalJson = JSON.stringify({
+    v: 1,
+    offset: 5,
+    criteria_sha256: CRITERIA,
+    content_root_sha256: ROOT,
+  });
+  const body = Buffer.from(nonCanonicalJson, "utf8").toString("base64url");
+  const digest = createHash("sha256").update(nonCanonicalJson, "utf8").digest("hex");
+  assert.throws(
+    () =>
+      decodeCatalogueCursor(`${body}.${digest}`, {
+        contentRootSha256: ROOT,
+        criteriaSha256: CRITERIA,
+        limit: 5,
+      }),
+    /not canonical JSON/u,
+  );
+
+  const misaligned = encodeCatalogueCursor(
+    { contentRootSha256: ROOT, criteriaSha256: CRITERIA },
+    7,
+  );
+  assert.throws(
+    () =>
+      decodeCatalogueCursor(misaligned, {
+        contentRootSha256: ROOT,
+        criteriaSha256: CRITERIA,
+        limit: 5,
+      }),
+    /not aligned/u,
+  );
+});
+
+test("rejects malformed tokens and invalid encoder inputs", () => {
+  const binding = { contentRootSha256: ROOT, criteriaSha256: CRITERIA, limit: 5 };
+  for (const token of ["", "not-a-cursor", "a.b.c", "=." + "0".repeat(64)]) {
+    assert.throws(() => decodeCatalogueCursor(token, binding), InvalidCatalogueCursorError);
+  }
+  assert.throws(
+    () => encodeCatalogueCursor({ contentRootSha256: ROOT, criteriaSha256: CRITERIA }, 0),
+    /positive safe integer/u,
+  );
+});

--- a/apps/mcp-gateway/test/http-app.test.ts
+++ b/apps/mcp-gateway/test/http-app.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CatalogueSnapshot } from "../src/catalogue-snapshot.js";
+import { createGatewayHttpHandler } from "../src/http-app.js";
+import { catalogueOpenApiDocument } from "../src/openapi.js";
+
+const snapshot = {
+  bundle: { records: [] },
+  recordsById: new Map(),
+  version: "0.1.0",
+  revision: "a".repeat(40),
+  contentRootSha256: "b".repeat(64),
+  manifestSha256: "c".repeat(64),
+  recordCount: 36,
+  stale: false,
+  warnings: Object.freeze([]),
+  root: "/verified/catalogue",
+} as unknown as CatalogueSnapshot;
+
+const handle = createGatewayHttpHandler({
+  snapshot,
+  createTraceId: () => "d".repeat(32),
+});
+
+function request(path: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers);
+  if (!headers.has("host")) headers.set("host", "127.0.0.1:8787");
+  return new Request(`http://127.0.0.1:8787${path}`, { ...init, headers });
+}
+
+test("reports verified catalogue health without activating operations", async () => {
+  const response = await handle(request("/healthz"));
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.deepEqual(await response.json(), {
+    status: "ok",
+    product: "GIS AI GO",
+    lifecycle: "candidate-blocked",
+    catalogue: {
+      version: "0.1.0",
+      revision: "a".repeat(40),
+      content_root_sha256: "b".repeat(64),
+      record_count: 36,
+      stale: false,
+      warnings: [],
+    },
+  });
+});
+
+test("readiness is deliberately blocked with zero active operations", async () => {
+  const response = await handle(request("/readyz"));
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), {
+    status: "blocked",
+    reason: "inline-evidence-and-public-policy-unavailable",
+    active_tools: [],
+    active_api_operations: [],
+  });
+});
+
+test("serves an OpenAPI candidate with no catalogue operation paths", async () => {
+  const response = await handle(request("/openapi.json"));
+  assert.equal(response.status, 200);
+  const document = (await response.json()) as { paths: Record<string, unknown> };
+  assert.deepEqual(Object.keys(document.paths).sort(), ["/healthz", "/openapi.json", "/readyz"]);
+  assert.equal("/catalogue/search" in document.paths, false);
+  assert.equal("/catalogue/describe" in document.paths, false);
+  assert.equal(Object.isFrozen(catalogueOpenApiDocument), true);
+  assert.equal(Object.isFrozen(catalogueOpenApiDocument.paths), true);
+});
+
+test("rejects unrecognised hosts and cross-origin requests", async () => {
+  const badHost = await handle(
+    request("/healthz", { headers: { host: "attacker.invalid" } }),
+  );
+  assert.equal(badHost.status, 400);
+  const badOrigin = await handle(
+    request("/healthz", { headers: { origin: "https://attacker.invalid" } }),
+  );
+  assert.equal(badOrigin.status, 400);
+  assert.equal(badOrigin.headers.get("access-control-allow-origin"), null);
+});
+
+test("rejects methods, query strings, unknown routes and unacceptable media", async () => {
+  for (const candidate of [
+    request("/healthz", { method: "POST" }),
+    request("/healthz?verbose=true"),
+    request("/catalogue/search"),
+    request("/healthz", { headers: { accept: "text/html" } }),
+  ]) {
+    const response = await handle(candidate);
+    assert.ok(response.status >= 400);
+    assert.equal(response.headers.get("content-type"), "application/problem+json; charset=utf-8");
+    const problem = (await response.json()) as Record<string, unknown>;
+    assert.equal(problem.schema, "gis-ai-go.catalogue-problem.v1");
+    assert.equal(problem.trace_id, "d".repeat(32));
+  }
+});
+
+test("rejects non-canonical request paths without escaping the problem envelope", async () => {
+  for (const path of ["/%41", "/%2f", "/%ZZ"]) {
+    const response = await handle(request(path));
+    assert.equal(response.status, 400);
+    assert.equal(response.headers.get("content-type"), "application/problem+json; charset=utf-8");
+    const problem = (await response.json()) as Record<string, unknown>;
+    assert.equal(problem.schema, "gis-ai-go.catalogue-problem.v1");
+    assert.equal(problem.code, "invalid_request");
+    assert.equal(problem.trace_id, "d".repeat(32));
+    assert.equal("instance" in problem, false);
+  }
+
+  const canonical = await handle(request("/unknown"));
+  assert.equal((await canonical.json() as Record<string, unknown>).instance, "/unknown");
+});
+
+test("accepts a bounded request identifier without reflecting an invalid one", async () => {
+  const accepted = await handle(
+    request("/unknown", { headers: { "x-request-id": "caller-request:42" } }),
+  );
+  assert.equal((await accepted.json() as Record<string, unknown>).request_id, "caller-request:42");
+
+  const rejected = await handle(
+    request("/unknown", { headers: { "x-request-id": "bad request id" } }),
+  );
+  assert.match(
+    (await rejected.json() as Record<string, unknown>).request_id as string,
+    /^[0-9a-f]{32}$/u,
+  );
+});

--- a/apps/mcp-gateway/test/http-server.test.ts
+++ b/apps/mcp-gateway/test/http-server.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { request as nodeRequest } from "node:http";
+import test from "node:test";
+
+import type { CatalogueSnapshot } from "../src/catalogue-snapshot.js";
+import { createGatewayNodeServer } from "../src/http-server.js";
+
+const snapshot = {
+  bundle: { records: [] },
+  recordsById: new Map(),
+  version: "0.1.0",
+  revision: "a".repeat(40),
+  contentRootSha256: "b".repeat(64),
+  manifestSha256: "c".repeat(64),
+  recordCount: 36,
+  stale: false,
+  warnings: Object.freeze([]),
+  root: "/verified/catalogue",
+} as unknown as CatalogueSnapshot;
+
+interface ReceivedResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string | string[] | undefined>>;
+  readonly body: string;
+}
+
+test("the bounded Node adapter serves health and rejects request bodies", async () => {
+  const server = createGatewayNodeServer(snapshot);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  assert.ok(address !== null && typeof address === "object");
+
+  const send = (
+    method: string,
+    body?: string,
+    path = "/healthz",
+  ): Promise<ReceivedResponse> =>
+    new Promise((resolve, reject) => {
+      const request = nodeRequest(
+        {
+          hostname: "127.0.0.1",
+          port: address.port,
+          path,
+          method,
+          headers: {
+            accept: "application/json",
+            host: "127.0.0.1:8787",
+            ...(body === undefined ? {} : { "content-length": Buffer.byteLength(body) }),
+          },
+        },
+        (response) => {
+          const chunks: Buffer[] = [];
+          response.on("data", (chunk: Buffer) => chunks.push(chunk));
+          response.on("end", () => {
+            resolve({
+              status: response.statusCode ?? 0,
+              headers: response.headers,
+              body: Buffer.concat(chunks).toString("utf8"),
+            });
+          });
+        },
+      );
+      request.once("error", reject);
+      request.end(body);
+    });
+
+  try {
+    const health = await send("GET");
+    assert.equal(health.status, 200);
+    assert.equal(health.headers["cache-control"], "no-store");
+    assert.equal(JSON.parse(health.body).lifecycle, "candidate-blocked");
+
+    const bodyRejected = await send("POST", "{}");
+    assert.equal(bodyRejected.status, 400);
+    assert.equal(bodyRejected.body, "");
+
+    const absoluteTargetRejected = await send(
+      "GET",
+      undefined,
+      "http://attacker.invalid/healthz",
+    );
+    assert.equal(absoluteTargetRejected.status, 400);
+
+    const nonCanonicalPath = await send("GET", undefined, "/%41");
+    assert.equal(nonCanonicalPath.status, 400);
+    assert.equal(
+      nonCanonicalPath.headers["content-type"],
+      "application/problem+json; charset=utf-8",
+    );
+    assert.equal(JSON.parse(nonCanonicalPath.body).code, "invalid_request");
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error === undefined ? resolve() : reject(error));
+    });
+  }
+});

--- a/apps/mcp-gateway/test/index.test.ts
+++ b/apps/mcp-gateway/test/index.test.ts
@@ -1,29 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { assertStageZeroRequest, gatewayMetadata } from "../src/index.js";
+import { catalogueActivation, gatewayMetadata } from "../src/index.js";
 
-test("publishes the agreed non-networked identity", () => {
+test("publishes the agreed inactive gateway identity", () => {
   assert.equal(gatewayMetadata.product, "GIS AI GO");
   assert.equal(gatewayMetadata.registryId, "io.github.chris-page-gov/gis-ai-go");
+  assert.equal(gatewayMetadata.protocolTarget, "2026-07-28");
   assert.equal(gatewayMetadata.liveProviderCalls, false);
+  assert.equal(gatewayMetadata.lifecycle, "candidate-blocked");
 });
 
-test("rejects non-synthetic work", () => {
-  assert.throws(
-    () => assertStageZeroRequest({ synthetic: false, networkAccess: false }),
-    /synthetic requests only/,
-  );
-});
-
-test("rejects network access", () => {
-  assert.throws(
-    () => assertStageZeroRequest({ synthetic: true, networkAccess: true }),
-    /forbids network/,
-  );
-});
-
-test("accepts an offline synthetic validation request", () => {
-  const result = assertStageZeroRequest({ synthetic: true, networkAccess: false });
-  assert.equal(result.stage, 0);
+test("has no activation or environment-variable escape hatch", () => {
+  assert.deepEqual(catalogueActivation, {
+    state: "blocked",
+    reason: "inline-evidence-and-public-policy-unavailable",
+    activeTools: [],
+    activeApiOperations: [],
+  });
+  assert.equal(Object.isFrozen(catalogueActivation), true);
+  assert.deepEqual(gatewayMetadata.activeTools, []);
+  assert.deepEqual(gatewayMetadata.activeApiOperations, []);
 });

--- a/apps/mcp-gateway/tsconfig.json
+++ b/apps/mcp-gateway/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "resolveJsonModule": true,
     "rootDir": "."
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["openapi/**/*.json", "src/**/*.ts", "test/**/*.ts"]
 }

--- a/changelog.d/MCP-201.gateway.changed.md
+++ b/changelog.d/MCP-201.gateway.changed.md
@@ -1,0 +1,4 @@
+- Added a fail-closed, checksum-verified catalogue loader and deterministic
+  search/describe application behind a loopback-only gateway candidate whose
+  readiness, MCP tools and catalogue API operations remain hard-blocked pending
+  reviewed public policy and inline evidence receipts.

--- a/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
+++ b/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
@@ -22,8 +22,11 @@ application code is not evidence of an active tool or API operation.
 The checksum-verified catalogue loader:
 
 - accepts an absolute, canonical directory only and follows no symbolic link;
-- bounds the number of files and directories, total bytes, individual control
-  files and relative path lengths;
+- streams directory entries so file and directory limits apply before a complete
+  listing is materialised;
+- bounds total bytes, individual control files and relative path lengths, reads no
+  more than the recorded file length plus one byte, and rechecks the same file's
+  identity and metadata after reading;
 - requires the generated marker and an exact checksum-ledger match for the complete
   inventory;
 - verifies every payload digest and cross-checks the manifest, build receipt,
@@ -39,6 +42,8 @@ The transport-neutral application implements deterministic in-process
 
 - closed request, result and problem envelopes;
 - bounded Unicode query analysis, facet arrays, page sizes, cursors and record IDs;
+- fail-closed validation that every snapshot can fit the narrower public result
+  schema without truncation or semantic reinterpretation;
 - stable sorting and catalogue-native source relationships; and
 - opaque deterministic cursors bound to the exact catalogue content root and
   normalised search criteria.
@@ -59,7 +64,8 @@ The local candidate binds to `127.0.0.1:8787` only. Its complete surface is:
 The listener accepts only explicit loopback Host and same-origin Origin values,
 does not emit wildcard cross-origin permissions, rejects request bodies and applies
 bounded URL, header, request and keep-alive settings. The OpenAPI document contains
-no catalogue operation path.
+no catalogue operation path. Malformed or non-canonical paths remain bounded
+problem responses and are never reflected as invalid problem identities.
 
 ## Capabilities that do not exist
 
@@ -89,4 +95,5 @@ interoperability. Only that reviewed change may replace the block and advertise 
 catalogue capability.
 
 See the [verification record](MCP-201_VERIFICATION.md) for the distinction between
-protected-main evidence and pending local-candidate evidence.
+protected-main shared-contract evidence, accepted local candidate evidence and
+pending remote candidate evidence.

--- a/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
+++ b/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
@@ -1,0 +1,92 @@
+# MCP-201 inactive gateway candidate
+
+- status: local candidate; activation and publication blocked
+- work item: [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19)
+- protected-main base: `e5e6d4db5ac7036198cde64279e815f214f3defd`
+- supported public product: immutable
+  [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+- activation block: `inline-evidence-and-public-policy-unavailable`
+
+## Purpose
+
+This slice establishes the smallest fail-closed application and process boundary
+needed before introducing an MCP transport or catalogue API. It can verify and load
+the canonical public catalogue, execute deterministic search and description in
+process, and report that the gateway is deliberately not ready.
+
+It does not make either catalogue operation available to a client. The presence of
+application code is not evidence of an active tool or API operation.
+
+## Candidate boundary
+
+The checksum-verified catalogue loader:
+
+- accepts an absolute, canonical directory only and follows no symbolic link;
+- bounds the number of files and directories, total bytes, individual control
+  files and relative path lengths;
+- requires the generated marker and an exact checksum-ledger match for the complete
+  inventory;
+- verifies every payload digest and cross-checks the manifest, build receipt,
+  content root, record order and public discovery bundle identity; and
+- rejects the complete load on any ambiguity, returning no partial catalogue.
+
+The resulting catalogue and record index are immutable for the life of the
+application. Staleness is reported as a warning: the candidate does not silently
+represent a governed snapshot as current source authority.
+
+The transport-neutral application implements deterministic in-process
+`catalogue.search` and `catalogue.describe` functions. It uses:
+
+- closed request, result and problem envelopes;
+- bounded Unicode query analysis, facet arrays, page sizes, cursors and record IDs;
+- stable sorting and catalogue-native source relationships; and
+- opaque deterministic cursors bound to the exact catalogue content root and
+  normalised search criteria.
+
+Cursor digests detect corruption and misuse across catalogue or query boundaries.
+They are not an authentication mechanism and convey no authority.
+
+## HTTP surface
+
+The local candidate binds to `127.0.0.1:8787` only. Its complete surface is:
+
+| Method and path | Status | Meaning |
+| --- | ---: | --- |
+| `GET /healthz` | `200` | The process has loaded a verified catalogue snapshot. |
+| `GET /readyz` | `503` | Activation is blocked; active tool and API lists are empty. |
+| `GET /openapi.json` | `200` | The exact inactive-candidate contract. |
+
+The listener accepts only explicit loopback Host and same-origin Origin values,
+does not emit wildcard cross-origin permissions, rejects request bodies and applies
+bounded URL, header, request and keep-alive settings. The OpenAPI document contains
+no catalogue operation path.
+
+## Capabilities that do not exist
+
+This candidate has no:
+
+- HTTP search or description route;
+- MCP listener, discovery response or tool registration;
+- public deployment, public service URL or registry entry;
+- provider adapter or provider network call;
+- public policy decision point, identity integration or rate service; or
+- canonical evidence store or reviewed inline result receipt.
+
+The static Explorer remains the only supported public product. It does not depend
+on this process.
+
+## Activation gate
+
+The production activation value is frozen with zero active MCP tools and zero
+active direct-API operations. It has no environment-variable, command-line or test
+escape hatch.
+
+EVID-204 must provide reviewed public policy decisions and canonical inline
+evidence receipts on the shared application path. A later pull request must then
+add and verify the protocol-conformant MCP listener, direct catalogue routes,
+matching lifecycle discovery, malicious-input controls and client
+interoperability. Only that reviewed change may replace the block and advertise a
+catalogue capability.
+
+See the [verification record](MCP-201_VERIFICATION.md) for the distinction between
+protected-main evidence and pending local-candidate evidence.

--- a/docs/operations/MCP-201_VERIFICATION.md
+++ b/docs/operations/MCP-201_VERIFICATION.md
@@ -88,7 +88,7 @@ listed above completed this slice's remote gate.
 - complete local gate: passing at the candidate implementation commit on
   20 August 2026
 - independent current-byte review: `SHIP`; no P0, P1 or P2 finding
-- pull request: `local-candidate/pending`
+- pull request: [27](https://github.com/chris-page-gov/gis-ai-go/pull/27)
 - pull-request assurance and provenance: `local-candidate/pending`
 - pull-request CodeQL: `local-candidate/pending`
 - protected-main merge and post-merge evidence: `local-candidate/pending`
@@ -151,8 +151,8 @@ commit; the repaired current bytes then received an independent `SHIP` review an
 passed all 38 gateway tests. This does not claim that the absent public service has
 been security-tested as a deployed service.
 
-The pull request, remote CodeQL, protected-main merge and post-merge evidence remain
-deliberately `local-candidate/pending` until they exist.
+Pull-request assurance, remote CodeQL, protected-main merge and post-merge evidence
+remain deliberately `local-candidate/pending` until they exist.
 
 ## Activation and publication boundary
 

--- a/docs/operations/MCP-201_VERIFICATION.md
+++ b/docs/operations/MCP-201_VERIFICATION.md
@@ -1,9 +1,12 @@
-# MCP-201 shared catalogue contract verification record
+# MCP-201 verification record
 
-- status: pull-request implementation and security gates passed; protected-main
-  verification pending
+- status: shared catalogue contract verified on protected `main`; inactive local
+  gateway candidate verification pending
 - reviewed on: 20 August 2026
 - work item: [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19)
+
+## Protected-main shared catalogue contract
+
 - protected-main base: `80ac89d89e04751045693cecff4a3a714d121ebe`
 - candidate implementation commit: `5150cc25a56fb4263f4f6ec832f8995ad2a9d4c9`
 - security remediation commit: `2e6094e4c81d0cb60fa19e5cf0a4f6dc4ae30082`
@@ -12,23 +15,28 @@
   [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338159020)
 - pull-request CodeQL:
   [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338156959)
-- protected-main merge and post-merge assurance: pending
+- protected-main merge: `e5e6d4db5ac7036198cde64279e815f214f3defd`
+- protected-main assurance and provenance:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916345)
+- protected-main CodeQL:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916269)
+- protected-main provenance:
+  [attestation 41792357](https://github.com/chris-page-gov/gis-ai-go/attestations/41792357)
 
-## Outcome
+### Outcome
 
-This first MCP-201 slice establishes a shared catalogue contract over the existing
+The protected-main slice establishes a shared catalogue contract over the existing
 checksum-verified public catalogue. The Explorer adopts that shared core through
-thin compatibility adapters, while the candidate request and result schemas define
-a bounded foundation for later read-only catalogue delivery.
+thin compatibility adapters, while closed request, result and problem schemas
+define a bounded foundation for later read-only catalogue delivery.
 
-This candidate does not provide an MCP listener, direct API, provider adapter,
-execution path or evidence store. `catalogue.search` and `catalogue.describe` are
-not registered, advertised or active. EVID-204 must add and review canonical inline
-evidence before either tool can be activated; the candidate result schema therefore
-rejects an opaque evidence reference rather than implying persistence or
-attestation that does not exist.
+It does not provide an MCP listener, catalogue API, provider adapter, execution
+path or evidence store. `catalogue.search` and `catalogue.describe` are not
+registered, advertised or active. Its candidate result schema rejects an opaque
+evidence reference rather than implying persistence or attestation that does not
+exist.
 
-## Candidate scope
+### Contract scope
 
 - the catalogue parser, search, facet, graph, timeline and link helpers are owned by
   the shared contracts package and consumed by the existing Explorer;
@@ -39,9 +47,9 @@ attestation that does not exist.
 - repository contract validation checks every schema against JSON Schema Draft
   2020-12 and the GIS AI GO URN namespace.
 
-## Complete local candidate evidence
+### Accepted evidence
 
-The current working-tree bytes passed the complete locked `pnpm run check` on
+The exact pull-request candidate passed the complete locked `pnpm run check` on
 20 August 2026. The gate included:
 
 - 19 of 19 shared catalogue contract tests;
@@ -60,27 +68,66 @@ The current working-tree bytes passed the complete locked `pnpm run check` on
 - a 461-file baseline secret and machine-path scan, 9 rendered diagrams and a
   146-component CycloneDX SBOM;
 - the Explorer production build and built ESM contracts-package runtime import;
-- confirmation that the immutable research tree is unchanged from the protected-main
-  base; and
+- confirmation that the immutable research tree was unchanged from its
+  protected-main base; and
 - an independent current-byte review with a `SHIP` verdict and no P0, P1 or P2
   finding.
 
 The first pull-request CodeQL run identified a high-severity polynomial regular
 expression in the inherited HTML-like-content guard. The issue was reproduced on
 the real parser path, replaced by a linear-time scanner and covered by adversarial
-and legitimate controls. The exact remediation commit passed the complete local
-gate, pull-request assurance, all three CodeQL language analyses and the aggregate
-"No new alerts" check; the original alert is closed as fixed and the repository has
-no open code-scanning alert.
+and legitimate controls. The remediation commit passed the complete local gate,
+pull-request assurance, all three CodeQL language analyses and the aggregate
+"No new alerts" check. The protected-main assurance, CodeQL and provenance evidence
+listed above completed this slice's remote gate.
 
-These local results do not replace pull-request checks, CodeQL, protected-main
-merge or post-merge assurance. Those remote evidence gates remain pending and must
-pass before this record can be promoted from a local candidate.
+## Inactive gateway candidate
+
+- protected-main base: `e5e6d4db5ac7036198cde64279e815f214f3defd`
+- candidate implementation commit: `local-candidate/pending`
+- complete local gate: `local-candidate/pending`
+- independent current-byte review: `local-candidate/pending`
+- pull request: `local-candidate/pending`
+- pull-request assurance and provenance: `local-candidate/pending`
+- pull-request CodeQL: `local-candidate/pending`
+- protected-main merge and post-merge evidence: `local-candidate/pending`
+
+### Candidate outcome
+
+The current local bytes add a fail-closed, checksum-verified immutable catalogue
+loader and a deterministic, transport-neutral application for
+`catalogue.search` and `catalogue.describe`. The functions use closed envelopes,
+bounded inputs and deterministic cursors bound to the exact catalogue content root
+and normalised search criteria.
+
+The HTTP candidate binds to loopback and exposes only:
+
+- `GET /healthz` for process and verified-catalogue health;
+- `GET /readyz`, which always returns `503` with empty active tool and API lists;
+  and
+- `GET /openapi.json`, whose contract contains no catalogue operation path.
+
+There is no search or description route, MCP listener or tool registration, public
+deployment, provider call, policy engine or evidence store. The application code
+can be tested directly, but it cannot be activated through an environment variable,
+command-line option or test mode.
+
+These implementation facts are not verification evidence. The candidate commit,
+complete local gate, independent review, pull request, CodeQL and protected-main
+evidence remain deliberately recorded as `local-candidate/pending` until they
+exist. No test count or remote result is asserted for this candidate yet.
 
 ## Activation and publication boundary
 
-No service or new public endpoint is published by this slice. The supported public
-product remains the static `v0.1.0` Explorer. A later MCP-201 slice must implement
-and test the listener and direct API, while EVID-204 must supply reviewed inline
-evidence. Tool advertisement and activation can follow only after those controls
-and the applicable security and interoperability gates pass.
+No service or new public endpoint is published by either slice. The supported
+public product remains the static `v0.1.0` Explorer.
+
+Activation is hard-blocked as
+`inline-evidence-and-public-policy-unavailable`. EVID-204 must add reviewed public
+policy decisions and canonical inline result receipts to the shared application
+path. A later reviewed MCP-201 change must add and test the protocol-conformant MCP
+listener, direct catalogue routes, lifecycle agreement and interoperability before
+either operation can be advertised or published.
+
+The durable candidate boundary is documented in
+[MCP-201 inactive gateway candidate](MCP-201_GATEWAY_CANDIDATE.md).

--- a/docs/operations/MCP-201_VERIFICATION.md
+++ b/docs/operations/MCP-201_VERIFICATION.md
@@ -1,7 +1,7 @@
 # MCP-201 verification record
 
-- status: shared catalogue contract verified on protected `main`; inactive local
-  gateway candidate verification pending
+- status: shared catalogue contract verified on protected `main`; inactive gateway
+  candidate verified locally with pull-request evidence pending
 - reviewed on: 20 August 2026
 - work item: [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19)
 
@@ -84,9 +84,10 @@ listed above completed this slice's remote gate.
 ## Inactive gateway candidate
 
 - protected-main base: `e5e6d4db5ac7036198cde64279e815f214f3defd`
-- candidate implementation commit: `local-candidate/pending`
-- complete local gate: `local-candidate/pending`
-- independent current-byte review: `local-candidate/pending`
+- candidate implementation commit: `442f788108106744e1e2ed7283e38c2a22aac5f1`
+- complete local gate: passing at the candidate implementation commit on
+  20 August 2026
+- independent current-byte review: `SHIP`; no P0, P1 or P2 finding
 - pull request: `local-candidate/pending`
 - pull-request assurance and provenance: `local-candidate/pending`
 - pull-request CodeQL: `local-candidate/pending`
@@ -97,8 +98,11 @@ listed above completed this slice's remote gate.
 The current local bytes add a fail-closed, checksum-verified immutable catalogue
 loader and a deterministic, transport-neutral application for
 `catalogue.search` and `catalogue.describe`. The functions use closed envelopes,
-bounded inputs and deterministic cursors bound to the exact catalogue content root
-and normalised search criteria.
+bounded inputs and outputs, and deterministic cursors bound to the exact catalogue
+content root and normalised search criteria. The loader streams its bounded
+inventory, reads only the recorded file length plus one byte and rechecks file
+identity and metadata after each read. The application rejects any verified
+snapshot that cannot fit the closed result schema.
 
 The HTTP candidate binds to loopback and exposes only:
 
@@ -112,10 +116,43 @@ deployment, provider call, policy engine or evidence store. The application code
 can be tested directly, but it cannot be activated through an environment variable,
 command-line option or test mode.
 
-These implementation facts are not verification evidence. The candidate commit,
-complete local gate, independent review, pull request, CodeQL and protected-main
-evidence remain deliberately recorded as `local-candidate/pending` until they
-exist. No test count or remote result is asserted for this candidate yet.
+Malformed request identities, hostile unknown keys and non-canonical URL paths fail
+through bounded problem envelopes rather than escaping as raw server errors. The
+exact regression suite covers schema-boundary overflow, same-inode file growth,
+over-limit directory inventories and malformed path encodings.
+
+### Accepted local evidence
+
+The exact candidate implementation commit passed the complete locked
+`pnpm run check` gate on 20 August 2026. The gate included:
+
+- 19 of 19 shared catalogue contract tests and 38 of 38 gateway tests;
+- 16 of 16 Explorer build-policy tests, 42 of 42 Explorer unit and component
+  tests and 27 of 27 real-browser tests;
+- 88 of 88 repository Python tests and 2 of 2 execution-boundary tests;
+- two clean locked builds with byte-identical Pages archives
+  (`99586ce3156255c0c5942d6eca8d1f004581123d86f4e19153e6cbaac774c6c4`),
+  checksum files and archive receipts;
+- validation of version `0.1.0` across 8 manifests and locks, 12 schemas and
+  53 evaluation records;
+- 305 local Markdown links, 183 immutable research hashes, 2 ledger snapshots and
+  71 source identifiers;
+- a 479-file baseline secret and machine-path scan, 9 rendered diagrams and a
+  146-component CycloneDX SBOM; and
+- deterministic OKF content root
+  `57bfb5a190424289ea09b7eb0729ecdad08292ec7cb8abed148ddf29c9f975d1`,
+  with the immutable research tree unchanged from protected `main`.
+
+The formal pre-remediation security diff scan covered all 14 changed runtime
+surfaces and found no security-reportable issue under the inactive, loopback-only
+and operator-write-only boundary. It also validated five merge-blocking contract
+and resource-bound defects. Those defects were fixed before the implementation
+commit; the repaired current bytes then received an independent `SHIP` review and
+passed all 38 gateway tests. This does not claim that the absent public service has
+been security-tested as a deployed service.
+
+The pull request, remote CodeQL, protected-main merge and post-merge evidence remain
+deliberately `local-candidate/pending` until they exist.
 
 ## Activation and publication boundary
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,7 +5,8 @@ as historical evidence. Current authority and status are in [`CONTEXT.md`](../..
 and [`PROGRESS.md`](../../PROGRESS.md); ADR-0004 records progression beyond the local
 pause. The static Explorer is the supported
 [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
-public discovery product. No MCP service exists.
+public discovery product. An inactive local gateway candidate exists, but no public
+MCP service or catalogue API exists.
 
 - [Stage 0 boundary](STAGE_0_BOUNDARY.md)
 - [Dependency baseline](DEPENDENCIES.md)
@@ -16,4 +17,5 @@ public discovery product. No MCP service exists.
 - [DISC-104 GitHub Pages verification record](DISC-104_VERIFICATION.md)
 - [QUAL-105 release-assurance verification record](QUAL-105_VERIFICATION.md)
 - [`v0.1.0` supported-release evidence](V0.1.0_RELEASE_EVIDENCE.md)
-- [MCP-201 shared catalogue contract verification record](MCP-201_VERIFICATION.md)
+- [MCP-201 inactive gateway candidate boundary](MCP-201_GATEWAY_CANDIDATE.md)
+- [MCP-201 verification record](MCP-201_VERIFICATION.md)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/mcp-gateway:
     dependencies:
+      '@gis-ai-go/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0


### PR DESCRIPTION
## Summary

- add a checksum-verified, immutable catalogue snapshot loader with streamed inventory and bounded file reads
- add deterministic transport-neutral `catalogue.search` and `catalogue.describe` application functions, closed problems and content-bound cursors
- add a loopback-only diagnostic process exposing health, blocked readiness and OpenAPI with no catalogue route or MCP tool
- keep activation hard-blocked until EVID-204 supplies reviewed public policy and canonical inline evidence

## Publication boundary

This is an inactive candidate only. It advertises zero tools and zero direct API operations, has no MCP listener, provider call, evidence store or public deployment, and does not change the supported static `v0.1.0` product.

## Verification

- complete locked `pnpm run check` passed at implementation commit `442f788108106744e1e2ed7283e38c2a22aac5f1`
- 19 shared-contract, 38 gateway, 16 Explorer build-policy, 42 Explorer unit/component, 88 repository Python, 2 execution-boundary and 27 browser tests passed
- two clean builds produced byte-identical Pages archives
- five independent contract/resource-bound review findings were fixed; current-byte reviews returned SHIP with no P0-P2 findings
- link, version, secret/path, schema, SBOM, diagram, production-build and immutable-research gates passed

Refs #19
