### PR TITLE
feat(evidence): add canonical public inline receipts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,10 +84,12 @@ checksum-verified catalogue loader and deterministic transport-neutral
 `catalogue.search`/`catalogue.describe` application. Its loopback listener exposes
 only health, deliberately blocked readiness and its OpenAPI contract. It exposes
 no catalogue route, starts no MCP listener, registers no tool and is not publicly
-deployed. EVID-204 is now the active prerequisite: it must add server-constructed
-anonymous-open policy decisions and canonical inline receipts that state they are
-not persisted and not attested. There is still no live provider adapter, policy
-engine, identity integration or evidence store.
+deployed. The local EVID-204A candidate adds server-constructed anonymous-open
+policy decisions and canonical inline receipts that state they are not persisted
+and not attested, without changing that activation boundary. Its complete locked
+local gate passes; protected pull-request and main evidence remain pending. There
+is still no live provider adapter, external policy service, identity integration or
+evidence store.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -104,12 +104,15 @@ The supported target active set is exactly `catalogue.search`,
   all CodeQL language analyses and an independent no-P0-P2 review; and
 - the candidate verifies the immutable catalogue, supplies deterministic bounded
   in-process search and description, and exposes only loopback health, blocked
-  readiness and OpenAPI with zero active tools or API operations.
+  readiness and OpenAPI with zero active tools or API operations; and
+- the local EVID-204A candidate adds RFC 8785 canonicalisation, content-addressed
+  anonymous-open authority and policy decisions, and independently verified inline
+  receipts to every in-process catalogue success while keeping activation blocked.
 
 ## Next
 
-1. Add the bounded EVID-204 anonymous-open public policy and canonical inline receipt
-   slice while keeping readiness blocked and persistence absent.
+1. Complete independent review and the protected pull-request gate for the bounded
+   EVID-204A inline-evidence candidate.
 2. Add and verify the protocol-conformant MCP listener and direct catalogue routes,
    then activate `catalogue.search` and `catalogue.describe` only when their full
    policy, evidence, lifecycle and interoperability gates pass.
@@ -118,9 +121,9 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Current blockers
 
-- No blocker is known for the bounded EVID-204 inline-evidence slice.
-- Activating or publishing a catalogue service is hard-blocked until EVID-204 adds
-  reviewed public policy and canonical inline evidence receipts. The current
+- No blocker is known for the bounded EVID-204A pull-request gate.
+- Activating or publishing a catalogue service remains hard-blocked until transport
+  conformance and interoperability are implemented and reviewed. The current
   candidate has no activation override.
 - The candidate has no MCP listener, catalogue API operation, provider adapter or
   evidence store; those remain implementation work, not implied capabilities.
@@ -146,8 +149,19 @@ The supported target active set is exactly `catalogue.search`,
   [run 32344358198](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32344358198),
   then merged as `4948890c10adb4f0ac6f427cda21cb0c0c4607dd`; the candidate exposes no
   catalogue operation, MCP tool or public deployment;
-- current complete local gate: type checking, 38 gateway tests, 16 Explorer
-  build-policy tests, 42 Explorer unit and component tests, 88 repository Python
+- EVID-204A local candidate: 19 shared-contract tests, 20 canonical-evidence tests,
+  2 authority-context tests, 6 public-policy tests and 41 gateway tests pass; all
+  94 repository Python tests, 2 execution-boundary tests, 16 Explorer build-policy
+  tests, 42 Explorer unit and component tests and 27 real-browser tests also pass;
+  the gate validates 11 manifests and locks, 15 schemas and 55 records, 308 local
+  links, 183 immutable research hashes, 2 ledgers and 71 source identifiers, scans
+  508 text files, renders 9 diagrams and emits a 149-component SBOM;
+- EVID-204A reproducibility: two clean locked builds produced the same Pages archive
+  SHA-256 `f6adb7998c26bef62a651ec825e3a4426d955af4a09167b264dfa221d0ef28b0`;
+  the OKF content root is
+  `157ccef25e03043b69bf1f2be180b4b0242b5056c17edcfcd15acbd94c6e2007`;
+- current complete local gate: type checking, 41 gateway tests, 16 Explorer
+  build-policy tests, 42 Explorer unit and component tests, 94 repository Python
   tests, 2 execution-boundary tests and 27 real-browser tests pass;
 - QUAL-105 reproducibility: two complete clean locked builds produce byte-identical
   Pages archives, checksums and receipts; the public workflow now emits a mandatory

--- a/apps/mcp-gateway/README.md
+++ b/apps/mcp-gateway/README.md
@@ -17,7 +17,11 @@ It is an implementation workbench, not a supported or deployed service.
   use closed request, result and problem envelopes, bounded inputs and outputs, and
   cursors bound to both the catalogue content root and normalised search criteria.
   A snapshot that cannot fit the public result schema is rejected rather than
-  truncated.
+  truncated. Every successful result follows one evidence-producing path through
+  the server-owned anonymous-open authority context and checked-in default-deny
+  public policy. Its canonical inline receipt binds the exact catalogue, normalised
+  parameter digest, result core, gateway revision and record-specific licence
+  evidence while stating `not-persisted` and `not-attested`.
 - the HTTP candidate listens only on `127.0.0.1:8787` and exposes `GET /healthz`,
   `GET /readyz` and `GET /openapi.json`. Readiness always returns `503` with zero
   active tools and zero active API operations.
@@ -29,13 +33,15 @@ authority.
 
 The application functions are not mounted on HTTP routes. There is no
 `catalogue.search` or `catalogue.describe` endpoint, MCP listener, MCP tool
-registration, public deployment, provider call, policy engine or evidence store.
+registration, public deployment, provider call, external policy service or evidence
+store.
 There is no environment-variable or command-line activation override.
 
 Activation remains hard-blocked as
-`inline-evidence-and-public-policy-unavailable`. EVID-204 must add reviewed public
-policy decisions and canonical inline evidence receipts before a later reviewed
-change may mount or advertise either operation.
+`transport-and-interoperability-unverified`. A later reviewed change must add and
+verify the protocol-conformant transports and client interoperability before it may
+mount or advertise either operation. The compiled public document is not OPA,
+authentication, identity or an enterprise entitlement service.
 
 ## Local verification
 
@@ -55,4 +61,4 @@ pnpm --filter @gis-ai-go/mcp-gateway run start:http
 ```
 
 See the [candidate boundary](../../docs/operations/MCP-201_GATEWAY_CANDIDATE.md)
-and [verification record](../../docs/operations/MCP-201_VERIFICATION.md).
+and [EVID-204 inline-evidence boundary](../../docs/operations/EVID-204_INLINE_EVIDENCE.md).

--- a/apps/mcp-gateway/openapi/catalogue-api.openapi.json
+++ b/apps/mcp-gateway/openapi/catalogue-api.openapi.json
@@ -15,7 +15,7 @@
   "security": [],
   "x-gis-ai-go-lifecycle": "candidate-blocked",
   "x-gis-ai-go-active-catalogue-operations": [],
-  "x-gis-ai-go-blocked-by": "inline-evidence-and-public-policy-unavailable",
+  "x-gis-ai-go-blocked-by": "transport-and-interoperability-unverified",
   "paths": {
     "/healthz": {
       "get": {
@@ -150,7 +150,7 @@
             "const": "blocked"
           },
           "reason": {
-            "const": "inline-evidence-and-public-policy-unavailable"
+            "const": "transport-and-interoperability-unverified"
           },
           "active_tools": {
             "type": "array",

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -8,12 +8,15 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "prepare:test": "pnpm --dir ../.. run build:okf && pnpm --filter @gis-ai-go/contracts run build",
+    "prepare:test": "pnpm --dir ../.. run build:okf && pnpm --filter @gis-ai-go/contracts run build && pnpm --filter @gis-ai-go/evidence run build && pnpm --filter @gis-ai-go/authority-context run build && pnpm --filter @gis-ai-go/policy-client run build",
     "test": "pnpm run prepare:test && pnpm run build && node --test dist/test/*.test.js",
     "start:http": "node dist/src/http-main.js ../../artifacts/okf"
   },
   "dependencies": {
+    "@gis-ai-go/authority-context": "workspace:*",
     "@gis-ai-go/contracts": "workspace:*",
+    "@gis-ai-go/evidence": "workspace:*",
+    "@gis-ai-go/policy-client": "workspace:*",
     "@modelcontextprotocol/server": "2.0.0"
   }
 }

--- a/apps/mcp-gateway/src/activation.ts
+++ b/apps/mcp-gateway/src/activation.ts
@@ -1,5 +1,5 @@
 export const ACTIVATION_BLOCK_REASON =
-  "inline-evidence-and-public-policy-unavailable" as const;
+  "transport-and-interoperability-unverified" as const;
 
 export interface BlockedCatalogueActivation {
   readonly state: "blocked";
@@ -11,9 +11,10 @@ export interface BlockedCatalogueActivation {
 /**
  * The only production activation state in this candidate.
  *
- * EVID-204 must replace this closed value with a reviewed policy decision and
- * inline receipt factory before any catalogue operation is mounted or advertised.
- * There is deliberately no environment-variable or command-line override.
+ * EVID-204A supplies reviewed in-process public policy decisions and inline
+ * receipts. Transport registration, protocol conformance and interoperability
+ * remain unverified, so no catalogue operation is mounted or advertised. There
+ * is deliberately no environment-variable or command-line override.
  */
 export const catalogueActivation: BlockedCatalogueActivation = Object.freeze({
   state: "blocked",

--- a/apps/mcp-gateway/src/catalogue-application.ts
+++ b/apps/mcp-gateway/src/catalogue-application.ts
@@ -18,6 +18,16 @@ import {
   type RecordType,
   type RightsState,
 } from "@gis-ai-go/contracts";
+import {
+  buildInlineReceipt,
+  canonicalJsonClone,
+  verifyInlineReceipt,
+  type EvidenceSoftwareIdentity,
+  type InlineEvidenceReceipt,
+  type PublicCatalogueOperation,
+  type RecordLicenceObligation,
+} from "@gis-ai-go/evidence";
+import { evaluatePublicCataloguePolicy } from "@gis-ai-go/policy-client";
 
 import type { CatalogueSnapshot } from "./catalogue-snapshot.js";
 import {
@@ -136,7 +146,7 @@ export interface CatalogueRecordDetail {
   readonly details: Readonly<Record<string, JsonValue>>;
 }
 
-export interface CatalogueSearchResult {
+export interface CatalogueSearchResultCore {
   readonly schema: "gis-ai-go.catalogue-result.v1";
   readonly operation: "catalogue.search";
   readonly request_id: string;
@@ -155,7 +165,11 @@ export interface CatalogueSearchResult {
   };
 }
 
-export interface CatalogueDescribeResult {
+export interface CatalogueSearchResult extends CatalogueSearchResultCore {
+  readonly evidence_receipt: InlineEvidenceReceipt;
+}
+
+export interface CatalogueDescribeResultCore {
   readonly schema: "gis-ai-go.catalogue-result.v1";
   readonly operation: "catalogue.describe";
   readonly request_id: string;
@@ -181,6 +195,15 @@ export interface CatalogueDescribeResult {
   };
 }
 
+export interface CatalogueDescribeResult extends CatalogueDescribeResultCore {
+  readonly evidence_receipt: InlineEvidenceReceipt;
+}
+
+export interface CatalogueApplicationOptions {
+  readonly software: EvidenceSoftwareIdentity;
+  readonly now?: () => Date;
+}
+
 export interface CatalogueApplication {
   readonly search: (
     request: unknown,
@@ -190,6 +213,11 @@ export interface CatalogueApplication {
     request: unknown,
     context: CatalogueProblemContext,
   ) => CatalogueDescribeResult;
+}
+
+interface CatalogueEvidenceRuntime {
+  readonly software: EvidenceSoftwareIdentity;
+  readonly now: () => Date;
 }
 
 interface NormalisedSearchRequest {
@@ -387,7 +415,7 @@ function assertResultRecord(record: CatalogueRecord, path: string): void {
     FRESHNESS_STATUSES,
   );
   assertControlledResultValue(record.status, `${path}.status`, RECORD_STATUSES);
-  assertResultStringArray(record.sourceRefs, `${path}.sourceRefs`, 1, 100, 512);
+  assertResultStringArray(record.sourceRefs, `${path}.sourceRefs`, 1, 99, 512);
   assertResultStringArray(record.limitations, `${path}.limitations`, 1, 50, 2_048);
   assertResultStringArray(record.tags, `${path}.tags`, 0, 50, 128);
   assertSourceNativeValue(record.details, `${path}.details`, new WeakSet<object>());
@@ -489,10 +517,60 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
+function applicationRuntime(options: CatalogueApplicationOptions): CatalogueEvidenceRuntime {
+  if (!isPlainObject(options)) {
+    throw new TypeError("Catalogue application options must be a plain object");
+  }
+  const optionKeys = Object.keys(options).sort();
+  if (
+    (optionKeys.length !== 1 || optionKeys[0] !== "software") &&
+    (optionKeys.length !== 2 || optionKeys[0] !== "now" || optionKeys[1] !== "software")
+  ) {
+    throw new TypeError("Catalogue application options have an unexpected shape");
+  }
+  if (!isPlainObject(options.software)) {
+    throw new TypeError("Catalogue application software must be a plain object");
+  }
+  const softwareKeys = Object.keys(options.software).sort();
+  if (
+    softwareKeys.length !== 3 ||
+    softwareKeys[0] !== "name" ||
+    softwareKeys[1] !== "revision" ||
+    softwareKeys[2] !== "version" ||
+    options.software.name !== "gis-ai-go-mcp-gateway" ||
+    !RESULT_SEMVER.test(options.software.version) ||
+    !RESULT_SHA40.test(options.software.revision)
+  ) {
+    throw new TypeError("Catalogue application software identity is invalid");
+  }
+  if (options.now !== undefined && typeof options.now !== "function") {
+    throw new TypeError("Catalogue application now option must be a function");
+  }
+  return Object.freeze({
+    software: canonicalJsonClone(options.software),
+    now: options.now ?? (() => new Date()),
+  });
+}
+
+function hasOnlyPairedSurrogates(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isProblemBoundedText(value: string, maximum: number): boolean {
   return (
     codePointLength(value) >= 1 &&
     codePointLength(value) <= maximum &&
+    hasOnlyPairedSurrogates(value) &&
     !PROBLEM_CONTROL_CHARACTER.test(value)
   );
 }
@@ -646,6 +724,14 @@ function normaliseSearchRequest(
     if (request.query.length === 0) {
       fieldFailure(context, "$.query", "out_of_range", "Query must not be empty.");
     }
+    if (!hasOnlyPairedSurrogates(request.query)) {
+      fieldFailure(
+        context,
+        "$.query",
+        "invalid_value",
+        "Query must contain valid Unicode scalar values.",
+      );
+    }
     const analysis = analyseCatalogueQuery(request.query);
     if (analysis.exceedsCharacterLimit) {
       fieldFailure(
@@ -715,6 +801,105 @@ function catalogueIdentity(snapshot: CatalogueSnapshot): CatalogueIdentity {
     reviewed_at: snapshot.bundle.reviewedAt,
     stale_after: snapshot.bundle.staleAfter,
   };
+}
+
+function receiptTimestamp(runtime: CatalogueEvidenceRuntime): string {
+  const value = runtime.now();
+  if (!(value instanceof Date) || !Number.isFinite(value.valueOf())) {
+    throw new TypeError("Catalogue application clock must return a valid Date");
+  }
+  return value.toISOString();
+}
+
+function licenceObligations(
+  records: readonly CatalogueRecord[],
+): readonly RecordLicenceObligation[] {
+  return records.map((record) => ({
+    record_id: record.id,
+    record_licence: record.rights.recordLicence,
+    described_resource_licence: record.rights.describedResourceLicence,
+    attribution: record.rights.attribution,
+  }));
+}
+
+function resultWithEvidence(
+  resultCore: CatalogueSearchResultCore,
+  normalisedParameters: unknown,
+  returnedRecords: readonly CatalogueRecord[],
+  snapshot: CatalogueSnapshot,
+  context: CatalogueProblemContext,
+  runtime: CatalogueEvidenceRuntime,
+): CatalogueSearchResult;
+function resultWithEvidence(
+  resultCore: CatalogueDescribeResultCore,
+  normalisedParameters: unknown,
+  returnedRecords: readonly CatalogueRecord[],
+  snapshot: CatalogueSnapshot,
+  context: CatalogueProblemContext,
+  runtime: CatalogueEvidenceRuntime,
+): CatalogueDescribeResult;
+function resultWithEvidence(
+  resultCore: CatalogueSearchResultCore | CatalogueDescribeResultCore,
+  normalisedParameters: unknown,
+  returnedRecords: readonly CatalogueRecord[],
+  snapshot: CatalogueSnapshot,
+  context: CatalogueProblemContext,
+  runtime: CatalogueEvidenceRuntime,
+): CatalogueSearchResult | CatalogueDescribeResult {
+  const operation: PublicCatalogueOperation = resultCore.operation;
+  const policyEvaluation = evaluatePublicCataloguePolicy({
+    requestId: context.requestId,
+    traceId: context.traceId,
+    operation,
+    catalogue: snapshot.bundle,
+  });
+  if (!policyEvaluation.allowed || policyEvaluation.decision === null) {
+    throwCatalogueProblem("service_unavailable", context, {
+      detail: "The public catalogue policy did not authorise this result.",
+    });
+  }
+
+  const immutableCore = canonicalJsonClone(resultCore);
+  const transformations = [
+    { name: "load-checksum-verified-catalogue", version: "v1" },
+    { name: "normalise-parameters", version: "v1" },
+    ...(operation === "catalogue.search"
+      ? ([{ name: "filter-catalogue", version: "v1" }] as const)
+      : []),
+    { name: "project-result-core", version: "v1" },
+  ] as const;
+  const recordLicences = licenceObligations(returnedRecords);
+  const receipt = buildInlineReceipt({
+    createdAt: receiptTimestamp(runtime),
+    requestId: context.requestId,
+    traceId: context.traceId,
+    operation,
+    normalisedParameters,
+    authorityContext: policyEvaluation.authorityContext,
+    publicPolicy: policyEvaluation.policy,
+    policyDecision: policyEvaluation.decision,
+    catalogue: immutableCore.catalogue,
+    transformations,
+    software: runtime.software,
+    resultCore: immutableCore,
+    licenceObligations: recordLicences,
+  });
+  const verification = verifyInlineReceipt(receipt, {
+    normalisedParameters,
+    resultCore: immutableCore,
+    publicPolicy: policyEvaluation.policy,
+    expectedAuthorityContext: policyEvaluation.authorityContext,
+    expectedPolicyDecision: policyEvaluation.decision,
+    expectedCatalogue: immutableCore.catalogue,
+    expectedSoftware: runtime.software,
+    licenceObligations: recordLicences,
+  });
+  if (!verification.valid) {
+    throw new Error("The catalogue application produced unverifiable inline evidence");
+  }
+  return canonicalJsonClone({ ...immutableCore, evidence_receipt: receipt }) as
+    | CatalogueSearchResult
+    | CatalogueDescribeResult;
 }
 
 function summary(record: CatalogueRecord): CatalogueRecordSummary {
@@ -811,6 +996,7 @@ function searchCatalogueFromValidatedSnapshot(
   snapshot: CatalogueSnapshot,
   input: unknown,
   context: CatalogueProblemContext,
+  runtime: CatalogueEvidenceRuntime,
 ): CatalogueSearchResult {
   const request = normaliseSearchRequest(input, snapshot, context);
   const state = searchState(request);
@@ -850,7 +1036,7 @@ function searchCatalogueFromValidatedSnapshot(
         )
       : null;
 
-  return {
+  const resultCore: CatalogueSearchResultCore = {
     schema: "gis-ai-go.catalogue-result.v1",
     operation: "catalogue.search",
     request_id: context.requestId,
@@ -868,16 +1054,19 @@ function searchCatalogueFromValidatedSnapshot(
       },
     },
   };
-}
-
-export function searchCatalogue(
-  snapshot: CatalogueSnapshot,
-  input: unknown,
-  context: CatalogueProblemContext,
-): CatalogueSearchResult {
-  assertCatalogueProblemContext(context);
-  assertCatalogueResultSnapshotBounds(snapshot);
-  return searchCatalogueFromValidatedSnapshot(snapshot, input, context);
+  return resultWithEvidence(
+    resultCore,
+    {
+      query: request.query,
+      facets: request.facets,
+      limit: request.limit,
+      offset,
+    },
+    pageRecords,
+    snapshot,
+    context,
+    runtime,
+  );
 }
 
 function normaliseDescribeRequest(
@@ -924,6 +1113,7 @@ function describeCatalogueFromValidatedSnapshot(
   snapshot: CatalogueSnapshot,
   input: unknown,
   context: CatalogueProblemContext,
+  runtime: CatalogueEvidenceRuntime,
 ): CatalogueDescribeResult {
   const request = normaliseDescribeRequest(input, context);
   const record = snapshot.recordsById.get(request.recordId);
@@ -938,11 +1128,16 @@ function describeCatalogueFromValidatedSnapshot(
     relation: "source" as const,
     record_id: recordId,
   }));
-  const sources = sourceIds.map((recordId) => {
+  const sourceRecords = sourceIds
+    .filter((recordId) => recordId !== record.id)
+    .map((recordId) => {
     const source = snapshot.recordsById.get(recordId);
     if (source === undefined) {
       throw new Error(`Validated catalogue source ${recordId} is unavailable`);
     }
+      return source;
+    });
+  const sources = sourceRecords.map((source) => {
     return {
       id: source.id,
       title: source.title,
@@ -953,7 +1148,7 @@ function describeCatalogueFromValidatedSnapshot(
     };
   });
 
-  return {
+  const resultCore: CatalogueDescribeResultCore = {
     schema: "gis-ai-go.catalogue-result.v1",
     operation: "catalogue.describe",
     request_id: context.requestId,
@@ -968,29 +1163,34 @@ function describeCatalogueFromValidatedSnapshot(
       },
     },
   };
-}
-
-export function describeCatalogue(
-  snapshot: CatalogueSnapshot,
-  input: unknown,
-  context: CatalogueProblemContext,
-): CatalogueDescribeResult {
-  assertCatalogueProblemContext(context);
-  assertCatalogueResultSnapshotBounds(snapshot);
-  return describeCatalogueFromValidatedSnapshot(snapshot, input, context);
+  return resultWithEvidence(
+    resultCore,
+    {
+      record_id: request.recordId,
+      include: [...request.include],
+    },
+    request.include.has("sources") ? [record, ...sourceRecords] : [record],
+    snapshot,
+    context,
+    runtime,
+  );
 }
 
 /** Bind the two catalogue operations to one immutable, transport-neutral snapshot. */
-export function createCatalogueApplication(snapshot: CatalogueSnapshot): CatalogueApplication {
+export function createCatalogueApplication(
+  snapshot: CatalogueSnapshot,
+  options: CatalogueApplicationOptions,
+): CatalogueApplication {
   assertCatalogueResultSnapshotBounds(snapshot);
+  const runtime = applicationRuntime(options);
   return Object.freeze({
     search: (request: unknown, context: CatalogueProblemContext) => {
       assertCatalogueProblemContext(context);
-      return searchCatalogueFromValidatedSnapshot(snapshot, request, context);
+      return searchCatalogueFromValidatedSnapshot(snapshot, request, context, runtime);
     },
     describe: (request: unknown, context: CatalogueProblemContext) => {
       assertCatalogueProblemContext(context);
-      return describeCatalogueFromValidatedSnapshot(snapshot, request, context);
+      return describeCatalogueFromValidatedSnapshot(snapshot, request, context, runtime);
     },
   });
 }

--- a/apps/mcp-gateway/test/catalogue-application.test.ts
+++ b/apps/mcp-gateway/test/catalogue-application.test.ts
@@ -8,6 +8,8 @@ import {
   type CatalogueRecord,
   type JsonValue,
 } from "@gis-ai-go/contracts";
+import { verifyInlineReceipt } from "@gis-ai-go/evidence";
+import { PUBLIC_CATALOGUE_POLICY } from "@gis-ai-go/policy-client";
 
 import {
   assertCatalogueResultSnapshotBounds,
@@ -35,7 +37,20 @@ const CONTEXT = Object.freeze({
 const SNAPSHOT = await loadCatalogueSnapshot(SOURCE_CATALOGUE, {
   now: new Date("2026-08-20T12:00:00Z"),
 });
-const APPLICATION = createCatalogueApplication(SNAPSHOT);
+const TEST_APPLICATION_OPTIONS = Object.freeze({
+  software: Object.freeze({
+    name: "gis-ai-go-mcp-gateway" as const,
+    version: "0.1.0",
+    revision: "a".repeat(40),
+  }),
+  now: () => new Date("2026-08-20T12:34:56Z"),
+});
+
+function testApplication(snapshot: CatalogueSnapshot = SNAPSHOT) {
+  return createCatalogueApplication(snapshot, TEST_APPLICATION_OPTIONS);
+}
+
+const APPLICATION = testApplication();
 const MUTATION_RECORD_ID = "hmlr:dataset:price-paid-data";
 
 function snapshotForBundle(bundle: CatalogueBundle): CatalogueSnapshot {
@@ -96,6 +111,45 @@ test("search returns governed Price Paid and INSPIRE summaries with controlled f
   assert.equal(pricePaid.data.records[0]?.authority, "source-authoritative");
   assert.equal(pricePaid.data.records[0]?.rights, "open-with-conditions");
   assert.ok(pricePaid.data.facets.types.some(({ value }) => value === "dataset"));
+  assert.equal(pricePaid.evidence_receipt.schema, "gis-ai-go.evidence-receipt.v1");
+  assert.equal(pricePaid.evidence_receipt.operation.name, "catalogue.search");
+  assert.equal(pricePaid.evidence_receipt.policy_decision.effect, "allow-with-obligations");
+  assert.equal(pricePaid.evidence_receipt.policy_decision.policy_default_effect, "deny");
+  assert.deepEqual(
+    pricePaid.evidence_receipt.licence_obligations.map(({ record_id: id }) => id),
+    pricePaid.data.records.map(({ id }) => id).sort(),
+  );
+  assert.deepEqual(pricePaid.evidence_receipt.evidence_handling, {
+    attestation: "not-attested",
+    delivery: "inline-only",
+    persistence: "not-persisted",
+  });
+  assert.equal(Object.isFrozen(pricePaid), true);
+  assert.equal(Object.isFrozen(pricePaid.evidence_receipt), true);
+  assert.equal(JSON.stringify(pricePaid.evidence_receipt).includes("Price Paid"), false);
+
+  const { evidence_receipt: pricePaidReceipt, ...pricePaidCore } = pricePaid;
+  const receiptVerification = verifyInlineReceipt(pricePaidReceipt, {
+    normalisedParameters: {
+      query: "price paid",
+      facets: {
+        types: ["dataset"],
+        authority: [],
+        access: [],
+        rights: [],
+        freshness: [],
+        tags: [],
+      },
+      limit: 20,
+      offset: 0,
+    },
+    resultCore: pricePaidCore,
+    publicPolicy: PUBLIC_CATALOGUE_POLICY,
+    expectedCatalogue: pricePaid.catalogue,
+    expectedSoftware: TEST_APPLICATION_OPTIONS.software,
+    licenceObligations: pricePaidReceipt.licence_obligations,
+  });
+  assert.equal(receiptVerification.valid, true, receiptVerification.errors.join("; "));
 
   const inspire = APPLICATION.search(
     { query: "INSPIRE", facets: { tags: ["inspire"] }, limit: 100 },
@@ -107,6 +161,88 @@ test("search returns governed Price Paid and INSPIRE summaries with controlled f
   );
   assert.equal(inspire.data.page.returned, inspire.data.records.length);
   assert.equal(inspire.data.page.next_cursor, null);
+});
+
+test("inline receipt verification rejects parameter replay and result or rights tampering", () => {
+  const result = APPLICATION.search({ query: "Price Paid", limit: 1 }, CONTEXT);
+  const { evidence_receipt: receipt, ...resultCore } = result;
+  const normalisedParameters = {
+    query: "price paid",
+    facets: {
+      types: [],
+      authority: [],
+      access: [],
+      rights: [],
+      freshness: [],
+      tags: [],
+    },
+    limit: 1,
+    offset: 0,
+  };
+  const expectedLicences = receipt.licence_obligations;
+
+  const replay = verifyInlineReceipt(receipt, {
+    normalisedParameters: { ...normalisedParameters, offset: 1 },
+    resultCore,
+    publicPolicy: PUBLIC_CATALOGUE_POLICY,
+    licenceObligations: expectedLicences,
+  });
+  assert.equal(replay.valid, false);
+
+  const changedResult = {
+    ...resultCore,
+    data: {
+      ...resultCore.data,
+      page: {
+        ...resultCore.data.page,
+        matched: resultCore.data.page.matched + 1,
+      },
+    },
+  };
+  const resultTamper = verifyInlineReceipt(receipt, {
+    normalisedParameters,
+    resultCore: changedResult,
+    publicPolicy: PUBLIC_CATALOGUE_POLICY,
+    licenceObligations: expectedLicences,
+  });
+  assert.equal(resultTamper.valid, false);
+
+  const changedReceipt = {
+    ...receipt,
+    licence_obligations: receipt.licence_obligations.map((obligation, index) =>
+      index === 0 ? { ...obligation, attribution: "Changed attribution" } : obligation,
+    ),
+  };
+  const rightsTamper = verifyInlineReceipt(changedReceipt, {
+    normalisedParameters,
+    resultCore,
+    publicPolicy: PUBLIC_CATALOGUE_POLICY,
+    licenceObligations: expectedLicences,
+  });
+  assert.equal(rightsTamper.valid, false);
+});
+
+test("application creation requires exact software identity and a valid injected clock", () => {
+  const invalidOptions = [
+    {},
+    { software: TEST_APPLICATION_OPTIONS.software, unexpected: true },
+    { software: { ...TEST_APPLICATION_OPTIONS.software, name: "other-gateway" } },
+    { software: { ...TEST_APPLICATION_OPTIONS.software, version: "0.1.0-dev" } },
+    { software: { ...TEST_APPLICATION_OPTIONS.software, revision: "A".repeat(40) } },
+    { software: TEST_APPLICATION_OPTIONS.software, now: "not-a-function" },
+  ] as const;
+  for (const options of invalidOptions) {
+    assert.throws(
+      () => createCatalogueApplication(SNAPSHOT, options as never),
+      TypeError,
+    );
+  }
+
+  const invalidClock = createCatalogueApplication(SNAPSHOT, {
+    software: TEST_APPLICATION_OPTIONS.software,
+    now: () => new Date(Number.NaN),
+  });
+  assert.throws(() => invalidClock.search({}, CONTEXT), /clock must return a valid Date/u);
 });
 
 test("application creation rejects parser-valid records outside the result contract", () => {
@@ -153,7 +289,7 @@ test("application creation rejects parser-valid records outside the result contr
 
   for (const [path, overrides] of cases) {
     const snapshot = parserValidSnapshotWithRecord(overrides);
-    assert.throws(() => createCatalogueApplication(snapshot), (error: unknown) => {
+    assert.throws(() => testApplication(snapshot), (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /^Catalogue result contract rejected at /u);
       assert.ok(error.message.includes(path));
@@ -166,9 +302,9 @@ test("result bounds reject excessive source references, facets and source-native
   const base = SNAPSHOT.recordsById.get(MUTATION_RECORD_ID);
   assert.ok(base);
 
-  const sourceRefs = Array.from({ length: 101 }, (_, index) => `source:${index}`);
+  const sourceRefs = Array.from({ length: 100 }, (_, index) => `source:${index}`);
   assert.throws(
-    () => createCatalogueApplication(uncheckedSnapshotWithRecord({ sourceRefs })),
+    () => testApplication(uncheckedSnapshotWithRecord({ sourceRefs })),
     /sourceRefs/u,
   );
 
@@ -183,7 +319,7 @@ test("result bounds reject excessive source references, facets and source-native
   ];
   for (const details of detailCases) {
     assert.throws(
-      () => createCatalogueApplication(uncheckedSnapshotWithRecord({ details })),
+      () => testApplication(uncheckedSnapshotWithRecord({ details })),
       /details/u,
     );
   }
@@ -233,7 +369,7 @@ test("pagination is deterministic and rejects tampering or replay", () => {
     ...SNAPSHOT,
     contentRootSha256: "f".repeat(64),
   }) satisfies CatalogueSnapshot;
-  const changedApplication = createCatalogueApplication(changedSnapshot);
+  const changedApplication = testApplication(changedSnapshot);
   expectProblem(
     () => changedApplication.search({ query: "HMLR", limit: 1, cursor }, CONTEXT),
     "invalid_cursor",
@@ -259,6 +395,18 @@ test("query limits count normalised terms and Unicode code points", () => {
     () => APPLICATION.search({ query: astralCharacter.repeat(257) }, CONTEXT),
     "invalid_request",
   );
+
+  const unpairedSurrogate = expectProblem(
+    () => APPLICATION.search({ query: "\ud800" }, CONTEXT),
+    "invalid_request",
+  );
+  assert.deepEqual(unpairedSurrogate.problem.errors, [
+    {
+      path: "$.query",
+      code: "invalid_value",
+      message: "Query must contain valid Unicode scalar values.",
+    },
+  ]);
 });
 
 test("closed requests reject unknown properties, facet values and tags", () => {
@@ -286,7 +434,7 @@ test("closed requests reject unknown properties, facet values and tags", () => {
 });
 
 test("hostile unknown property identities remain controlled catalogue problems", () => {
-  const hostileKeys = ["x".repeat(300), "unsafe\nproperty"] as const;
+  const hostileKeys = ["x".repeat(300), "unsafe\nproperty", "\ud800"] as const;
   for (const key of hostileKeys) {
     const root = expectProblem(
       () => APPLICATION.search({ [key]: true }, CONTEXT),
@@ -492,6 +640,28 @@ test("describe preserves full governed fields and stable source expansions", () 
   assert.deepEqual(relationshipIds, [...(relationshipIds ?? [])].sort());
   assert.deepEqual(sourceIds, relationshipIds);
   assert.ok(result.data.included.sources?.every((source) => source.title.length > 0));
+
+  assert.equal(result.evidence_receipt.operation.name, "catalogue.describe");
+  const evidencedRecordIds = [result.data.record.id, ...(sourceIds ?? [])].sort();
+  assert.equal(
+    result.evidence_receipt.result.returned_record_count,
+    evidencedRecordIds.length,
+  );
+  assert.deepEqual(
+    result.evidence_receipt.licence_obligations.map(({ record_id: id }) => id),
+    evidencedRecordIds,
+  );
+  const { evidence_receipt: receipt, ...resultCore } = result;
+  const verification = verifyInlineReceipt(receipt, {
+    normalisedParameters: {
+      record_id: "hmlr:dataset:price-paid-data",
+      include: ["relationships", "sources"],
+    },
+    resultCore,
+    publicPolicy: PUBLIC_CATALOGUE_POLICY,
+    licenceObligations: receipt.licence_obligations,
+  });
+  assert.equal(verification.valid, true, verification.errors.join("; "));
 });
 
 test("describe include order is canonical and IDs are exact and case-sensitive", () => {
@@ -544,4 +714,18 @@ test("describe include order is canonical and IDs are exact and case-sensitive",
     "No catalogue record has the supplied exact ID.",
   );
   assert.equal(hostileMissing.problem.detail?.includes("missing\nrecord"), false);
+});
+
+test("describe does not duplicate a self-referencing source projection or licence", () => {
+  const result = APPLICATION.describe({ record_id: "S-ARAZZO" }, CONTEXT);
+  assert.deepEqual(result.data.record.source_refs, ["S-ARAZZO"]);
+  assert.deepEqual(result.data.included.relationships, [
+    { relation: "source", record_id: "S-ARAZZO" },
+  ]);
+  assert.deepEqual(result.data.included.sources, []);
+  assert.deepEqual(
+    result.evidence_receipt.licence_obligations.map(({ record_id: id }) => id),
+    ["S-ARAZZO"],
+  );
+  assert.equal(result.evidence_receipt.result.returned_record_count, 1);
 });

--- a/apps/mcp-gateway/test/http-app.test.ts
+++ b/apps/mcp-gateway/test/http-app.test.ts
@@ -53,7 +53,7 @@ test("readiness is deliberately blocked with zero active operations", async () =
   assert.equal(response.status, 503);
   assert.deepEqual(await response.json(), {
     status: "blocked",
-    reason: "inline-evidence-and-public-policy-unavailable",
+    reason: "transport-and-interoperability-unverified",
     active_tools: [],
     active_api_operations: [],
   });

--- a/apps/mcp-gateway/test/index.test.ts
+++ b/apps/mcp-gateway/test/index.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import * as gateway from "../src/index.js";
 import { catalogueActivation, gatewayMetadata } from "../src/index.js";
 
 test("publishes the agreed inactive gateway identity", () => {
@@ -14,11 +15,13 @@ test("publishes the agreed inactive gateway identity", () => {
 test("has no activation or environment-variable escape hatch", () => {
   assert.deepEqual(catalogueActivation, {
     state: "blocked",
-    reason: "inline-evidence-and-public-policy-unavailable",
+    reason: "transport-and-interoperability-unverified",
     activeTools: [],
     activeApiOperations: [],
   });
   assert.equal(Object.isFrozen(catalogueActivation), true);
   assert.deepEqual(gatewayMetadata.activeTools, []);
   assert.deepEqual(gatewayMetadata.activeApiOperations, []);
+  assert.equal("searchCatalogue" in gateway, false);
+  assert.equal("describeCatalogue" in gateway, false);
 });

--- a/changelog.d/EVID-204.changed.md
+++ b/changelog.d/EVID-204.changed.md
@@ -1,0 +1,5 @@
+- Added RFC 8785 canonical JSON, domain-separated content identities, a
+  server-constructed anonymous-open authority context and a compiled default-deny
+  public policy. Every successful in-process catalogue result now carries a
+  verifiable record-specific inline receipt that explicitly remains non-persisted
+  and non-attested; transports and advertised operations remain blocked.

--- a/docs/decisions/ADR-0010-canonical-public-inline-evidence.md
+++ b/docs/decisions/ADR-0010-canonical-public-inline-evidence.md
@@ -1,0 +1,97 @@
+# ADR-0010: Canonical public inline evidence
+
+- status: accepted
+- date: 20 August 2026
+- decision owner: Chris Page
+- work item: [EVID-204](https://github.com/chris-page-gov/gis-ai-go/issues/22)
+
+## Context
+
+The inactive gateway can verify the public catalogue and execute deterministic
+search and description in process, but it cannot yet return an honest policy
+decision or evidence receipt. The preserved research contracts are permissive
+candidates designed for protected identity, provider execution and a future
+evidence store. Reusing them for anonymous public catalogue access would imply
+identity, persistence and attestation that do not exist.
+
+The first evidence slice must close the catalogue application path without
+activating a route or tool and without creating a temporary in-memory map that is
+described as an append-only ledger.
+
+## Decision
+
+GIS AI GO will use RFC 8785 JSON Canonicalisation Scheme (JCS) for the bounded JSON
+values covered by public evidence. The implementation will reject values outside
+the interoperable JSON model, including non-finite numbers, sparse arrays, cycles,
+non-plain objects, accessors and unpaired Unicode surrogates. Content identities use
+SHA-256 with a product, contract-version and purpose domain separator.
+
+The catalogue application will construct one anonymous-open authority context on
+the server. It carries no person, organisation, credential, device, client role or
+caller-supplied authority. A checked-in compiled JSON policy will:
+
+- deny by default;
+- allow only `catalogue.search` and `catalogue.describe`;
+- require public, open, read-only, non-personal and non-protected inputs; and
+- return controlled obligations for inline evidence, record licences, described
+  resource licences, attribution, non-persistence and non-attestation.
+
+This is a compiled public document evaluated in process. It is not OPA, Rego,
+authentication, entitlement or an enterprise policy decision point.
+
+Every successful in-process catalogue result must take one path: validate and
+normalise the request, select bounded public records, construct authority, evaluate
+policy, construct the receipt-free result core, build and verify its inline receipt,
+validate the complete result and then return it. Receiptless result builders must
+not remain public bypasses.
+
+The receipt will bind:
+
+- request, trace and governed operation identifiers;
+- a digest of normalised semantic parameters, never raw query or cursor text;
+- the exact catalogue identity, revision and content root;
+- deterministic transformation and gateway software identity;
+- the receipt-free result digest, media type and returned-record count;
+- sorted record-specific record licence, described-resource licence and attribution
+  evidence; and
+- the embedded authority context and policy decision.
+
+It will state `inline-only`, `not-persisted` and `not-attested`. It will contain no
+receipt URI, attester, signature, caller identity, prompt, geometry, machine path or
+unnecessary raw request value.
+
+After this slice, readiness remains blocked and the active tool and API-operation
+arrays remain empty. The block reason moves from missing policy/evidence to missing
+transport and interoperability verification.
+
+## Consequences
+
+- Equivalent bounded inputs and result cores have stable, testable content
+  identities.
+- Policy, authority, catalogue, result and licence mutations fail receipt
+  verification rather than producing a weaker claim.
+- The application cannot return a success result without inline public evidence.
+- Timestamps remain injectable so tests are deterministic and one server time can
+  be used for each receipt.
+- The verifier checks that `created_at` is a timestamp but does not compare it with
+  a clock. Receipts have no expiry, nonce or one-time replay prevention, so an
+  otherwise valid receipt remains valid when presented again with the same
+  independently supplied material.
+- The receipt proves structural and content binding only; it is not a signature,
+  computation attestation or durable audit record.
+
+## Deferred work
+
+This decision does not implement canonical events, event sequencing, append-only
+storage, hash chains, restart verification, corruption recovery, `evidence.inspect`,
+receipt freshness or expiry checks, nonce or replay state, provider or execution
+receipts, full cross-service trace propagation, MCP/API routes, service publication
+or registry entry. Those need their own reviewed contracts and operational evidence.
+
+## Threat boundary
+
+This slice directly reduces the policy-bypass, provenance-spoofing and receipt-
+tampering paths represented by research risks RK08, RK20 and RK21. It reduces RK25
+query-history exposure by retaining only a digest of normalised parameters. RK21
+deletion and mutable-overwrite risks remain open until a real append-only store is
+implemented and verified.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -13,6 +13,7 @@ research recommendations remain unchanged in the preserved pack at
 - [ADR-0007: Immutable GitHub Pages publication](ADR-0007-immutable-pages-publication.md)
 - [ADR-0008: Supported Pages transport from verified payload](ADR-0008-supported-pages-transport.md)
 - [ADR-0009: Read-only MCP tool lifecycle](ADR-0009-read-only-mcp-tool-lifecycle.md)
+- [ADR-0010: Canonical public inline evidence](ADR-0010-canonical-public-inline-evidence.md)
 
 Research decisions D01–D19 are accepted as constraints for building and evaluating
 Stage 0, not as blanket authority for later production stages. Research decision D20

--- a/docs/operations/EVID-204_INLINE_EVIDENCE.md
+++ b/docs/operations/EVID-204_INLINE_EVIDENCE.md
@@ -1,0 +1,89 @@
+# EVID-204 canonical public inline evidence
+
+- status: local candidate; complete locked local gate passing
+- work item: [EVID-204](https://github.com/chris-page-gov/gis-ai-go/issues/22)
+- decision: [ADR-0010](../decisions/ADR-0010-canonical-public-inline-evidence.md)
+- supported public release: [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+
+## Outcome boundary
+
+This slice adds canonical, verifiable evidence to the two inactive in-process
+catalogue operations. It does not activate a route or MCP tool and it does not
+publish a service.
+
+The server constructs one anonymous-open authority context. A checked-in compiled
+JSON policy denies by default and allows only `catalogue.search` and
+`catalogue.describe` over the bounded public metadata catalogue. The policy is not
+OPA and the authority context is not a user, organisation, credential or workload
+identity.
+
+Each successful application result carries an inline evidence receipt that binds
+the normalised parameters, exact catalogue publication, result core, gateway
+software, trace identifiers, public policy decision and record-specific licence
+evidence. The receipt says `inline-only`, `not-persisted` and `not-attested`.
+
+## Deliberate exclusions
+
+This slice provides no:
+
+- event stream, append-only ledger, persistence or evidence lookup;
+- signature, attester, identity provider, OPA service or protected entitlement;
+- provider or execution receipt, provider call or geometry processing;
+- MCP listener, catalogue HTTP route, advertised tool or active API operation;
+- receipt freshness or expiry validation, a nonce or one-time replay prevention;
+  an otherwise valid receipt remains valid when presented again with the exact
+  independently supplied material; or
+- public deployment beyond the unchanged static `v0.1.0` Explorer.
+
+Readiness remains blocked until transport conformance and interoperability are
+implemented and reviewed. Persistence, corruption recovery and `evidence.inspect`
+remain open acceptance work under EVID-204.
+
+## Verification contract
+
+The candidate must pass all of the following before a pull request is opened:
+
+1. schema fixtures validate against the closed authority, policy, decision,
+   receipt and catalogue-result contracts;
+2. RFC 8785 canonicalisation tests cover ordering, number and Unicode controls,
+   unsupported values and adversarial structures;
+3. domain-separated content identities are deterministic and reject mutation,
+   truncation, replay across domains and wrong independently supplied material;
+4. the compiled policy proves default deny, exact operation allow-listing and the
+   public/open/non-personal/non-protected boundary;
+5. catalogue application tests prove every success has a valid receipt and no
+   receiptless exported result path remains;
+6. receipts omit raw queries, cursors, caller identity, credentials, prompts,
+   machine paths and evidence URIs; and
+7. the complete locked repository assurance gate and independent security review
+   pass with the immutable research tree unchanged.
+
+## Evidence state
+
+| Evidence | State |
+| --- | --- |
+| Local implementation commit | pending |
+| Focused schema and package tests | passing: 19 contracts, 20 evidence, 2 authority, 6 policy and 41 gateway tests |
+| Complete locked local gate | passing on the uncommitted candidate working tree |
+| Independent evidence-core review | `SHIP`; no P0, P1 or P2 finding |
+| Independent whole-diff security and contract review | `SHIP`; no P0, P1 or P2 finding across all 60 candidate files |
+| Pull request assurance and CodeQL | pending |
+| Protected-main assurance, provenance and attestation | pending |
+
+Pending rows are not capability claims. Update them only from exact retained
+evidence after the corresponding gate succeeds.
+
+The complete gate also passed 94 repository Python tests, 2 execution-boundary
+tests, 16 Explorer build-policy tests, 42 Explorer unit and component tests and 27
+real-browser tests. It validated 11 manifests and locks, 15 schemas and 55 records,
+308 local links, 183 immutable research hashes, 2 ledgers and 71 source identifiers,
+scanned 508 text files, rendered 9 diagrams and generated a 149-component SBOM. Two
+clean locked builds produced byte-identical Pages archive SHA-256
+`f6adb7998c26bef62a651ec825e3a4426d955af4a09167b264dfa221d0ef28b0`; this
+slice does not change or deploy that static product.
+
+The final independent integration review found no material evidence error. The
+final security diff review sealed exact snapshot
+`codex-security-snapshot/v1:sha256:f0233f6a5d8a4d5b3d31f17ea9b9f65effdf3998f3d5acc833d87da147525f90`
+after reviewing all 31 modified and 29 added files. The remaining pending rows are
+remote publication evidence, not local implementation gaps.

--- a/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
+++ b/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
@@ -5,7 +5,7 @@
 - protected-main base: `e5e6d4db5ac7036198cde64279e815f214f3defd`
 - supported public product: immutable
   [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
-- activation block: `inline-evidence-and-public-policy-unavailable`
+- current activation block: `transport-and-interoperability-unverified`
 
 ## Purpose
 
@@ -46,7 +46,10 @@ The transport-neutral application implements deterministic in-process
   schema without truncation or semantic reinterpretation;
 - stable sorting and catalogue-native source relationships; and
 - opaque deterministic cursors bound to the exact catalogue content root and
-  normalised search criteria.
+  normalised search criteria; and
+- after the bounded EVID-204A follow-up, a server-owned anonymous-open authority,
+  compiled default-deny public policy and required canonical inline receipt on
+  every successful result.
 
 Cursor digests detect corruption and misuse across catalogue or query boundaries.
 They are not an authentication mechanism and convey no authority.
@@ -75,8 +78,8 @@ This candidate has no:
 - MCP listener, discovery response or tool registration;
 - public deployment, public service URL or registry entry;
 - provider adapter or provider network call;
-- public policy decision point, identity integration or rate service; or
-- canonical evidence store or reviewed inline result receipt.
+- external policy decision point, OPA, identity integration or rate service; or
+- evidence store, ledger, lookup or attestation.
 
 The static Explorer remains the only supported public product. It does not depend
 on this process.
@@ -87,12 +90,13 @@ The production activation value is frozen with zero active MCP tools and zero
 active direct-API operations. It has no environment-variable, command-line or test
 escape hatch.
 
-EVID-204 must provide reviewed public policy decisions and canonical inline
-evidence receipts on the shared application path. A later pull request must then
-add and verify the protocol-conformant MCP listener, direct catalogue routes,
-matching lifecycle discovery, malicious-input controls and client
-interoperability. Only that reviewed change may replace the block and advertise a
-catalogue capability.
+The bounded EVID-204A follow-up provides reviewed public policy decisions and
+canonical, non-persisted, non-attested inline evidence on the shared application
+path without activating it. A later pull request must add and verify the
+protocol-conformant MCP listener, direct catalogue routes, matching lifecycle
+discovery, malicious-input controls and client interoperability. Only that reviewed
+change may replace the current block and advertise a catalogue capability.
 
-See the [verification record](MCP-201_VERIFICATION.md) for the distinction between
-the two protected-main slices and their accepted evidence.
+See the [MCP-201 verification record](MCP-201_VERIFICATION.md) and
+[EVID-204A evidence boundary](EVID-204_INLINE_EVIDENCE.md) for the distinction
+between merged capability foundations and inactive follow-up work.

--- a/docs/operations/MCP-201_VERIFICATION.md
+++ b/docs/operations/MCP-201_VERIFICATION.md
@@ -1,7 +1,7 @@
 # MCP-201 verification record
 
-- status: shared catalogue contract and inactive gateway candidate merged on
-  protected `main`; acceptance-evidence run pending
+- status: shared catalogue contract and inactive gateway candidate accepted on
+  protected `main`; EVID-204A remains an inactive local candidate
 - reviewed on: 20 August 2026
 - work item: [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19)
 
@@ -32,9 +32,9 @@ define a bounded foundation for later read-only catalogue delivery.
 
 It does not provide an MCP listener, catalogue API, provider adapter, execution
 path or evidence store. `catalogue.search` and `catalogue.describe` are not
-registered, advertised or active. Its candidate result schema rejects an opaque
-evidence reference rather than implying persistence or attestation that does not
-exist.
+registered, advertised or active. EVID-204A subsequently replaces the earlier
+receiptless candidate result with a required inline receipt that expressly says it
+is not persisted and not attested.
 
 ### Contract scope
 
@@ -97,7 +97,12 @@ listed above completed this slice's remote gate.
 - protected-main merge: `4948890c10adb4f0ac6f427cda21cb0c0c4607dd`
 - acceptance-evidence pull request:
   [28](https://github.com/chris-page-gov/gis-ai-go/pull/28)
-- protected-main acceptance run: pending this docs-only follow-up
+- protected-main acceptance run:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32346195668)
+- protected-main acceptance CodeQL:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32346195675)
+- protected-main acceptance attestation:
+  [41809248](https://github.com/chris-page-gov/gis-ai-go/attestations/41809248)
 
 ### Candidate outcome
 
@@ -118,9 +123,9 @@ The HTTP candidate binds to loopback and exposes only:
 - `GET /openapi.json`, whose contract contains no catalogue operation path.
 
 There is no search or description route, MCP listener or tool registration, public
-deployment, provider call, policy engine or evidence store. The application code
-can be tested directly, but it cannot be activated through an environment variable,
-command-line option or test mode.
+deployment, provider call, external policy service or evidence store. The
+application code can be tested directly, but it cannot be activated through an
+environment variable, command-line option or test mode.
 
 Malformed request identities, hostile unknown keys and non-canonical URL paths fail
 through bounded problem envelopes rather than escaping as raw server errors. The
@@ -157,12 +162,19 @@ commit; the repaired current bytes then received an independent `SHIP` review an
 passed all 38 gateway tests. This does not claim that the absent public service has
 been security-tested as a deployed service.
 
-The pull-request gate and protected-main merge are complete. GitHub did not emit a
-push workflow for the implementation merge during the 15-minute monitored
-acceptance window, so this docs-only follow-up deliberately leaves the
-protected-main acceptance run pending rather than treating absent evidence as a
-pass. Its protected-main run must cover the unchanged runtime tree before this
-slice is recorded complete.
+The pull-request gate and implementation merge completed, but GitHub did not emit a
+push workflow for that runtime merge during the 15-minute monitored acceptance
+window. The unchanged runtime tree was therefore accepted through the subsequent
+docs-only [pull request 28](https://github.com/chris-page-gov/gis-ai-go/pull/28),
+which merged as `87d6a1b4f8fb15597e5ae91132aa9b61dca57667`. Protected-main assurance and
+provenance passed in
+[run 32346195668](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32346195668),
+CodeQL passed in
+[run 32346195675](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32346195675),
+and [attestation 41809248](https://github.com/chris-page-gov/gis-ai-go/attestations/41809248)
+binds archive SHA-256
+`f6adb7998c26bef62a651ec825e3a4426d955af4a09167b264dfa221d0ef28b0` to that exact
+protected-main commit and run.
 
 The pull-request head and protected-main merge both resolve to tree
 `5b04c4552a0d750aa7a904fbcde4aebd7b1bd1d4`, and the repository had zero open
@@ -174,12 +186,13 @@ check suite or workflow run for the merge.
 No service or new public endpoint is published by either slice. The supported
 public product remains the static `v0.1.0` Explorer.
 
-Activation is hard-blocked as
-`inline-evidence-and-public-policy-unavailable`. EVID-204 must add reviewed public
-policy decisions and canonical inline result receipts to the shared application
-path. A later reviewed MCP-201 change must add and test the protocol-conformant MCP
-listener, direct catalogue routes, lifecycle agreement and interoperability before
-either operation can be advertised or published.
+The EVID-204A local candidate changes the activation reason to
+`transport-and-interoperability-unverified` only after adding reviewed public policy
+decisions and required canonical inline result receipts to the shared application
+path. It does not activate an operation. A later reviewed MCP-201 change must add
+and test the protocol-conformant MCP listener, direct catalogue routes, lifecycle
+agreement and interoperability before either operation can be advertised or
+published.
 
 The durable candidate boundary is documented in
 [MCP-201 inactive gateway candidate](MCP-201_GATEWAY_CANDIDATE.md).

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -19,3 +19,4 @@ MCP service or catalogue API exists.
 - [`v0.1.0` supported-release evidence](V0.1.0_RELEASE_EVIDENCE.md)
 - [MCP-201 inactive gateway candidate boundary](MCP-201_GATEWAY_CANDIDATE.md)
 - [MCP-201 verification record](MCP-201_VERIFICATION.md)
+- [EVID-204 canonical public inline evidence](EVID-204_INLINE_EVIDENCE.md)

--- a/docs/threat-model/README.md
+++ b/docs/threat-model/README.md
@@ -5,3 +5,18 @@ The research threat register is preserved as
 context in the immutable research report. Stage 0 exercises repository, dependency,
 secret, malformed-contract and live-execution boundaries only. It does not claim that
 future identity, policy, provider or hosting risks are controlled.
+
+## EVID-204A public inline-evidence scope
+
+ADR-0010 adds a bounded anonymous-public evidence path for the inactive catalogue
+application. It does not activate or publish a service.
+
+| Research risk | Control in this slice | Residual boundary |
+| --- | --- | --- |
+| RK08 policy bypass | One application success path constructs server authority, evaluates default-deny policy and requires an inline receipt. | Transport registration and every future operation need separate enforcement tests. |
+| RK20 provenance spoofing | Domain-separated identities bind policy, authority, catalogue, parameters, result core, software and record-specific rights. | No signature or computation attestation is claimed. |
+| RK21 audit tampering | Inline receipt mutation and truncation fail verification. | No ledger exists; deletion, overwrite, restart and recovery controls remain open. |
+| RK25 query-history exposure | Receipts retain a semantic-parameter digest rather than raw query or cursor text. | Future operational logs and persistent evidence need separate privacy and retention review. |
+
+The public policy is a compiled checked-in JSON document. It is not OPA, protected
+identity, authentication or an enterprise entitlement decision.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "pnpm run build:okf && pnpm --recursive --if-present run build",
     "typecheck": "pnpm --recursive --if-present run typecheck",
-    "test:typescript": "pnpm --filter @gis-ai-go/contracts run test && pnpm --filter @gis-ai-go/mcp-gateway run test",
+    "test:typescript": "pnpm --filter @gis-ai-go/contracts run test && pnpm --filter @gis-ai-go/evidence run test && pnpm --filter @gis-ai-go/authority-context run test && pnpm --filter @gis-ai-go/policy-client run test && pnpm --filter @gis-ai-go/mcp-gateway run test",
     "test:explorer": "pnpm --filter @gis-ai-go/public-explorer run test:unit",
     "test:browser": "pnpm run build:explorer && pnpm --filter @gis-ai-go/public-explorer run test:browser",
     "test:python": "uv run --locked --cache-dir .uv-cache python -m unittest discover -s tests -p 'test_*.py' && uv run --locked --cache-dir .uv-cache python -m unittest discover -s services/geo-execution/tests -p 'test_*.py'",

--- a/packages/authority-context/README.md
+++ b/packages/authority-context/README.md
@@ -1,4 +1,15 @@
-# Authority-context package boundary
+# Public authority context
 
-Reserved for construction and validation of trusted actor chains. Stage 0 promotes
-the candidate JSON Schema only; it implements no authentication or device posture.
+This package constructs the one authority context available to the first public
+catalogue slice: an anonymous, open, read-only context owned by the gateway. The
+context is content-addressed using RFC 8785 JSON canonicalisation and is
+recursively frozen before it is exported.
+
+`getPublicAuthorityContext()` accepts no caller input. In particular, this
+package does not consume or infer a user, organisation, role, client, device,
+credential, token, entitlement or request time. Authentication and identity
+integration are outside this slice.
+
+The context permits only `catalogue.search` and `catalogue.describe`. Both
+operations require an inline receipt that is explicitly not persisted and not
+attested.

--- a/packages/authority-context/package.json
+++ b/packages/authority-context/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@gis-ai-go/authority-context",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Server-owned anonymous-open authority context for the GIS AI GO public catalogue",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "prepare:test": "pnpm --filter @gis-ai-go/evidence run build",
+    "test": "pnpm run prepare:test && pnpm run build && node --test dist/test/*.test.js"
+  },
+  "dependencies": {
+    "@gis-ai-go/evidence": "workspace:*"
+  }
+}

--- a/packages/authority-context/src/index.ts
+++ b/packages/authority-context/src/index.ts
@@ -1,0 +1,50 @@
+import {
+  CANONICALISATION,
+  buildPublicAuthorityContext,
+  canonicalJsonClone,
+  verifyPublicAuthorityContext,
+  type PublicAuthorityContext,
+  type PublicAuthorityContextCore,
+} from "@gis-ai-go/evidence";
+
+const PUBLIC_AUTHORITY_CONTEXT_CORE = {
+  schema: "gis-ai-go.public-authority-context.v1",
+  canonicalisation: CANONICALISATION,
+  construction: {
+    source: "server",
+    profile: "anonymous-open",
+    product: "gis-ai-go-gateway",
+  },
+  access: {
+    authentication: "none",
+    tier: "open",
+    publication_classification: "public",
+    contains_personal_data: false,
+    contains_protected_data: false,
+    read_only: true,
+  },
+  permitted_operations: ["catalogue.describe", "catalogue.search"],
+  evidence: {
+    receipt: "inline-required",
+    persistence: "not-persisted",
+    attestation: "not-attested",
+  },
+} as const satisfies PublicAuthorityContextCore;
+
+/**
+ * The only authority context in the anonymous public catalogue slice.
+ *
+ * It is constructed entirely from server-owned constants and contains no
+ * identity, entitlement, credential, device or request-time material.
+ */
+export const PUBLIC_AUTHORITY_CONTEXT: PublicAuthorityContext =
+  buildPublicAuthorityContext(PUBLIC_AUTHORITY_CONTEXT_CORE);
+
+if (!verifyPublicAuthorityContext(PUBLIC_AUTHORITY_CONTEXT)) {
+  throw new Error("The server-owned public authority context failed its content identity check");
+}
+
+/** Return a detached, recursively frozen copy of the server-owned context. */
+export function getPublicAuthorityContext(): PublicAuthorityContext {
+  return canonicalJsonClone(PUBLIC_AUTHORITY_CONTEXT);
+}

--- a/packages/authority-context/test/authority-context.test.ts
+++ b/packages/authority-context/test/authority-context.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { canonicalJson, verifyPublicAuthorityContext } from "@gis-ai-go/evidence";
+
+import { PUBLIC_AUTHORITY_CONTEXT, getPublicAuthorityContext } from "../src/index.js";
+
+function assertRecursivelyFrozen(value: unknown): void {
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+  assert.equal(Object.isFrozen(value), true);
+  for (const child of Object.values(value)) {
+    assertRecursivelyFrozen(child);
+  }
+}
+
+function keysIn(value: unknown): Set<string> {
+  const keys = new Set<string>();
+  if (Array.isArray(value)) {
+    for (const child of value) {
+      for (const key of keysIn(child)) keys.add(key);
+    }
+  } else if (value !== null && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      keys.add(key);
+      for (const nested of keysIn(child)) keys.add(nested);
+    }
+  }
+  return keys;
+}
+
+test("constructs a deterministic frozen anonymous-open context without caller input", () => {
+  const first = getPublicAuthorityContext();
+  const second = getPublicAuthorityContext();
+
+  assert.notEqual(first, second);
+  assert.equal(canonicalJson(first), canonicalJson(second));
+  assert.equal(canonicalJson(first), canonicalJson(PUBLIC_AUTHORITY_CONTEXT));
+  assert.equal(verifyPublicAuthorityContext(first), true);
+  assertRecursivelyFrozen(first);
+
+  assert.deepEqual(first.permitted_operations, ["catalogue.describe", "catalogue.search"]);
+  assert.equal(first.construction.source, "server");
+  assert.equal(first.construction.profile, "anonymous-open");
+  assert.equal(first.access.authentication, "none");
+  assert.equal(first.access.read_only, true);
+  assert.equal(first.evidence.persistence, "not-persisted");
+  assert.equal(first.evidence.attestation, "not-attested");
+
+  const forbidden = new Set([
+    "actor",
+    "client",
+    "credential",
+    "device",
+    "entitlement",
+    "organisation",
+    "request_time",
+    "role",
+    "subject",
+    "token",
+    "user_id",
+    "workload",
+  ]);
+  assert.equal([...keysIn(first)].some((key) => forbidden.has(key)), false);
+});
+
+test("detects any mutation of a detached context", () => {
+  const tampered = structuredClone(getPublicAuthorityContext());
+  (tampered.access as unknown as { contains_protected_data: boolean }).contains_protected_data =
+    true;
+  assert.equal(verifyPublicAuthorityContext(tampered), false);
+});

--- a/packages/authority-context/tsconfig.json
+++ b/packages/authority-context/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -17,10 +17,12 @@ authority for transport requests and responses. The checksum-verified OKF bundle
 the authority for catalogue records; TypeScript types do not create new records or
 provider capabilities.
 
-The candidate catalogue result schema deliberately omits a receipt. `EVID-204` must
-add and verify the canonical inline evidence contract before any public catalogue
-tool is activated; an opaque reference must not imply an evidence store that does
-not exist.
+The candidate catalogue result schema requires the canonical EVID-204A inline
+receipt on every successful search and description result. The receipt explicitly
+states that it is not persisted and not attested; it is not an opaque reference to
+an evidence store. Transport activation remains a separately reviewed lifecycle
+decision.
 
 The package does not start a listener, fetch a provider, execute Python, decide
-policy or persist evidence.
+policy or persist evidence. Those responsibilities remain in their bounded
+consumer packages.

--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -1,4 +1,20 @@
 # Evidence package boundary
 
-Reserved for canonical audit events and result receipts. Stage 0 validates a synthetic
-receipt only and does not provide an append-only store or attestation.
+This package supplies deterministic canonical JSON, domain-separated SHA-256
+content identities and closed inline catalogue evidence receipts.
+
+Canonical JSON follows the JSON Canonicalization Scheme rules used by RFC 8785 for
+the supported JSON data model: object keys are ordered by UTF-16 code units,
+strings and numbers use ECMAScript JSON serialisation, and the resulting text is
+encoded as UTF-8. Inputs outside the interoperable JSON model fail closed. This
+includes cycles, sparse arrays, accessors, non-plain objects, `undefined`, `bigint`,
+non-finite numbers and unpaired Unicode surrogates.
+
+Inline receipts bind the normalised request parameters, result core, exact
+catalogue publication, authority context, policy decision, software revision and
+trace identifiers. Raw query text is not retained in a receipt. Every receipt
+states that delivery is inline-only, persistence is absent and attestation is
+absent.
+
+This package does not provide a ledger, evidence lookup, persistence, signing,
+attestation, identity integration, policy decision point or public transport.

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@gis-ai-go/evidence",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Canonical JSON, content identities and inline evidence receipts for GIS AI GO",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "test": "pnpm run build && node --test dist/test/*.test.js"
+  }
+}

--- a/packages/evidence/src/canonical-json.ts
+++ b/packages/evidence/src/canonical-json.ts
@@ -1,0 +1,254 @@
+import { types as utilTypes } from "node:util";
+
+export type CanonicalJsonPrimitive = null | boolean | number | string;
+export type CanonicalJsonValue =
+  | CanonicalJsonPrimitive
+  | readonly CanonicalJsonValue[]
+  | { readonly [key: string]: CanonicalJsonValue };
+
+export type CanonicalJsonErrorCode =
+  | "accessor-property"
+  | "cycle"
+  | "invalid-array-property"
+  | "invalid-number"
+  | "invalid-object-property"
+  | "invalid-string"
+  | "non-plain-object"
+  | "sparse-array"
+  | "unsupported-type";
+
+/** A structured description of a value that cannot be represented canonically. */
+export class CanonicalJsonError extends TypeError {
+  public readonly code: CanonicalJsonErrorCode;
+  public readonly path: string;
+
+  public constructor(code: CanonicalJsonErrorCode, path: string, message: string) {
+    super(`Canonical JSON rejected ${path}: ${message}`);
+    this.name = "CanonicalJsonError";
+    this.code = code;
+    this.path = path;
+  }
+}
+
+function fail(code: CanonicalJsonErrorCode, path: string, message: string): never {
+  throw new CanonicalJsonError(code, path, message);
+}
+
+function safePathForKey(parent: string, key: string): string {
+  const rendered = JSON.stringify(key);
+  return `${parent}[${rendered ?? '"<invalid>"'}]`;
+}
+
+function assertPairedSurrogates(value: string, path: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        fail("invalid-string", path, "contains an unpaired high surrogate");
+      }
+      index += 1;
+      continue;
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      fail("invalid-string", path, "contains an unpaired low surrogate");
+    }
+  }
+}
+
+function ownKeys(value: object, path: string): readonly PropertyKey[] {
+  try {
+    return Reflect.ownKeys(value);
+  } catch {
+    return fail("non-plain-object", path, "own properties could not be inspected");
+  }
+}
+
+function ownDescriptor(value: object, key: PropertyKey, path: string): PropertyDescriptor {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined) {
+      return fail("invalid-object-property", path, "an own property disappeared during inspection");
+    }
+    return descriptor;
+  } catch {
+    return fail("invalid-object-property", path, "an own property could not be inspected");
+  }
+}
+
+function prototypeOf(value: object, path: string): object | null {
+  try {
+    return Object.getPrototypeOf(value) as object | null;
+  } catch {
+    return fail("non-plain-object", path, "the prototype could not be inspected");
+  }
+}
+
+function serialiseArray(value: readonly unknown[], path: string, ancestors: WeakSet<object>): string {
+  if (prototypeOf(value, path) !== Array.prototype) {
+    return fail("non-plain-object", path, "array subclasses are not supported");
+  }
+
+  const keys = ownKeys(value, path);
+  const indexDescriptors = new Map<number, PropertyDescriptor>();
+  for (const key of keys) {
+    if (typeof key !== "string") {
+      return fail("invalid-array-property", path, "non-string properties are not supported");
+    }
+    if (key === "length") {
+      continue;
+    }
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(key)) {
+      return fail("invalid-array-property", path, `unexpected property ${JSON.stringify(key)}`);
+    }
+    const index = Number(key);
+    if (!Number.isSafeInteger(index) || index < 0 || index >= value.length || String(index) !== key) {
+      return fail("invalid-array-property", path, `invalid array index ${JSON.stringify(key)}`);
+    }
+    const itemPath = `${path}[${index}]`;
+    const descriptor = ownDescriptor(value, key, itemPath);
+    if (!("value" in descriptor)) {
+      return fail("accessor-property", itemPath, "accessor properties are not supported");
+    }
+    if (descriptor.enumerable !== true) {
+      return fail("invalid-array-property", itemPath, "array items must be enumerable");
+    }
+    indexDescriptors.set(index, descriptor);
+  }
+
+  if (indexDescriptors.size !== value.length) {
+    return fail("sparse-array", path, "every array index must be present");
+  }
+
+  const items = new Array<string>(value.length);
+  for (const [index, descriptor] of indexDescriptors) {
+    items[index] = serialise(descriptor.value, `${path}[${index}]`, ancestors);
+  }
+  return `[${items.join(",")}]`;
+}
+
+function serialiseObject(
+  value: Record<string, unknown>,
+  path: string,
+  ancestors: WeakSet<object>,
+): string {
+  const prototype = prototypeOf(value, path);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return fail("non-plain-object", path, "only plain objects are supported");
+  }
+
+  const descriptors = new Map<string, PropertyDescriptor>();
+  for (const key of ownKeys(value, path)) {
+    if (typeof key !== "string") {
+      return fail("invalid-object-property", path, "non-string properties are not supported");
+    }
+    assertPairedSurrogates(key, `${path} property name`);
+    const propertyPath = safePathForKey(path, key);
+    const descriptor = ownDescriptor(value, key, propertyPath);
+    if (!("value" in descriptor)) {
+      return fail("accessor-property", propertyPath, "accessor properties are not supported");
+    }
+    if (descriptor.enumerable !== true) {
+      return fail("invalid-object-property", propertyPath, "non-enumerable properties are not supported");
+    }
+    descriptors.set(key, descriptor);
+  }
+
+  // The default JavaScript comparison is defined over UTF-16 code units. Do not
+  // replace this with localeCompare or code-point ordering.
+  const keys = [...descriptors.keys()].sort();
+  const entries = keys.map((key) => {
+    const descriptor = descriptors.get(key);
+    if (descriptor === undefined) {
+      return fail("invalid-object-property", path, "a property disappeared during ordering");
+    }
+    const encodedKey = JSON.stringify(key);
+    if (encodedKey === undefined) {
+      return fail("invalid-string", safePathForKey(path, key), "the property name is invalid");
+    }
+    return `${encodedKey}:${serialise(descriptor.value, safePathForKey(path, key), ancestors)}`;
+  });
+  return `{${entries.join(",")}}`;
+}
+
+function serialise(value: unknown, path: string, ancestors: WeakSet<object>): string {
+  if (value === null) {
+    return "null";
+  }
+  switch (typeof value) {
+    case "boolean":
+      return value ? "true" : "false";
+    case "number": {
+      if (!Number.isFinite(value)) {
+        return fail("invalid-number", path, "numbers must be finite");
+      }
+      const encoded = JSON.stringify(value);
+      if (encoded === undefined) {
+        return fail("invalid-number", path, "the number cannot be serialised");
+      }
+      return encoded;
+    }
+    case "string": {
+      assertPairedSurrogates(value, path);
+      const encoded = JSON.stringify(value);
+      if (encoded === undefined) {
+        return fail("invalid-string", path, "the string cannot be serialised");
+      }
+      return encoded;
+    }
+    case "object": {
+      const objectValue = value as object;
+      if (utilTypes.isProxy(objectValue)) {
+        return fail("non-plain-object", path, "proxy objects are not supported");
+      }
+      if (ancestors.has(objectValue)) {
+        return fail("cycle", path, "cyclic values are not supported");
+      }
+      ancestors.add(objectValue);
+      try {
+        return Array.isArray(value)
+          ? serialiseArray(value, path, ancestors)
+          : serialiseObject(value as Record<string, unknown>, path, ancestors);
+      } finally {
+        ancestors.delete(objectValue);
+      }
+    }
+    case "bigint":
+    case "function":
+    case "symbol":
+    case "undefined":
+      return fail("unsupported-type", path, `${typeof value} is not part of the JSON data model`);
+  }
+  return fail("unsupported-type", path, "the value is not part of the JSON data model");
+}
+
+/**
+ * Serialise a value using RFC 8785 JSON canonicalisation semantics. Values
+ * outside the interoperable JSON data model are rejected rather than omitted or
+ * coerced.
+ */
+export function canonicalJson(value: unknown): string {
+  return serialise(value, "$", new WeakSet<object>());
+}
+
+/** Return a fresh UTF-8 byte sequence for the canonical JSON representation. */
+export function canonicalJsonBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalJson(value));
+}
+
+function freezeJson(value: unknown): void {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
+    return;
+  }
+  for (const child of Object.values(value)) {
+    freezeJson(child);
+  }
+  Object.freeze(value);
+}
+
+/** Validate, detach and recursively freeze a value in the canonical JSON model. */
+export function canonicalJsonClone<T>(value: T): T {
+  const cloned = JSON.parse(canonicalJson(value)) as T;
+  freezeJson(cloned);
+  return cloned;
+}

--- a/packages/evidence/src/digest.ts
+++ b/packages/evidence/src/digest.ts
@@ -1,0 +1,86 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+import { canonicalJsonBytes } from "./canonical-json.js";
+
+export const DOMAIN_SEPARATION_PREFIX = "GIS-AI-GO\u0000canonical-json\u0000sha256\u0000v1\u0000";
+
+const DOMAIN_PATTERN = /^[a-z0-9](?:[a-z0-9.-]{0,126}[a-z0-9])?\.v[1-9][0-9]*$/u;
+const CONTENT_ID_PREFIX_PATTERN = /^gis-ai-go:[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+
+export const CANONICAL_DOMAINS = Object.freeze({
+  authorityContext: "gis-ai-go.public-authority-context.v1",
+  catalogueParameters: "gis-ai-go.catalogue-parameters.v1",
+  catalogueResultCore: "gis-ai-go.catalogue-result-core.v1",
+  evidenceReceipt: "gis-ai-go.evidence-receipt.v1",
+  publicPolicy: "gis-ai-go.public-policy.v1",
+  publicPolicyDecision: "gis-ai-go.public-policy-decision.v1",
+} as const);
+
+export interface CanonicalDigest<D extends string = string> {
+  readonly domain: D;
+  readonly sha256: string;
+}
+
+function assertDomain(domain: string): void {
+  if (!DOMAIN_PATTERN.test(domain)) {
+    throw new TypeError(
+      "Canonical digest domain must be a bounded lower-case ASCII name ending in a non-zero .v version",
+    );
+  }
+}
+
+function assertContentIdPrefix(prefix: string): void {
+  if (!CONTENT_ID_PREFIX_PATTERN.test(prefix)) {
+    throw new TypeError("Content identity prefix must be a lower-case gis-ai-go namespace");
+  }
+}
+
+/** Hash canonical JSON in an unambiguous product/version/domain envelope. */
+export function domainSeparatedSha256(domain: string, value: unknown): string {
+  assertDomain(domain);
+  return createHash("sha256")
+    .update(DOMAIN_SEPARATION_PREFIX, "utf8")
+    .update(domain, "utf8")
+    .update("\u0000", "utf8")
+    .update(canonicalJsonBytes(value))
+    .digest("hex");
+}
+
+export function canonicalDigest<const D extends string>(
+  domain: D,
+  value: unknown,
+): CanonicalDigest<D> {
+  return Object.freeze({ domain, sha256: domainSeparatedSha256(domain, value) });
+}
+
+export function contentAddress(prefix: string, domain: string, value: unknown): string {
+  assertContentIdPrefix(prefix);
+  return `${prefix}:sha256:${domainSeparatedSha256(domain, value)}`;
+}
+
+export function verifyDomainSeparatedSha256(
+  expectedSha256: string,
+  domain: string,
+  value: unknown,
+): boolean {
+  if (!SHA256_PATTERN.test(expectedSha256)) {
+    return false;
+  }
+  const actual = domainSeparatedSha256(domain, value);
+  return timingSafeEqual(Buffer.from(expectedSha256, "hex"), Buffer.from(actual, "hex"));
+}
+
+export function verifyContentAddress(
+  expectedId: string,
+  prefix: string,
+  domain: string,
+  value: unknown,
+): boolean {
+  assertContentIdPrefix(prefix);
+  const marker = `${prefix}:sha256:`;
+  if (!expectedId.startsWith(marker)) {
+    return false;
+  }
+  return verifyDomainSeparatedSha256(expectedId.slice(marker.length), domain, value);
+}

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./canonical-json.js";
+export * from "./digest.js";
+export * from "./receipt.js";

--- a/packages/evidence/src/receipt.ts
+++ b/packages/evidence/src/receipt.ts
@@ -1,0 +1,1717 @@
+import {
+  CanonicalJsonError,
+  canonicalJson,
+  canonicalJsonClone,
+  type CanonicalJsonValue,
+} from "./canonical-json.js";
+import {
+  CANONICAL_DOMAINS,
+  canonicalDigest,
+  contentAddress,
+  verifyContentAddress,
+  verifyDomainSeparatedSha256,
+  type CanonicalDigest,
+} from "./digest.js";
+
+export const CANONICALISATION = "rfc8785-jcs" as const;
+
+const SHA40 = /^[0-9a-f]{40}$/u;
+const SHA256 = /^[0-9a-f]{64}$/u;
+const TRACE_ID = /^[0-9a-f]{32}$/u;
+const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u;
+const SEMVER = /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u;
+const DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/u;
+
+const AUTHORITY_ID_PREFIX = "gis-ai-go:public-authority-context";
+const POLICY_ID_PREFIX = "gis-ai-go:public-policy";
+const DECISION_ID_PREFIX = "gis-ai-go:public-policy-decision";
+const RECEIPT_ID_PREFIX = "gis-ai-go:evidence-receipt";
+
+export const PUBLIC_CATALOGUE_OPERATIONS = ["catalogue.describe", "catalogue.search"] as const;
+export type PublicCatalogueOperation = (typeof PUBLIC_CATALOGUE_OPERATIONS)[number];
+
+export const GOVERNED_OPERATIONS = [
+  "artefact.export",
+  "catalogue.describe",
+  "catalogue.search",
+  "data.query",
+  "evidence.inspect",
+  "map.render",
+  "route.plan",
+  "selection.resolve",
+  "spatial.analyse",
+  "spatial.locate",
+  "statistics.compare",
+  "workflow.execute",
+] as const;
+export type GovernedOperation = (typeof GOVERNED_OPERATIONS)[number];
+
+export const PUBLIC_POLICY_OBLIGATIONS = [
+  "inline-evidence-receipt",
+  "not-attested",
+  "not-persisted",
+  "preserve-attribution",
+  "preserve-described-resource-licence",
+  "preserve-record-licence",
+] as const;
+export type PublicPolicyObligation = (typeof PUBLIC_POLICY_OBLIGATIONS)[number];
+
+export interface PublicAuthorityContextCore {
+  readonly schema: "gis-ai-go.public-authority-context.v1";
+  readonly canonicalisation: typeof CANONICALISATION;
+  readonly construction: {
+    readonly source: "server";
+    readonly profile: "anonymous-open";
+    readonly product: "gis-ai-go-gateway";
+  };
+  readonly access: {
+    readonly authentication: "none";
+    readonly tier: "open";
+    readonly publication_classification: "public";
+    readonly contains_personal_data: false;
+    readonly contains_protected_data: false;
+    readonly read_only: true;
+  };
+  readonly permitted_operations: readonly PublicCatalogueOperation[];
+  readonly evidence: {
+    readonly receipt: "inline-required";
+    readonly persistence: "not-persisted";
+    readonly attestation: "not-attested";
+  };
+}
+
+export interface PublicAuthorityContext extends PublicAuthorityContextCore {
+  readonly context_id: string;
+}
+
+export interface PublicPolicyRule {
+  readonly rule_id: "public-catalogue-describe" | "public-catalogue-search";
+  readonly operation: PublicCatalogueOperation;
+  readonly effect: "allow-with-obligations";
+  readonly obligations: readonly PublicPolicyObligation[];
+}
+
+export interface PublicPolicyCore {
+  readonly schema: "gis-ai-go.public-policy.v1";
+  readonly version: string;
+  readonly canonicalisation: typeof CANONICALISATION;
+  readonly compilation: {
+    readonly kind: "compiled-json";
+    readonly runtime: "gis-ai-go-gateway";
+  };
+  readonly default_effect: "deny";
+  readonly applies_to: {
+    readonly authority_profile: "anonymous-open";
+    readonly access_tier: "open";
+    readonly publication_classification: "public";
+    readonly contains_personal_data: false;
+    readonly contains_protected_data: false;
+    readonly read_only: true;
+  };
+  readonly rules: readonly PublicPolicyRule[];
+}
+
+export interface PublicPolicy extends PublicPolicyCore {
+  readonly policy_id: string;
+}
+
+export type PublicPolicyReasonCode =
+  | "authority-context-not-applicable"
+  | "operation-not-allowed"
+  | "publication-not-public"
+  | "public-catalogue-read-allowed";
+
+export interface PublicPolicyDecisionCore {
+  readonly schema: "gis-ai-go.public-policy-decision.v1";
+  readonly canonicalisation: typeof CANONICALISATION;
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly authority_context_id: string;
+  readonly policy_id: string;
+  readonly policy_version: string;
+  readonly policy_default_effect: "deny";
+  readonly operation: GovernedOperation;
+  readonly effect: "allow-with-obligations" | "deny";
+  readonly reason_code: PublicPolicyReasonCode;
+  readonly obligations: readonly PublicPolicyObligation[];
+}
+
+export interface PublicPolicyDecision extends PublicPolicyDecisionCore {
+  readonly decision_id: string;
+}
+
+export interface CatalogueIdentity {
+  readonly id: string;
+  readonly version: string;
+  readonly revision: string;
+  readonly content_root_sha256: string;
+  readonly record_count: number;
+  readonly reviewed_at: string;
+  readonly stale_after: string;
+}
+
+export type EvidenceTransformationName =
+  | "filter-catalogue"
+  | "load-checksum-verified-catalogue"
+  | "normalise-parameters"
+  | "project-result-core";
+
+export interface EvidenceTransformation {
+  readonly name: EvidenceTransformationName;
+  readonly version: "v1";
+}
+
+export interface EvidenceSoftwareIdentity {
+  readonly name: "gis-ai-go-mcp-gateway";
+  readonly version: string;
+  readonly revision: string;
+}
+
+export interface RecordLicenceObligation {
+  readonly record_id: string;
+  readonly record_licence: string;
+  readonly described_resource_licence: string;
+  readonly attribution: string;
+}
+
+export const RECEIPT_VERIFICATION_CHECKS = [
+  "authority-context",
+  "catalogue-integrity",
+  "licence-obligations",
+  "normalised-parameters-digest",
+  "public-policy-decision",
+  "result-core-digest",
+  "schema",
+] as const;
+export type ReceiptVerificationCheck = (typeof RECEIPT_VERIFICATION_CHECKS)[number];
+
+export interface InlineEvidenceReceiptCore {
+  readonly schema: "gis-ai-go.evidence-receipt.v1";
+  readonly created_at: string;
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly operation: {
+    readonly name: PublicCatalogueOperation;
+    readonly contract_version: "v1";
+    readonly normalised_parameters: CanonicalDigest<"gis-ai-go.catalogue-parameters.v1">;
+  };
+  readonly authority_context: PublicAuthorityContext;
+  readonly policy_decision: PublicPolicyDecision;
+  readonly catalogue: CatalogueIdentity;
+  readonly transformations: readonly EvidenceTransformation[];
+  readonly software: EvidenceSoftwareIdentity;
+  readonly result: {
+    readonly domain: "gis-ai-go.catalogue-result-core.v1";
+    readonly sha256: string;
+    readonly media_type: "application/json";
+    readonly returned_record_count: number;
+  };
+  readonly licence_obligations: readonly RecordLicenceObligation[];
+  readonly verification: {
+    readonly status: "passed";
+    readonly canonicalisation: typeof CANONICALISATION;
+    readonly digest_algorithm: "sha256";
+    readonly checks: readonly ReceiptVerificationCheck[];
+  };
+  readonly evidence_handling: {
+    readonly delivery: "inline-only";
+    readonly persistence: "not-persisted";
+    readonly attestation: "not-attested";
+  };
+}
+
+export interface InlineEvidenceReceipt extends InlineEvidenceReceiptCore {
+  readonly receipt_id: string;
+}
+
+export interface InlineReceiptBuildInput {
+  readonly createdAt: string;
+  readonly requestId: string;
+  readonly traceId: string;
+  readonly operation: PublicCatalogueOperation;
+  /** Normalised application parameters. Only their digest is emitted. */
+  readonly normalisedParameters: unknown;
+  readonly authorityContext: PublicAuthorityContext;
+  /** The compiled policy is verified but is not duplicated in the receipt. */
+  readonly publicPolicy: PublicPolicy;
+  readonly policyDecision: PublicPolicyDecision;
+  readonly catalogue: CatalogueIdentity;
+  readonly transformations: readonly EvidenceTransformation[];
+  readonly software: EvidenceSoftwareIdentity;
+  /** Successful result envelope with `evidence_receipt` omitted. */
+  readonly resultCore: unknown;
+  readonly licenceObligations: readonly RecordLicenceObligation[];
+}
+
+export interface InlineReceiptVerificationMaterial {
+  readonly normalisedParameters: unknown;
+  readonly resultCore: unknown;
+  readonly publicPolicy: PublicPolicy;
+  /** Independently derived exact rights for every returned record. */
+  readonly licenceObligations: readonly RecordLicenceObligation[];
+  readonly expectedAuthorityContext?: PublicAuthorityContext;
+  readonly expectedPolicyDecision?: PublicPolicyDecision;
+  readonly expectedCatalogue?: CatalogueIdentity;
+  readonly expectedSoftware?: EvidenceSoftwareIdentity;
+}
+
+export interface InlineReceiptVerificationResult {
+  readonly valid: boolean;
+  readonly checks: readonly ReceiptVerificationCheck[];
+  readonly errors: readonly string[];
+}
+
+export class InlineReceiptError extends TypeError {
+  public readonly path: string;
+
+  public constructor(path: string, message: string) {
+    super(`Inline evidence rejected ${path}: ${message}`);
+    this.name = "InlineReceiptError";
+    this.path = path;
+  }
+}
+
+function fail(path: string, message: string): never {
+  throw new InlineReceiptError(path, message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function recordAt(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    return fail(path, "must be a plain object");
+  }
+  return value;
+}
+
+function stringAt(value: unknown, path: string, maxLength: number): string {
+  if (typeof value !== "string" || value.length === 0 || Array.from(value).length > maxLength) {
+    return fail(path, `must be a non-empty string of at most ${maxLength} Unicode characters`);
+  }
+  return value;
+}
+
+function assertExactKeys(value: Record<string, unknown>, expected: readonly string[], path: string): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    fail(path, "has an unexpected or missing property");
+  }
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  path: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  if (
+    Object.keys(value).some((key) => !allowed.has(key)) ||
+    required.some((key) => !Object.hasOwn(value, key))
+  ) {
+    fail(path, "has an unexpected or missing property");
+  }
+}
+
+function assertRequestId(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string" || value.length > 128 || !REQUEST_ID.test(value)) {
+    fail(path, "must be a valid bounded request identifier");
+  }
+}
+
+function assertTraceId(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string" || !TRACE_ID.test(value)) {
+    fail(path, "must be 32 lower-case hexadecimal characters");
+  }
+}
+
+function assertDateTime(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string" || value.length > 35) {
+    fail(path, "must be a valid RFC 3339 date-time");
+  }
+  const match = DATE_TIME.exec(value);
+  if (match === null) {
+    fail(path, "must be a valid RFC 3339 date-time");
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetSign = match[7] === "-" ? -1 : 1;
+  const offsetHour = match[8] === undefined ? 0 : Number(match[8]);
+  const offsetMinute = match[9] === undefined ? 0 : Number(match[9]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (
+    year < 1 ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth[month - 1]! ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 60 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    fail(path, "must contain a real calendar date and bounded time components");
+  }
+  if (second === 60) {
+    const local = new Date(0);
+    local.setUTCFullYear(year, month - 1, day);
+    local.setUTCHours(hour, minute, 59, 0);
+    const offset = offsetSign * (offsetHour * 60 + offsetMinute) * 60_000;
+    const utc = new Date(local.getTime() - offset);
+    const validLeapPoint =
+      utc.getUTCHours() === 23 &&
+      utc.getUTCMinutes() === 59 &&
+      ((utc.getUTCMonth() === 5 && utc.getUTCDate() === 30) ||
+        (utc.getUTCMonth() === 11 && utc.getUTCDate() === 31));
+    if (!validLeapPoint) {
+      fail(path, "second 60 is valid only at a UTC June or December leap-second boundary");
+    }
+  }
+}
+
+function assertSemver(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string" || value.length > 32 || !SEMVER.test(value)) {
+    fail(path, "must be a bounded semantic version");
+  }
+}
+
+function assertContentId(value: unknown, prefix: string, path: string): asserts value is string {
+  const marker = `${prefix}:sha256:`;
+  if (
+    typeof value !== "string" ||
+    !value.startsWith(marker) ||
+    !SHA256.test(value.slice(marker.length))
+  ) {
+    fail(path, "must be a content-addressed SHA-256 identifier in the expected domain");
+  }
+}
+
+function sameCanonical(left: unknown, right: unknown): boolean {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function sortedUniqueStrings(
+  actual: readonly unknown[],
+  expected: readonly string[],
+  path: string,
+): void {
+  if (
+    actual.length !== expected.length ||
+    actual.some((entry, index) => entry !== expected[index])
+  ) {
+    fail(path, "must contain the canonical sorted values exactly once");
+  }
+}
+
+function identityCore(
+  value: unknown,
+  identityKey: string,
+  path: string,
+): { readonly identity: string; readonly core: Record<string, unknown> } {
+  const record = recordAt(value, path);
+  const identity = record[identityKey];
+  if (typeof identity !== "string") {
+    return fail(`${path}.${identityKey}`, "must be a string");
+  }
+  const core = Object.fromEntries(Object.entries(record).filter(([key]) => key !== identityKey));
+  return { identity, core };
+}
+
+function buildIdentity<TCore, TDocument>(
+  core: TCore,
+  identityKey: string,
+  prefix: string,
+  domain: string,
+): TDocument {
+  const detached = canonicalJsonClone(core);
+  const identity = contentAddress(prefix, domain, detached);
+  return canonicalJsonClone({ ...(detached as object), [identityKey]: identity }) as TDocument;
+}
+
+function assertPublicAuthorityContextCore(
+  value: unknown,
+  path: string,
+  expectIdentity: boolean,
+): asserts value is PublicAuthorityContextCore | PublicAuthorityContext {
+  canonicalJson(value);
+  const context = recordAt(value, path);
+  const keys = [
+    "access",
+    "canonicalisation",
+    "construction",
+    "evidence",
+    "permitted_operations",
+    "schema",
+  ];
+  if (expectIdentity) {
+    keys.push("context_id");
+  }
+  assertExactKeys(context, keys, path);
+  if (context.schema !== "gis-ai-go.public-authority-context.v1") {
+    fail(`${path}.schema`, "must identify the public authority context v1 schema");
+  }
+  if (context.canonicalisation !== CANONICALISATION) {
+    fail(`${path}.canonicalisation`, "must use RFC 8785 JCS");
+  }
+  if (expectIdentity) {
+    assertContentId(context.context_id, AUTHORITY_ID_PREFIX, `${path}.context_id`);
+  }
+
+  const construction = recordAt(context.construction, `${path}.construction`);
+  assertExactKeys(construction, ["product", "profile", "source"], `${path}.construction`);
+  if (
+    construction.source !== "server" ||
+    construction.profile !== "anonymous-open" ||
+    construction.product !== "gis-ai-go-gateway"
+  ) {
+    fail(`${path}.construction`, "must be the fixed server-constructed anonymous-open profile");
+  }
+
+  const access = recordAt(context.access, `${path}.access`);
+  assertExactKeys(
+    access,
+    [
+      "authentication",
+      "contains_personal_data",
+      "contains_protected_data",
+      "publication_classification",
+      "read_only",
+      "tier",
+    ],
+    `${path}.access`,
+  );
+  if (
+    access.authentication !== "none" ||
+    access.tier !== "open" ||
+    access.publication_classification !== "public" ||
+    access.contains_personal_data !== false ||
+    access.contains_protected_data !== false ||
+    access.read_only !== true
+  ) {
+    fail(`${path}.access`, "must describe only public, open, read-only, non-personal data");
+  }
+
+  if (!Array.isArray(context.permitted_operations)) {
+    fail(`${path}.permitted_operations`, "must be an array");
+  }
+  sortedUniqueStrings(
+    context.permitted_operations,
+    PUBLIC_CATALOGUE_OPERATIONS,
+    `${path}.permitted_operations`,
+  );
+
+  const evidence = recordAt(context.evidence, `${path}.evidence`);
+  assertExactKeys(evidence, ["attestation", "persistence", "receipt"], `${path}.evidence`);
+  if (
+    evidence.receipt !== "inline-required" ||
+    evidence.persistence !== "not-persisted" ||
+    evidence.attestation !== "not-attested"
+  ) {
+    fail(`${path}.evidence`, "must require non-persisted, non-attested inline evidence");
+  }
+}
+
+function assertPublicPolicyCore(
+  value: unknown,
+  path: string,
+  expectIdentity: boolean,
+): asserts value is PublicPolicyCore | PublicPolicy {
+  canonicalJson(value);
+  const policy = recordAt(value, path);
+  const keys = [
+    "applies_to",
+    "canonicalisation",
+    "compilation",
+    "default_effect",
+    "rules",
+    "schema",
+    "version",
+  ];
+  if (expectIdentity) {
+    keys.push("policy_id");
+  }
+  assertExactKeys(policy, keys, path);
+  if (policy.schema !== "gis-ai-go.public-policy.v1") {
+    fail(`${path}.schema`, "must identify the public policy v1 schema");
+  }
+  if (policy.canonicalisation !== CANONICALISATION || policy.default_effect !== "deny") {
+    fail(path, "must be RFC 8785 JCS canonicalised and default deny");
+  }
+  assertSemver(policy.version, `${path}.version`);
+  if (expectIdentity) {
+    assertContentId(policy.policy_id, POLICY_ID_PREFIX, `${path}.policy_id`);
+  }
+
+  const compilation = recordAt(policy.compilation, `${path}.compilation`);
+  assertExactKeys(compilation, ["kind", "runtime"], `${path}.compilation`);
+  if (compilation.kind !== "compiled-json" || compilation.runtime !== "gis-ai-go-gateway") {
+    fail(`${path}.compilation`, "must be compiled JSON for the GIS AI GO gateway");
+  }
+
+  const appliesTo = recordAt(policy.applies_to, `${path}.applies_to`);
+  assertExactKeys(
+    appliesTo,
+    [
+      "access_tier",
+      "authority_profile",
+      "contains_personal_data",
+      "contains_protected_data",
+      "publication_classification",
+      "read_only",
+    ],
+    `${path}.applies_to`,
+  );
+  if (
+    appliesTo.authority_profile !== "anonymous-open" ||
+    appliesTo.access_tier !== "open" ||
+    appliesTo.publication_classification !== "public" ||
+    appliesTo.contains_personal_data !== false ||
+    appliesTo.contains_protected_data !== false ||
+    appliesTo.read_only !== true
+  ) {
+    fail(`${path}.applies_to`, "must be limited to anonymous open public read-only data");
+  }
+
+  if (!Array.isArray(policy.rules) || policy.rules.length !== PUBLIC_CATALOGUE_OPERATIONS.length) {
+    fail(`${path}.rules`, "must contain the two public catalogue rules");
+  }
+  const ruleOperations: string[] = [];
+  for (const [index, ruleValue] of policy.rules.entries()) {
+    const rulePath = `${path}.rules[${index}]`;
+    const rule = recordAt(ruleValue, rulePath);
+    assertExactKeys(rule, ["effect", "obligations", "operation", "rule_id"], rulePath);
+    if (!PUBLIC_CATALOGUE_OPERATIONS.includes(rule.operation as PublicCatalogueOperation)) {
+      fail(`${rulePath}.operation`, "must be a public catalogue operation");
+    }
+    const operation = rule.operation as PublicCatalogueOperation;
+    const expectedRuleId =
+      operation === "catalogue.describe" ? "public-catalogue-describe" : "public-catalogue-search";
+    if (rule.rule_id !== expectedRuleId || rule.effect !== "allow-with-obligations") {
+      fail(rulePath, "must map the operation to its fixed allow-with-obligations rule");
+    }
+    if (!Array.isArray(rule.obligations)) {
+      fail(`${rulePath}.obligations`, "must be an array");
+    }
+    sortedUniqueStrings(rule.obligations, PUBLIC_POLICY_OBLIGATIONS, `${rulePath}.obligations`);
+    ruleOperations.push(operation);
+  }
+  sortedUniqueStrings(ruleOperations, PUBLIC_CATALOGUE_OPERATIONS, `${path}.rules`);
+}
+
+function assertPublicPolicyDecisionCore(
+  value: unknown,
+  path: string,
+  expectIdentity: boolean,
+): asserts value is PublicPolicyDecisionCore | PublicPolicyDecision {
+  canonicalJson(value);
+  const decision = recordAt(value, path);
+  const keys = [
+    "authority_context_id",
+    "canonicalisation",
+    "effect",
+    "obligations",
+    "operation",
+    "policy_default_effect",
+    "policy_id",
+    "policy_version",
+    "reason_code",
+    "request_id",
+    "schema",
+    "trace_id",
+  ];
+  if (expectIdentity) {
+    keys.push("decision_id");
+  }
+  assertExactKeys(decision, keys, path);
+  if (
+    decision.schema !== "gis-ai-go.public-policy-decision.v1" ||
+    decision.canonicalisation !== CANONICALISATION ||
+    decision.policy_default_effect !== "deny"
+  ) {
+    fail(path, "must be an RFC 8785 JCS default-deny public policy decision");
+  }
+  if (expectIdentity) {
+    assertContentId(decision.decision_id, DECISION_ID_PREFIX, `${path}.decision_id`);
+  }
+  assertRequestId(decision.request_id, `${path}.request_id`);
+  assertTraceId(decision.trace_id, `${path}.trace_id`);
+  assertContentId(decision.authority_context_id, AUTHORITY_ID_PREFIX, `${path}.authority_context_id`);
+  assertContentId(decision.policy_id, POLICY_ID_PREFIX, `${path}.policy_id`);
+  assertSemver(decision.policy_version, `${path}.policy_version`);
+  if (!GOVERNED_OPERATIONS.includes(decision.operation as GovernedOperation)) {
+    fail(`${path}.operation`, "must be a governed operation");
+  }
+  if (!Array.isArray(decision.obligations)) {
+    fail(`${path}.obligations`, "must be an array");
+  }
+  if (decision.effect === "allow-with-obligations") {
+    if (
+      !PUBLIC_CATALOGUE_OPERATIONS.includes(decision.operation as PublicCatalogueOperation) ||
+      decision.reason_code !== "public-catalogue-read-allowed"
+    ) {
+      fail(path, "an allow decision is limited to a named public catalogue rule");
+    }
+    sortedUniqueStrings(decision.obligations, PUBLIC_POLICY_OBLIGATIONS, `${path}.obligations`);
+    return;
+  }
+  if (decision.effect !== "deny") {
+    fail(`${path}.effect`, "must be allow-with-obligations or deny");
+  }
+  if (
+    ![
+      "authority-context-not-applicable",
+      "operation-not-allowed",
+      "publication-not-public",
+    ].includes(decision.reason_code as string) ||
+    decision.obligations.length !== 0
+  ) {
+    fail(path, "a deny decision must use a controlled deny reason and no obligations");
+  }
+}
+
+export function buildPublicAuthorityContext(
+  core: PublicAuthorityContextCore,
+): PublicAuthorityContext {
+  assertPublicAuthorityContextCore(core, "$.authority_context", false);
+  return buildIdentity<PublicAuthorityContextCore, PublicAuthorityContext>(
+    core,
+    "context_id",
+    AUTHORITY_ID_PREFIX,
+    CANONICAL_DOMAINS.authorityContext,
+  );
+}
+
+export function verifyPublicAuthorityContext(value: unknown): value is PublicAuthorityContext {
+  try {
+    assertPublicAuthorityContextCore(value, "$.authority_context", true);
+    const { identity, core } = identityCore(value, "context_id", "$.authority_context");
+    return verifyContentAddress(
+      identity,
+      AUTHORITY_ID_PREFIX,
+      CANONICAL_DOMAINS.authorityContext,
+      core,
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function buildPublicPolicy(core: PublicPolicyCore): PublicPolicy {
+  assertPublicPolicyCore(core, "$.public_policy", false);
+  return buildIdentity<PublicPolicyCore, PublicPolicy>(
+    core,
+    "policy_id",
+    POLICY_ID_PREFIX,
+    CANONICAL_DOMAINS.publicPolicy,
+  );
+}
+
+export function verifyPublicPolicy(value: unknown): value is PublicPolicy {
+  try {
+    assertPublicPolicyCore(value, "$.public_policy", true);
+    const { identity, core } = identityCore(value, "policy_id", "$.public_policy");
+    return verifyContentAddress(identity, POLICY_ID_PREFIX, CANONICAL_DOMAINS.publicPolicy, core);
+  } catch {
+    return false;
+  }
+}
+
+export function buildPublicPolicyDecision(
+  core: PublicPolicyDecisionCore,
+): PublicPolicyDecision {
+  assertPublicPolicyDecisionCore(core, "$.policy_decision", false);
+  return buildIdentity<PublicPolicyDecisionCore, PublicPolicyDecision>(
+    core,
+    "decision_id",
+    DECISION_ID_PREFIX,
+    CANONICAL_DOMAINS.publicPolicyDecision,
+  );
+}
+
+export function verifyPublicPolicyDecision(value: unknown): value is PublicPolicyDecision {
+  try {
+    assertPublicPolicyDecisionCore(value, "$.policy_decision", true);
+    const { identity, core } = identityCore(value, "decision_id", "$.policy_decision");
+    return verifyContentAddress(
+      identity,
+      DECISION_ID_PREFIX,
+      CANONICAL_DOMAINS.publicPolicyDecision,
+      core,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function assertCatalogue(value: unknown, path: string): asserts value is CatalogueIdentity {
+  const catalogue = recordAt(value, path);
+  assertExactKeys(
+    catalogue,
+    ["content_root_sha256", "id", "record_count", "reviewed_at", "revision", "stale_after", "version"],
+    path,
+  );
+  stringAt(catalogue.id, `${path}.id`, 512);
+  assertSemver(catalogue.version, `${path}.version`);
+  if (typeof catalogue.revision !== "string" || !SHA40.test(catalogue.revision)) {
+    fail(`${path}.revision`, "must be a 40-character lower-case Git revision");
+  }
+  if (typeof catalogue.content_root_sha256 !== "string" || !SHA256.test(catalogue.content_root_sha256)) {
+    fail(`${path}.content_root_sha256`, "must be a SHA-256 digest");
+  }
+  if (
+    !Number.isInteger(catalogue.record_count) ||
+    (catalogue.record_count as number) < 1 ||
+    (catalogue.record_count as number) > 10_000
+  ) {
+    fail(`${path}.record_count`, "must be an integer from 1 to 10000");
+  }
+  assertDateTime(catalogue.reviewed_at, `${path}.reviewed_at`);
+  assertDateTime(catalogue.stale_after, `${path}.stale_after`);
+}
+
+function compareByUnicodeCodePoint(left: string, right: string): number {
+  const leftPoints = Array.from(left, (character) => character.codePointAt(0) ?? 0);
+  const rightPoints = Array.from(right, (character) => character.codePointAt(0) ?? 0);
+  const count = Math.min(leftPoints.length, rightPoints.length);
+  for (let index = 0; index < count; index += 1) {
+    const difference = leftPoints[index]! - rightPoints[index]!;
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return leftPoints.length - rightPoints.length;
+}
+
+function normaliseLicenceObligations(
+  obligations: readonly RecordLicenceObligation[],
+): readonly RecordLicenceObligation[] {
+  if (obligations.length > 100) {
+    fail("$.licence_obligations", "must contain at most 100 records");
+  }
+  const detached = canonicalJsonClone(obligations);
+  const seen = new Set<string>();
+  for (const [index, obligation] of detached.entries()) {
+    const path = `$.licence_obligations[${index}]`;
+    const record = recordAt(obligation, path);
+    assertExactKeys(
+      record,
+      ["attribution", "described_resource_licence", "record_id", "record_licence"],
+      path,
+    );
+    const recordId = stringAt(record.record_id, `${path}.record_id`, 512);
+    stringAt(record.record_licence, `${path}.record_licence`, 2_048);
+    stringAt(record.described_resource_licence, `${path}.described_resource_licence`, 2_048);
+    stringAt(record.attribution, `${path}.attribution`, 8_192);
+    if (seen.has(recordId)) {
+      fail(`${path}.record_id`, "must identify a record only once");
+    }
+    seen.add(recordId);
+  }
+  return canonicalJsonClone([...detached].sort((left, right) =>
+    compareByUnicodeCodePoint(left.record_id, right.record_id),
+  ));
+}
+
+interface ResultCoreBinding {
+  readonly returnedRecordIds: readonly string[];
+}
+
+const RECORD_TYPES = ["bundle", "dataset", "provider", "source", "workflow"] as const;
+const AUTHORITY_CLASSES = ["derived", "project-authoritative", "source-authoritative"] as const;
+const ACCESS_STATES = ["planned-non-executing", "public", "public-metadata"] as const;
+const RIGHTS_STATES = ["metadata-citation", "open-with-conditions", "project-mit"] as const;
+const FRESHNESS_STATES = ["current", "review-required"] as const;
+const RECORD_STATUSES = [
+  "candidate",
+  "candidate-metadata",
+  "candidate-non-executing",
+  "external-source",
+] as const;
+const SOURCE_NATIVE_STRING_UNSAFE =
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+const SOURCE_NATIVE_KEY_UNSAFE =
+  /[\u0000-\u001f\u007f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+const SOURCE_NATIVE_DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function assertInteger(value: unknown, minimum: number, maximum: number, path: string): number {
+  if (!Number.isInteger(value) || (value as number) < minimum || (value as number) > maximum) {
+    return fail(path, `must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value as number;
+}
+
+function assertVocabulary(
+  value: unknown,
+  allowed: readonly string[],
+  path: string,
+): asserts value is string {
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    fail(path, "must use the closed contract vocabulary");
+  }
+}
+
+function assertUniqueJson(values: readonly unknown[], path: string): void {
+  const seen = new Set<string>();
+  for (const [index, value] of values.entries()) {
+    const identity = canonicalJson(value);
+    if (seen.has(identity)) {
+      fail(`${path}[${index}]`, "must be unique");
+    }
+    seen.add(identity);
+  }
+}
+
+function assertStringArray(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+  itemMaximum: number,
+  path: string,
+): asserts value is readonly string[] {
+  if (!Array.isArray(value) || value.length < minimum || value.length > maximum) {
+    fail(path, `must contain from ${minimum} to ${maximum} items`);
+  }
+  value.forEach((item, index) => stringAt(item, `${path}[${index}]`, itemMaximum));
+  assertUniqueJson(value, path);
+}
+
+function assertRecordSummary(value: unknown, path: string): string {
+  const record = recordAt(value, path);
+  assertExactKeys(
+    record,
+    [
+      "access",
+      "authority",
+      "description",
+      "freshness",
+      "id",
+      "rights",
+      "status",
+      "tags",
+      "title",
+      "type",
+    ],
+    path,
+  );
+  const id = stringAt(record.id, `${path}.id`, 512);
+  assertVocabulary(record.type, RECORD_TYPES, `${path}.type`);
+  stringAt(record.title, `${path}.title`, 512);
+  stringAt(record.description, `${path}.description`, 4_096);
+  assertVocabulary(record.authority, AUTHORITY_CLASSES, `${path}.authority`);
+  assertVocabulary(record.access, ACCESS_STATES, `${path}.access`);
+  assertVocabulary(record.rights, RIGHTS_STATES, `${path}.rights`);
+  assertVocabulary(record.freshness, FRESHNESS_STATES, `${path}.freshness`);
+  assertVocabulary(record.status, RECORD_STATUSES, `${path}.status`);
+  assertStringArray(record.tags, 0, 50, 128, `${path}.tags`);
+  return id;
+}
+
+function assertAuthority(value: unknown, path: string): void {
+  const authority = recordAt(value, path);
+  assertExactKeys(authority, ["class", "source", "statement"], path);
+  assertVocabulary(authority.class, AUTHORITY_CLASSES, `${path}.class`);
+  stringAt(authority.statement, `${path}.statement`, 4_096);
+  stringAt(authority.source, `${path}.source`, 512);
+}
+
+function assertPublication(value: unknown, path: string): void {
+  const publication = recordAt(value, path);
+  assertExactKeys(
+    publication,
+    ["classification", "contains_personal_data", "contains_protected_data"],
+    path,
+  );
+  if (
+    publication.classification !== "public" ||
+    publication.contains_personal_data !== false ||
+    publication.contains_protected_data !== false
+  ) {
+    fail(path, "must be the public non-personal, non-protected publication boundary");
+  }
+}
+
+function assertRecordAccess(value: unknown, path: string): void {
+  const access = recordAt(value, path);
+  assertExactKeys(access, ["authentication", "state", "tier"], path);
+  if (access.tier !== "open") {
+    fail(`${path}.tier`, "must be open");
+  }
+  assertVocabulary(access.state, ACCESS_STATES, `${path}.state`);
+  stringAt(access.authentication, `${path}.authentication`, 512);
+}
+
+function assertRecordRights(value: unknown, path: string): void {
+  const rights = recordAt(value, path);
+  assertExactKeys(
+    rights,
+    ["attribution", "described_resource_licence", "record_licence", "state"],
+    path,
+  );
+  assertVocabulary(rights.state, RIGHTS_STATES, `${path}.state`);
+  stringAt(rights.record_licence, `${path}.record_licence`, 2_048);
+  stringAt(rights.described_resource_licence, `${path}.described_resource_licence`, 2_048);
+  stringAt(rights.attribution, `${path}.attribution`, 8_192);
+}
+
+function assertFreshness(value: unknown, path: string): void {
+  const freshness = recordAt(value, path);
+  assertExactKeys(freshness, ["observed_at", "reviewed_at", "stale_after", "status"], path);
+  assertDateTime(freshness.observed_at, `${path}.observed_at`);
+  assertDateTime(freshness.reviewed_at, `${path}.reviewed_at`);
+  assertDateTime(freshness.stale_after, `${path}.stale_after`);
+  assertVocabulary(freshness.status, FRESHNESS_STATES, `${path}.status`);
+}
+
+function assertSourceNativeValue(value: unknown, path: string): void {
+  if (value === null || typeof value === "boolean") {
+    return;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      fail(path, "must be a finite source-native number");
+    }
+    return;
+  }
+  if (typeof value === "string") {
+    if (Array.from(value).length > 65_536 || SOURCE_NATIVE_STRING_UNSAFE.test(value)) {
+      fail(path, "contains unbounded or unsafe source-native text");
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > 10_000) {
+      fail(path, "contains too many source-native array items");
+    }
+    value.forEach((item, index) => assertSourceNativeValue(item, `${path}[${index}]`));
+    return;
+  }
+  const object = recordAt(value, path);
+  const keys = Object.keys(object);
+  if (keys.length > 256) {
+    fail(path, "contains too many source-native object properties");
+  }
+  for (const key of keys) {
+    if (
+      Array.from(key).length < 1 ||
+      Array.from(key).length > 256 ||
+      SOURCE_NATIVE_KEY_UNSAFE.test(key) ||
+      SOURCE_NATIVE_DANGEROUS_KEYS.has(key)
+    ) {
+      fail(path, "contains an unsafe source-native property name");
+    }
+    assertSourceNativeValue(object[key], `${path}.${key}`);
+  }
+}
+
+function assertRecordDetail(value: unknown, path: string): string {
+  const record = recordAt(value, path);
+  assertExactKeys(
+    record,
+    [
+      "access",
+      "authority",
+      "description",
+      "details",
+      "freshness",
+      "id",
+      "limitations",
+      "publication",
+      "rights",
+      "source_refs",
+      "status",
+      "tags",
+      "title",
+      "type",
+    ],
+    path,
+  );
+  const id = stringAt(record.id, `${path}.id`, 512);
+  assertVocabulary(record.type, RECORD_TYPES, `${path}.type`);
+  stringAt(record.title, `${path}.title`, 512);
+  stringAt(record.description, `${path}.description`, 4_096);
+  assertAuthority(record.authority, `${path}.authority`);
+  assertPublication(record.publication, `${path}.publication`);
+  assertRecordAccess(record.access, `${path}.access`);
+  assertRecordRights(record.rights, `${path}.rights`);
+  assertFreshness(record.freshness, `${path}.freshness`);
+  assertVocabulary(record.status, RECORD_STATUSES, `${path}.status`);
+  assertStringArray(record.source_refs, 1, 99, 512, `${path}.source_refs`);
+  assertStringArray(record.limitations, 1, 50, 2_048, `${path}.limitations`);
+  assertStringArray(record.tags, 0, 50, 128, `${path}.tags`);
+  if (!isRecord(record.details)) {
+    fail(`${path}.details`, "must be a source-native object");
+  }
+  assertSourceNativeValue(record.details, `${path}.details`);
+  return id;
+}
+
+function assertWarnings(value: unknown, path: string): void {
+  assertStringArray(value, 0, 20, 1_024, path);
+}
+
+function assertFacetGroup(
+  value: unknown,
+  maximum: number,
+  vocabulary: readonly string[] | null,
+  path: string,
+): void {
+  if (!Array.isArray(value) || value.length > maximum) {
+    fail(path, `must contain at most ${maximum} facet counts`);
+  }
+  const seenValues = new Set<string>();
+  for (const [index, entryValue] of value.entries()) {
+    const entryPath = `${path}[${index}]`;
+    const entry = recordAt(entryValue, entryPath);
+    assertExactKeys(entry, ["count", "value"], entryPath);
+    let facetValue: string;
+    if (vocabulary === null) {
+      facetValue = stringAt(entry.value, `${entryPath}.value`, 128);
+    } else {
+      assertVocabulary(entry.value, vocabulary, `${entryPath}.value`);
+      facetValue = entry.value as string;
+    }
+    if (seenValues.has(facetValue)) {
+      fail(path, "facet values must be unique");
+    }
+    seenValues.add(facetValue);
+    assertInteger(entry.count, 0, 10_000, `${entryPath}.count`);
+  }
+  assertUniqueJson(value, path);
+}
+
+function assertFacets(value: unknown, path: string): void {
+  const facets = recordAt(value, path);
+  assertExactKeys(facets, ["access", "authority", "freshness", "rights", "tags", "types"], path);
+  assertFacetGroup(facets.types, 5, RECORD_TYPES, `${path}.types`);
+  assertFacetGroup(facets.authority, 3, AUTHORITY_CLASSES, `${path}.authority`);
+  assertFacetGroup(facets.access, 3, ACCESS_STATES, `${path}.access`);
+  assertFacetGroup(facets.rights, 3, RIGHTS_STATES, `${path}.rights`);
+  assertFacetGroup(facets.freshness, 2, FRESHNESS_STATES, `${path}.freshness`);
+  assertFacetGroup(facets.tags, 100, null, `${path}.tags`);
+}
+
+function assertPage(value: unknown, returned: number, path: string): void {
+  const page = recordAt(value, path);
+  assertExactKeys(page, ["limit", "matched", "next_cursor", "returned"], path);
+  const limit = assertInteger(page.limit, 1, 100, `${path}.limit`);
+  const declaredReturned = assertInteger(page.returned, 0, 100, `${path}.returned`);
+  const matched = assertInteger(page.matched, 0, 10_000, `${path}.matched`);
+  if (declaredReturned !== returned || matched < returned || returned > limit) {
+    fail(path, "limit, returned and matched counts must agree with the record array");
+  }
+  if (
+    page.next_cursor !== null &&
+    (typeof page.next_cursor !== "string" ||
+      page.next_cursor.length < 1 ||
+      page.next_cursor.length > 1_024)
+  ) {
+    fail(`${path}.next_cursor`, "must be null or a bounded cursor");
+  }
+}
+
+function assertRelationship(value: unknown, path: string): void {
+  const relationship = recordAt(value, path);
+  assertExactKeys(relationship, ["record_id", "relation"], path);
+  if (relationship.relation !== "source") {
+    fail(`${path}.relation`, "must be source");
+  }
+  stringAt(relationship.record_id, `${path}.record_id`, 512);
+}
+
+function assertSourceSummary(value: unknown, path: string): string {
+  const source = recordAt(value, path);
+  assertExactKeys(source, ["access", "authority", "freshness", "id", "rights", "title"], path);
+  const id = stringAt(source.id, `${path}.id`, 512);
+  stringAt(source.title, `${path}.title`, 512);
+  assertVocabulary(source.authority, AUTHORITY_CLASSES, `${path}.authority`);
+  assertVocabulary(source.access, ACCESS_STATES, `${path}.access`);
+  assertVocabulary(source.rights, RIGHTS_STATES, `${path}.rights`);
+  assertVocabulary(source.freshness, FRESHNESS_STATES, `${path}.freshness`);
+  return id;
+}
+
+function inspectResultCore(
+  resultCore: unknown,
+  operation: PublicCatalogueOperation,
+  requestId: string,
+  traceId: string,
+  catalogue: CatalogueIdentity,
+): ResultCoreBinding {
+  canonicalJson(resultCore);
+  const result = recordAt(resultCore, "$.result_core");
+  assertExactKeys(
+    result,
+    ["catalogue", "data", "operation", "request_id", "schema", "trace_id", "warnings"],
+    "$.result_core",
+  );
+  if (result.schema !== "gis-ai-go.catalogue-result.v1") {
+    fail("$.result_core.schema", "must identify the catalogue result v1 schema");
+  }
+  if (result.operation !== operation || result.request_id !== requestId || result.trace_id !== traceId) {
+    fail("$.result_core", "operation, request and trace identifiers must match the receipt");
+  }
+  if (!sameCanonical(result.catalogue, catalogue)) {
+    fail("$.result_core.catalogue", "must match the receipt catalogue identity");
+  }
+  assertCatalogue(result.catalogue, "$.result_core.catalogue");
+  assertWarnings(result.warnings, "$.result_core.warnings");
+  const data = recordAt(result.data, "$.result_core.data");
+  if (operation === "catalogue.search") {
+    assertExactKeys(data, ["facets", "page", "records"], "$.result_core.data");
+    if (!Array.isArray(data.records) || data.records.length > 100) {
+      fail("$.result_core.data.records", "must be a bounded record array");
+    }
+    const identifiers = data.records.map((entry, index) =>
+      assertRecordSummary(entry, `$.result_core.data.records[${index}]`),
+    );
+    if (new Set(identifiers).size !== identifiers.length) {
+      fail("$.result_core.data.records", "record identifiers must be unique");
+    }
+    assertUniqueJson(data.records, "$.result_core.data.records");
+    assertFacets(data.facets, "$.result_core.data.facets");
+    assertPage(data.page, identifiers.length, "$.result_core.data.page");
+    return { returnedRecordIds: identifiers };
+  }
+  assertExactKeys(data, ["included", "record"], "$.result_core.data");
+  const identifiers = [assertRecordDetail(data.record, "$.result_core.data.record")];
+  const included = recordAt(data.included, "$.result_core.data.included");
+  assertAllowedKeys(included, [], ["relationships", "sources"], "$.result_core.data.included");
+  if (included.relationships !== undefined) {
+    if (!Array.isArray(included.relationships) || included.relationships.length > 100) {
+      fail("$.result_core.data.included.relationships", "must contain at most 100 relationships");
+    }
+    included.relationships.forEach((relationship, index) =>
+      assertRelationship(relationship, `$.result_core.data.included.relationships[${index}]`),
+    );
+    assertUniqueJson(included.relationships, "$.result_core.data.included.relationships");
+  }
+  if (included.sources !== undefined) {
+    if (!Array.isArray(included.sources) || included.sources.length > 99) {
+      fail("$.result_core.data.included.sources", "must contain at most 99 source projections");
+    }
+    for (const [index, source] of included.sources.entries()) {
+      identifiers.push(assertSourceSummary(source, `$.result_core.data.included.sources[${index}]`));
+    }
+    assertUniqueJson(included.sources, "$.result_core.data.included.sources");
+  }
+  if (new Set(identifiers).size !== identifiers.length) {
+    fail("$.result_core.data", "primary and included source record identifiers must be unique");
+  }
+  return { returnedRecordIds: identifiers };
+}
+
+function assertIdentityLinkage(
+  authority: PublicAuthorityContext,
+  policy: PublicPolicy,
+  decision: PublicPolicyDecision,
+  operation: PublicCatalogueOperation,
+  requestId: string,
+  traceId: string,
+): void {
+  if (!verifyPublicAuthorityContext(authority)) {
+    fail("$.authority_context.context_id", "does not match its canonical content");
+  }
+  if (!verifyPublicPolicy(policy)) {
+    fail("$.public_policy.policy_id", "does not match its canonical content");
+  }
+  if (!verifyPublicPolicyDecision(decision)) {
+    fail("$.policy_decision.decision_id", "does not match its canonical content");
+  }
+  if (
+    authority.schema !== "gis-ai-go.public-authority-context.v1" ||
+    authority.canonicalisation !== CANONICALISATION ||
+    authority.construction.source !== "server" ||
+    authority.construction.profile !== "anonymous-open" ||
+    authority.access.authentication !== "none" ||
+    authority.access.tier !== "open" ||
+    authority.access.publication_classification !== "public" ||
+    authority.access.contains_personal_data !== false ||
+    authority.access.contains_protected_data !== false ||
+    authority.access.read_only !== true ||
+    authority.evidence.receipt !== "inline-required" ||
+    authority.evidence.persistence !== "not-persisted" ||
+    authority.evidence.attestation !== "not-attested" ||
+    !authority.permitted_operations.includes(operation)
+  ) {
+    fail("$.authority_context", "is not the applicable anonymous-open public context");
+  }
+  if (
+    policy.schema !== "gis-ai-go.public-policy.v1" ||
+    policy.canonicalisation !== CANONICALISATION ||
+    policy.default_effect !== "deny" ||
+    !SEMVER.test(policy.version)
+  ) {
+    fail("$.public_policy", "is not the compiled default-deny JCS policy");
+  }
+  if (
+    decision.schema !== "gis-ai-go.public-policy-decision.v1" ||
+    decision.canonicalisation !== CANONICALISATION ||
+    decision.authority_context_id !== authority.context_id ||
+    decision.policy_id !== policy.policy_id ||
+    decision.policy_version !== policy.version ||
+    decision.policy_default_effect !== "deny" ||
+    decision.operation !== operation ||
+    decision.request_id !== requestId ||
+    decision.trace_id !== traceId ||
+    decision.effect !== "allow-with-obligations" ||
+    decision.reason_code !== "public-catalogue-read-allowed"
+  ) {
+    fail("$.policy_decision", "does not authorise this exact public catalogue result");
+  }
+  sortedUniqueStrings(decision.obligations, PUBLIC_POLICY_OBLIGATIONS, "$.policy_decision.obligations");
+}
+
+function assertTransformations(
+  value: unknown,
+  operation: PublicCatalogueOperation,
+  path = "$.transformations",
+): asserts value is readonly EvidenceTransformation[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 4) {
+    fail("$.transformations", "must contain between 1 and 4 transformations");
+  }
+  const transformations = value;
+  const seen = new Set<string>();
+  for (const [index, transformationValue] of transformations.entries()) {
+    const itemPath = `${path}[${index}]`;
+    const transformation = recordAt(transformationValue, itemPath);
+    assertExactKeys(transformation, ["name", "version"], itemPath);
+    if (
+      ![
+        "filter-catalogue",
+        "load-checksum-verified-catalogue",
+        "normalise-parameters",
+        "project-result-core",
+      ].includes(transformation.name as string) ||
+      transformation.version !== "v1"
+    ) {
+      fail(itemPath, "must be a supported versioned transformation");
+    }
+    const key = `${transformation.name}:${transformation.version}`;
+    if (seen.has(key)) {
+      fail(itemPath, "must be unique");
+    }
+    seen.add(key);
+  }
+  const expectedNames: readonly EvidenceTransformationName[] =
+    operation === "catalogue.search"
+      ? [
+          "load-checksum-verified-catalogue",
+          "normalise-parameters",
+          "filter-catalogue",
+          "project-result-core",
+        ]
+      : [
+          "load-checksum-verified-catalogue",
+          "normalise-parameters",
+          "project-result-core",
+        ];
+  if (
+    transformations.length !== expectedNames.length ||
+    transformations.some((transformation, index) => transformation.name !== expectedNames[index])
+  ) {
+    fail(path, `must use the exact ordered ${operation} transformation pipeline`);
+  }
+}
+
+function assertSoftware(value: unknown, path = "$.software"): asserts value is EvidenceSoftwareIdentity {
+  const software = recordAt(value, path);
+  assertExactKeys(software, ["name", "revision", "version"], path);
+  if (
+    software.name !== "gis-ai-go-mcp-gateway" ||
+    typeof software.version !== "string" ||
+    software.version.length > 32 ||
+    !SEMVER.test(software.version) ||
+    typeof software.revision !== "string" ||
+    !SHA40.test(software.revision)
+  ) {
+    fail(path, "must identify an exact semantic version and Git revision of the gateway");
+  }
+}
+
+function assertInlineReceiptSchema(value: unknown): asserts value is InlineEvidenceReceipt {
+  canonicalJson(value);
+  const receipt = recordAt(value, "$");
+  assertExactKeys(
+    receipt,
+    [
+      "authority_context",
+      "catalogue",
+      "created_at",
+      "evidence_handling",
+      "licence_obligations",
+      "operation",
+      "policy_decision",
+      "receipt_id",
+      "request_id",
+      "result",
+      "schema",
+      "software",
+      "trace_id",
+      "transformations",
+      "verification",
+    ],
+    "$",
+  );
+  if (receipt.schema !== "gis-ai-go.evidence-receipt.v1") {
+    fail("$.schema", "must identify the inline evidence receipt v1 schema");
+  }
+  assertContentId(receipt.receipt_id, RECEIPT_ID_PREFIX, "$.receipt_id");
+  assertDateTime(receipt.created_at, "$.created_at");
+  assertRequestId(receipt.request_id, "$.request_id");
+  assertTraceId(receipt.trace_id, "$.trace_id");
+
+  const operation = recordAt(receipt.operation, "$.operation");
+  assertExactKeys(operation, ["contract_version", "name", "normalised_parameters"], "$.operation");
+  if (
+    !PUBLIC_CATALOGUE_OPERATIONS.includes(operation.name as PublicCatalogueOperation) ||
+    operation.contract_version !== "v1"
+  ) {
+    fail("$.operation", "must identify a public catalogue v1 operation");
+  }
+  const parameters = recordAt(operation.normalised_parameters, "$.operation.normalised_parameters");
+  assertExactKeys(parameters, ["domain", "sha256"], "$.operation.normalised_parameters");
+  if (
+    parameters.domain !== CANONICAL_DOMAINS.catalogueParameters ||
+    typeof parameters.sha256 !== "string" ||
+    !SHA256.test(parameters.sha256)
+  ) {
+    fail("$.operation.normalised_parameters", "must contain the canonical parameter digest");
+  }
+
+  assertPublicAuthorityContextCore(receipt.authority_context, "$.authority_context", true);
+  assertPublicPolicyDecisionCore(receipt.policy_decision, "$.policy_decision", true);
+  assertCatalogue(receipt.catalogue, "$.catalogue");
+  assertTransformations(receipt.transformations, operation.name as PublicCatalogueOperation);
+  assertSoftware(receipt.software);
+
+  const result = recordAt(receipt.result, "$.result");
+  assertExactKeys(
+    result,
+    ["domain", "media_type", "returned_record_count", "sha256"],
+    "$.result",
+  );
+  if (
+    result.domain !== CANONICAL_DOMAINS.catalogueResultCore ||
+    typeof result.sha256 !== "string" ||
+    !SHA256.test(result.sha256) ||
+    result.media_type !== "application/json" ||
+    !Number.isInteger(result.returned_record_count) ||
+    (result.returned_record_count as number) < 0 ||
+    (result.returned_record_count as number) > 100
+  ) {
+    fail("$.result", "must contain the bounded canonical result-core digest");
+  }
+
+  if (!Array.isArray(receipt.licence_obligations)) {
+    fail("$.licence_obligations", "must be an array");
+  }
+  const obligations = normaliseLicenceObligations(
+    receipt.licence_obligations as unknown as readonly RecordLicenceObligation[],
+  );
+  if (!sameCanonical(obligations, receipt.licence_obligations)) {
+    fail("$.licence_obligations", "must be unique and sorted by record identifier code point");
+  }
+
+  const verification = recordAt(receipt.verification, "$.verification");
+  assertExactKeys(
+    verification,
+    ["canonicalisation", "checks", "digest_algorithm", "status"],
+    "$.verification",
+  );
+  if (
+    verification.status !== "passed" ||
+    verification.canonicalisation !== CANONICALISATION ||
+    verification.digest_algorithm !== "sha256" ||
+    !Array.isArray(verification.checks)
+  ) {
+    fail("$.verification", "must state the fixed successful JCS and SHA-256 semantics");
+  }
+  sortedUniqueStrings(verification.checks, RECEIPT_VERIFICATION_CHECKS, "$.verification.checks");
+
+  const handling = recordAt(receipt.evidence_handling, "$.evidence_handling");
+  assertExactKeys(handling, ["attestation", "delivery", "persistence"], "$.evidence_handling");
+  if (
+    handling.delivery !== "inline-only" ||
+    handling.persistence !== "not-persisted" ||
+    handling.attestation !== "not-attested"
+  ) {
+    fail("$.evidence_handling", "must state inline-only, non-persisted, non-attested handling");
+  }
+}
+
+function assertObligationCoverage(
+  obligations: readonly RecordLicenceObligation[],
+  returnedRecordIds: readonly string[],
+): void {
+  const expected = [...returnedRecordIds].sort(compareByUnicodeCodePoint);
+  const actual = obligations.map((obligation) => obligation.record_id);
+  if (new Set(expected).size !== expected.length || !sameCanonical(actual, expected)) {
+    fail("$.licence_obligations", "must cover each returned record exactly once in code-point order");
+  }
+}
+
+function snapshotBuildInput(value: unknown): InlineReceiptBuildInput {
+  canonicalJson(value);
+  const input = recordAt(value, "$.build_input");
+  assertExactKeys(
+    input,
+    [
+      "authorityContext",
+      "catalogue",
+      "createdAt",
+      "licenceObligations",
+      "normalisedParameters",
+      "operation",
+      "policyDecision",
+      "publicPolicy",
+      "requestId",
+      "resultCore",
+      "software",
+      "traceId",
+      "transformations",
+    ],
+    "$.build_input",
+  );
+  return canonicalJsonClone(value) as InlineReceiptBuildInput;
+}
+
+function snapshotVerificationMaterial(value: unknown): InlineReceiptVerificationMaterial {
+  canonicalJson(value);
+  const material = recordAt(value, "$.verification_material");
+  assertAllowedKeys(
+    material,
+    ["licenceObligations", "normalisedParameters", "publicPolicy", "resultCore"],
+    [
+      "expectedAuthorityContext",
+      "expectedCatalogue",
+      "expectedPolicyDecision",
+      "expectedSoftware",
+    ],
+    "$.verification_material",
+  );
+  return canonicalJsonClone(value) as InlineReceiptVerificationMaterial;
+}
+
+/** Build a detached, immutable, inline-only receipt without retaining raw parameters. */
+export function buildInlineReceipt(input: InlineReceiptBuildInput): InlineEvidenceReceipt {
+  const snapshot = snapshotBuildInput(input);
+  assertDateTime(snapshot.createdAt, "$.created_at");
+  assertRequestId(snapshot.requestId, "$.request_id");
+  assertTraceId(snapshot.traceId, "$.trace_id");
+  if (!PUBLIC_CATALOGUE_OPERATIONS.includes(snapshot.operation)) {
+    fail("$.operation.name", "must be a public catalogue operation");
+  }
+  assertCatalogue(snapshot.catalogue, "$.catalogue");
+  assertTransformations(snapshot.transformations, snapshot.operation);
+  assertSoftware(snapshot.software);
+  assertIdentityLinkage(
+    snapshot.authorityContext,
+    snapshot.publicPolicy,
+    snapshot.policyDecision,
+    snapshot.operation,
+    snapshot.requestId,
+    snapshot.traceId,
+  );
+
+  const resultBinding = inspectResultCore(
+    snapshot.resultCore,
+    snapshot.operation,
+    snapshot.requestId,
+    snapshot.traceId,
+    snapshot.catalogue,
+  );
+  const obligations = normaliseLicenceObligations(snapshot.licenceObligations);
+  assertObligationCoverage(obligations, resultBinding.returnedRecordIds);
+
+  // Canonicalising first also rejects raw material outside the interoperable JSON model.
+  canonicalJson(snapshot.normalisedParameters);
+  const core: InlineEvidenceReceiptCore = {
+    schema: "gis-ai-go.evidence-receipt.v1",
+    created_at: snapshot.createdAt,
+    request_id: snapshot.requestId,
+    trace_id: snapshot.traceId,
+    operation: {
+      name: snapshot.operation,
+      contract_version: "v1",
+      normalised_parameters: canonicalDigest(
+        CANONICAL_DOMAINS.catalogueParameters,
+        snapshot.normalisedParameters,
+      ),
+    },
+    authority_context: snapshot.authorityContext,
+    policy_decision: snapshot.policyDecision,
+    catalogue: snapshot.catalogue,
+    transformations: snapshot.transformations,
+    software: snapshot.software,
+    result: {
+      domain: CANONICAL_DOMAINS.catalogueResultCore,
+      sha256: canonicalDigest(CANONICAL_DOMAINS.catalogueResultCore, snapshot.resultCore).sha256,
+      media_type: "application/json",
+      returned_record_count: resultBinding.returnedRecordIds.length,
+    },
+    licence_obligations: obligations,
+    verification: {
+      status: "passed",
+      canonicalisation: CANONICALISATION,
+      digest_algorithm: "sha256",
+      checks: RECEIPT_VERIFICATION_CHECKS,
+    },
+    evidence_handling: {
+      delivery: "inline-only",
+      persistence: "not-persisted",
+      attestation: "not-attested",
+    },
+  };
+  const receipt = buildIdentity<InlineEvidenceReceiptCore, InlineEvidenceReceipt>(
+    core,
+    "receipt_id",
+    RECEIPT_ID_PREFIX,
+    CANONICAL_DOMAINS.evidenceReceipt,
+  );
+  assertInlineReceiptSchema(receipt);
+  return receipt;
+}
+
+function assertReceiptIdentity(receipt: InlineEvidenceReceipt): void {
+  const { identity, core } = identityCore(receipt, "receipt_id", "$");
+  if (!verifyContentAddress(identity, RECEIPT_ID_PREFIX, CANONICAL_DOMAINS.evidenceReceipt, core)) {
+    fail("$.receipt_id", "does not match the canonical receipt content");
+  }
+}
+
+function assertReceiptConstants(receipt: InlineEvidenceReceipt): void {
+  if (
+    receipt.schema !== "gis-ai-go.evidence-receipt.v1" ||
+    receipt.operation.contract_version !== "v1" ||
+    receipt.operation.normalised_parameters.domain !== CANONICAL_DOMAINS.catalogueParameters ||
+    receipt.result.domain !== CANONICAL_DOMAINS.catalogueResultCore ||
+    receipt.result.media_type !== "application/json" ||
+    receipt.verification.status !== "passed" ||
+    receipt.verification.canonicalisation !== CANONICALISATION ||
+    receipt.verification.digest_algorithm !== "sha256" ||
+    receipt.evidence_handling.delivery !== "inline-only" ||
+    receipt.evidence_handling.persistence !== "not-persisted" ||
+    receipt.evidence_handling.attestation !== "not-attested"
+  ) {
+    fail("$", "fixed inline, verification or digest semantics were changed");
+  }
+  sortedUniqueStrings(receipt.verification.checks, RECEIPT_VERIFICATION_CHECKS, "$.verification.checks");
+}
+
+/**
+ * Verify the receipt against independently supplied parameters, result core and
+ * compiled policy. Errors are bounded and never reflect the raw query material.
+ */
+export function verifyInlineReceipt(
+  receipt: unknown,
+  material: InlineReceiptVerificationMaterial,
+): InlineReceiptVerificationResult {
+  try {
+    const snapshot = snapshotVerificationMaterial(material);
+    assertInlineReceiptSchema(receipt);
+    const candidate = receipt;
+    assertReceiptIdentity(candidate);
+    assertReceiptConstants(candidate);
+    assertDateTime(candidate.created_at, "$.created_at");
+    assertRequestId(candidate.request_id, "$.request_id");
+    assertTraceId(candidate.trace_id, "$.trace_id");
+    if (!PUBLIC_CATALOGUE_OPERATIONS.includes(candidate.operation.name)) {
+      fail("$.operation.name", "must be a public catalogue operation");
+    }
+    assertCatalogue(candidate.catalogue, "$.catalogue");
+    assertTransformations(candidate.transformations, candidate.operation.name);
+    assertSoftware(candidate.software);
+    assertIdentityLinkage(
+      candidate.authority_context,
+      snapshot.publicPolicy,
+      candidate.policy_decision,
+      candidate.operation.name,
+      candidate.request_id,
+      candidate.trace_id,
+    );
+    const resultBinding = inspectResultCore(
+      snapshot.resultCore,
+      candidate.operation.name,
+      candidate.request_id,
+      candidate.trace_id,
+      candidate.catalogue,
+    );
+    const obligations = normaliseLicenceObligations(candidate.licence_obligations);
+    if (!sameCanonical(obligations, candidate.licence_obligations)) {
+      fail("$.licence_obligations", "must be sorted by record identifier code point");
+    }
+    assertObligationCoverage(obligations, resultBinding.returnedRecordIds);
+    const expectedObligations = normaliseLicenceObligations(snapshot.licenceObligations);
+    assertObligationCoverage(expectedObligations, resultBinding.returnedRecordIds);
+    if (!sameCanonical(obligations, expectedObligations)) {
+      fail("$.licence_obligations", "do not match the independently supplied exact record rights");
+    }
+    if (candidate.result.returned_record_count !== resultBinding.returnedRecordIds.length) {
+      fail("$.result.returned_record_count", "does not match the result core");
+    }
+    if (
+      !verifyDomainSeparatedSha256(
+        candidate.operation.normalised_parameters.sha256,
+        CANONICAL_DOMAINS.catalogueParameters,
+        snapshot.normalisedParameters,
+      )
+    ) {
+      fail("$.operation.normalised_parameters.sha256", "does not match the supplied parameters");
+    }
+    if (
+      !verifyDomainSeparatedSha256(
+        candidate.result.sha256,
+        CANONICAL_DOMAINS.catalogueResultCore,
+        snapshot.resultCore,
+      )
+    ) {
+      fail("$.result.sha256", "does not match the supplied result core");
+    }
+    if (
+      snapshot.expectedAuthorityContext !== undefined &&
+      !sameCanonical(candidate.authority_context, snapshot.expectedAuthorityContext)
+    ) {
+      fail("$.authority_context", "does not match the expected authority context");
+    }
+    if (
+      snapshot.expectedPolicyDecision !== undefined &&
+      !sameCanonical(candidate.policy_decision, snapshot.expectedPolicyDecision)
+    ) {
+      fail("$.policy_decision", "does not match the expected policy decision");
+    }
+    if (
+      snapshot.expectedCatalogue !== undefined &&
+      !sameCanonical(candidate.catalogue, snapshot.expectedCatalogue)
+    ) {
+      fail("$.catalogue", "does not match the expected catalogue");
+    }
+    if (
+      snapshot.expectedSoftware !== undefined &&
+      !sameCanonical(candidate.software, snapshot.expectedSoftware)
+    ) {
+      fail("$.software", "does not match the expected software identity");
+    }
+    return Object.freeze({ valid: true, checks: RECEIPT_VERIFICATION_CHECKS, errors: [] });
+  } catch (error) {
+    const message = error instanceof InlineReceiptError
+      ? error.message
+      : error instanceof CanonicalJsonError
+        ? `Inline evidence canonical material failed closed (${error.code})`
+        : "Inline evidence verification failed closed";
+    return Object.freeze({ valid: false, checks: [], errors: Object.freeze([message]) });
+  }
+}

--- a/packages/evidence/test/canonical-json.test.ts
+++ b/packages/evidence/test/canonical-json.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CanonicalJsonError,
+  canonicalJson,
+  canonicalJsonBytes,
+  canonicalJsonClone,
+} from "../src/index.js";
+
+test("matches the RFC 8785 primitive serialisation example", () => {
+  const sample = {
+    numbers: [333333333.33333329, 1e30, 4.5, 2e-3, 1e-27],
+    string: "€$\u000f\nA'B\"\\\\\"/",
+    literals: [null, true, false],
+  };
+
+  assert.equal(
+    canonicalJson(sample),
+    "{\"literals\":[null,true,false],\"numbers\":[333333333.3333333,1e+30,4.5,0.002,1e-27],\"string\":\"€$\\u000f\\nA'B\\\"\\\\\\\\\\\"/\"}",
+  );
+});
+
+test("orders object properties by UTF-16 code units as RFC 8785 requires", () => {
+  const sample = {
+    "€": "Euro Sign",
+    "\r": "Carriage Return",
+    "דּ": "Hebrew Letter Dalet With Dagesh",
+    "1": "One",
+    "😀": "Emoji: Grinning Face",
+    "\u0080": "Control",
+    "ö": "Latin Small Letter O With Diaeresis",
+  };
+
+  assert.equal(
+    canonicalJson(sample),
+    "{\"\\r\":\"Carriage Return\",\"1\":\"One\",\"\":\"Control\",\"ö\":\"Latin Small Letter O With Diaeresis\",\"€\":\"Euro Sign\",\"😀\":\"Emoji: Grinning Face\",\"דּ\":\"Hebrew Letter Dalet With Dagesh\"}",
+  );
+});
+
+test("is independent of object insertion order and emits UTF-8 bytes", () => {
+  const first = { z: 2, nested: { beta: "é", alpha: -0 }, a: 1 };
+  const second = { a: 1, nested: { alpha: 0, beta: "é" }, z: 2 };
+
+  assert.equal(canonicalJson(first), canonicalJson(second));
+  assert.deepEqual(Buffer.from(canonicalJsonBytes({ value: "é" })), Buffer.from('{"value":"é"}', "utf8"));
+});
+
+test("allows shared acyclic values and detached null-prototype objects", () => {
+  const shared = { value: 1 };
+  const detached = Object.create(null) as Record<string, unknown>;
+  detached.second = shared;
+  detached.first = shared;
+
+  assert.equal(canonicalJson(detached), '{"first":{"value":1},"second":{"value":1}}');
+  const clone = canonicalJsonClone(detached);
+  assert.ok(Object.isFrozen(clone));
+  assert.ok(Object.isFrozen((clone as Record<string, object>).first));
+});
+
+test("rejects values outside the interoperable JSON data model", () => {
+  const cycle: Record<string, unknown> = {};
+  cycle.self = cycle;
+  const sparse = new Array(2);
+  sparse[1] = "present";
+  const accessor = Object.defineProperty({}, "value", {
+    enumerable: true,
+    get: () => "not evaluated",
+  });
+  const hidden = Object.defineProperty({}, "value", { enumerable: false, value: 1 });
+  const symbolProperty = { value: 1 } as Record<PropertyKey, unknown>;
+  symbolProperty[Symbol("hidden")] = 2;
+  const extraArray = [1] as unknown[] & { extra?: number };
+  extraArray.extra = 2;
+
+  const hostile: readonly unknown[] = [
+    undefined,
+    1n,
+    Symbol("value"),
+    () => undefined,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    { value: undefined },
+    [undefined],
+    sparse,
+    new Date("2026-08-20T00:00:00Z"),
+    new Map(),
+    new Proxy({ value: 1 }, {}),
+    cycle,
+    accessor,
+    hidden,
+    symbolProperty,
+    extraArray,
+    "\ud800",
+    "\udc00",
+    { "\ud800": "invalid key" },
+  ];
+
+  for (const value of hostile) {
+    assert.throws(() => canonicalJson(value), CanonicalJsonError);
+  }
+});

--- a/packages/evidence/test/digest.test.ts
+++ b/packages/evidence/test/digest.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CANONICAL_DOMAINS,
+  canonicalDigest,
+  contentAddress,
+  domainSeparatedSha256,
+  verifyContentAddress,
+  verifyDomainSeparatedSha256,
+} from "../src/index.js";
+
+test("produces stable domain-separated digests for canonical content", () => {
+  const first = { query: "roads", limit: 20 };
+  const second = { limit: 20, query: "roads" };
+  const digest = domainSeparatedSha256(CANONICAL_DOMAINS.catalogueParameters, first);
+
+  assert.match(digest, /^[0-9a-f]{64}$/u);
+  assert.equal(digest, domainSeparatedSha256(CANONICAL_DOMAINS.catalogueParameters, second));
+  assert.deepEqual(canonicalDigest(CANONICAL_DOMAINS.catalogueParameters, first), {
+    domain: "gis-ai-go.catalogue-parameters.v1",
+    sha256: digest,
+  });
+  assert.equal(verifyDomainSeparatedSha256(digest, CANONICAL_DOMAINS.catalogueParameters, second), true);
+  assert.equal(
+    verifyDomainSeparatedSha256(digest, CANONICAL_DOMAINS.catalogueParameters, { ...second, limit: 21 }),
+    false,
+  );
+});
+
+test("separates equal canonical bytes in different semantic domains", () => {
+  const value = { id: "same-content" };
+  assert.notEqual(
+    domainSeparatedSha256(CANONICAL_DOMAINS.catalogueParameters, value),
+    domainSeparatedSha256(CANONICAL_DOMAINS.catalogueResultCore, value),
+  );
+});
+
+test("creates and verifies namespaced content identities", () => {
+  const value = { schema: "example.v1", value: true };
+  const identity = contentAddress(
+    "gis-ai-go:evidence-receipt",
+    CANONICAL_DOMAINS.evidenceReceipt,
+    value,
+  );
+  assert.match(identity, /^gis-ai-go:evidence-receipt:sha256:[0-9a-f]{64}$/u);
+  assert.equal(
+    verifyContentAddress(
+      identity,
+      "gis-ai-go:evidence-receipt",
+      CANONICAL_DOMAINS.evidenceReceipt,
+      value,
+    ),
+    true,
+  );
+  assert.equal(
+    verifyContentAddress(
+      identity,
+      "gis-ai-go:evidence-receipt",
+      CANONICAL_DOMAINS.evidenceReceipt,
+      { ...value, value: false },
+    ),
+    false,
+  );
+});
+
+test("rejects ambiguous or unversioned digest domains", () => {
+  for (const domain of ["", "example", "Example.v1", "example.v0", "example.v1\u0000other"] as const) {
+    assert.throws(() => domainSeparatedSha256(domain, null), TypeError);
+  }
+});

--- a/packages/evidence/test/fixtures.ts
+++ b/packages/evidence/test/fixtures.ts
@@ -1,0 +1,246 @@
+import {
+  CANONICALISATION,
+  PUBLIC_POLICY_OBLIGATIONS,
+  buildInlineReceipt,
+  buildPublicAuthorityContext,
+  buildPublicPolicy,
+  buildPublicPolicyDecision,
+  type CatalogueIdentity,
+  type EvidenceSoftwareIdentity,
+  type InlineEvidenceReceipt,
+  type InlineReceiptBuildInput,
+  type PublicAuthorityContext,
+  type PublicPolicy,
+  type PublicPolicyDecision,
+  type RecordLicenceObligation,
+} from "../src/index.js";
+
+export const REQUEST_ID = "request-fixture-1";
+export const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+export const CATALOGUE: CatalogueIdentity = Object.freeze({
+  id: "urn:gis-ai-go:okf:public-catalogue",
+  version: "0.1.0",
+  revision: "4948890c10adb4f0ac6f427cda21cb0c0c4607dd",
+  content_root_sha256: "57bfb5a190424289ea09b7eb0729ecdad08292ec7cb8abed148ddf29c9f975d1",
+  record_count: 36,
+  reviewed_at: "2026-08-20T06:00:00Z",
+  stale_after: "2026-11-20T06:00:00Z",
+});
+
+export const SOFTWARE: EvidenceSoftwareIdentity = Object.freeze({
+  name: "gis-ai-go-mcp-gateway",
+  version: "0.1.0",
+  revision: "4948890c10adb4f0ac6f427cda21cb0c0c4607dd",
+});
+
+export function makeAuthorityContext(): PublicAuthorityContext {
+  return buildPublicAuthorityContext({
+    schema: "gis-ai-go.public-authority-context.v1",
+    canonicalisation: CANONICALISATION,
+    construction: {
+      source: "server",
+      profile: "anonymous-open",
+      product: "gis-ai-go-gateway",
+    },
+    access: {
+      authentication: "none",
+      tier: "open",
+      publication_classification: "public",
+      contains_personal_data: false,
+      contains_protected_data: false,
+      read_only: true,
+    },
+    permitted_operations: ["catalogue.describe", "catalogue.search"],
+    evidence: {
+      receipt: "inline-required",
+      persistence: "not-persisted",
+      attestation: "not-attested",
+    },
+  });
+}
+
+export function makePublicPolicy(): PublicPolicy {
+  return buildPublicPolicy({
+    schema: "gis-ai-go.public-policy.v1",
+    version: "1.0.0",
+    canonicalisation: CANONICALISATION,
+    compilation: {
+      kind: "compiled-json",
+      runtime: "gis-ai-go-gateway",
+    },
+    default_effect: "deny",
+    applies_to: {
+      authority_profile: "anonymous-open",
+      access_tier: "open",
+      publication_classification: "public",
+      contains_personal_data: false,
+      contains_protected_data: false,
+      read_only: true,
+    },
+    rules: [
+      {
+        rule_id: "public-catalogue-describe",
+        operation: "catalogue.describe",
+        effect: "allow-with-obligations",
+        obligations: PUBLIC_POLICY_OBLIGATIONS,
+      },
+      {
+        rule_id: "public-catalogue-search",
+        operation: "catalogue.search",
+        effect: "allow-with-obligations",
+        obligations: PUBLIC_POLICY_OBLIGATIONS,
+      },
+    ],
+  });
+}
+
+export function makePolicyDecision(
+  authorityContext = makeAuthorityContext(),
+  publicPolicy = makePublicPolicy(),
+): PublicPolicyDecision {
+  return buildPublicPolicyDecision({
+    schema: "gis-ai-go.public-policy-decision.v1",
+    canonicalisation: CANONICALISATION,
+    request_id: REQUEST_ID,
+    trace_id: TRACE_ID,
+    authority_context_id: authorityContext.context_id,
+    policy_id: publicPolicy.policy_id,
+    policy_version: publicPolicy.version,
+    policy_default_effect: "deny",
+    operation: "catalogue.search",
+    effect: "allow-with-obligations",
+    reason_code: "public-catalogue-read-allowed",
+    obligations: PUBLIC_POLICY_OBLIGATIONS,
+  });
+}
+
+export function makeResultCore(): Record<string, unknown> {
+  return {
+    schema: "gis-ai-go.catalogue-result.v1",
+    operation: "catalogue.search",
+    request_id: REQUEST_ID,
+    trace_id: TRACE_ID,
+    catalogue: CATALOGUE,
+    warnings: [],
+    data: {
+      records: [
+        {
+          id: "urn:record:😀",
+          type: "dataset",
+          title: "Supplementary-plane record",
+          description: "A public synthetic record.",
+          authority: "project-authoritative",
+          access: "public-metadata",
+          rights: "project-mit",
+          freshness: "current",
+          status: "candidate",
+          tags: ["synthetic"],
+        },
+        {
+          id: "urn:record:\ue000",
+          type: "source",
+          title: "Private-use record",
+          description: "A second public synthetic record.",
+          authority: "source-authoritative",
+          access: "public",
+          rights: "open-with-conditions",
+          freshness: "review-required",
+          status: "external-source",
+          tags: [],
+        },
+      ],
+      facets: {
+        types: [],
+        authority: [],
+        access: [],
+        rights: [],
+        freshness: [],
+        tags: [],
+      },
+      page: {
+        limit: 20,
+        returned: 2,
+        matched: 2,
+        next_cursor: null,
+      },
+    },
+  };
+}
+
+export const LICENCE_OBLIGATIONS: readonly RecordLicenceObligation[] = Object.freeze([
+  Object.freeze({
+    record_id: "urn:record:😀",
+    record_licence: "MIT",
+    described_resource_licence: "Open Government Licence v3.0",
+    attribution: "Supplementary-plane publisher",
+  }),
+  Object.freeze({
+    record_id: "urn:record:\ue000",
+    record_licence: "MIT",
+    described_resource_licence: "Open Government Licence v3.0",
+    attribution: "Private-use publisher",
+  }),
+]);
+
+export interface ReceiptFixture {
+  readonly receipt: InlineEvidenceReceipt;
+  readonly authorityContext: PublicAuthorityContext;
+  readonly publicPolicy: PublicPolicy;
+  readonly policyDecision: PublicPolicyDecision;
+  readonly normalisedParameters: Record<string, unknown>;
+  readonly resultCore: Record<string, unknown>;
+}
+
+export function makeReceiptBuildInput(): InlineReceiptBuildInput {
+  const authorityContext = makeAuthorityContext();
+  const publicPolicy = makePublicPolicy();
+  const policyDecision = makePolicyDecision(authorityContext, publicPolicy);
+  const normalisedParameters = {
+    query: "phrase retained only in digest material",
+    facets: { types: ["dataset"] },
+    limit: 20,
+    cursor: null,
+  };
+  const resultCore = makeResultCore();
+  return {
+    createdAt: "2026-08-20T07:00:00Z",
+    requestId: REQUEST_ID,
+    traceId: TRACE_ID,
+    operation: "catalogue.search",
+    normalisedParameters,
+    authorityContext,
+    publicPolicy,
+    policyDecision,
+    catalogue: CATALOGUE,
+    transformations: [
+      { name: "load-checksum-verified-catalogue", version: "v1" },
+      { name: "normalise-parameters", version: "v1" },
+      { name: "filter-catalogue", version: "v1" },
+      { name: "project-result-core", version: "v1" },
+    ],
+    software: SOFTWARE,
+    resultCore,
+    licenceObligations: LICENCE_OBLIGATIONS,
+  };
+}
+
+export function makeReceiptFixture(): ReceiptFixture {
+  const input = makeReceiptBuildInput();
+  const receipt = buildInlineReceipt(input);
+  const {
+    authorityContext,
+    publicPolicy,
+    policyDecision,
+    normalisedParameters,
+    resultCore,
+  } = input;
+  return {
+    receipt,
+    authorityContext,
+    publicPolicy,
+    policyDecision,
+    normalisedParameters: normalisedParameters as Record<string, unknown>,
+    resultCore: resultCore as Record<string, unknown>,
+  };
+}

--- a/packages/evidence/test/provider-fixtures.test.ts
+++ b/packages/evidence/test/provider-fixtures.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  buildInlineReceipt,
+  verifyInlineReceipt,
+  verifyPublicAuthorityContext,
+  verifyPublicPolicy,
+  verifyPublicPolicyDecision,
+} from "../src/index.js";
+
+function readJson(relativeUrl: string): unknown {
+  return JSON.parse(readFileSync(new URL(relativeUrl, import.meta.url), "utf8")) as unknown;
+}
+
+test("published synthetic fixtures have reproducible content identities", () => {
+  const authorityContext = readJson(
+    "../../../../providers/fixtures/public-authority-context.example.json",
+  );
+  const policyDecision = readJson(
+    "../../../../providers/fixtures/public-policy-decision.example.json",
+  );
+  const receipt = readJson("../../../../providers/fixtures/evidence-receipt.example.json");
+  const publicPolicy = readJson("../../../policy-client/src/public-catalogue-v1.json");
+
+  if (!verifyPublicAuthorityContext(authorityContext)) {
+    assert.fail("the public authority fixture must have a valid content identity");
+  }
+  if (!verifyPublicPolicy(publicPolicy)) {
+    assert.fail("the checked-in policy must have a valid content identity");
+  }
+  if (!verifyPublicPolicyDecision(policyDecision)) {
+    assert.fail("the public policy-decision fixture must have a valid content identity");
+  }
+
+  const normalisedParameters = {
+    query: "inspire",
+    facets: {
+      types: ["dataset"],
+      authority: [],
+      access: [],
+      rights: [],
+      freshness: [],
+      tags: [],
+    },
+    limit: 20,
+    offset: 0,
+  };
+  const catalogue = {
+    id: "gis-ai-go:bundle:public-discovery",
+    version: "0.1.0",
+    revision: "1111111111111111111111111111111111111111",
+    content_root_sha256:
+      "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    record_count: 36,
+    reviewed_at: "2026-08-20T00:00:00Z",
+    stale_after: "2027-02-20T00:00:00Z",
+  };
+  const resultCore = {
+    schema: "gis-ai-go.catalogue-result.v1",
+    operation: "catalogue.search",
+    request_id: "request-public-catalogue-001",
+    trace_id: "0123456789abcdef0123456789abcdef",
+    catalogue,
+    warnings: [],
+    data: {
+      records: [
+        {
+          id: "hmlr:dataset:inspire-index-polygons",
+          type: "dataset",
+          title: "HM Land Registry INSPIRE index polygons",
+          description: "Public discovery metadata with a non-legal boundary caveat.",
+          authority: "source-authoritative",
+          access: "public-metadata",
+          rights: "open-with-conditions",
+          freshness: "current",
+          status: "candidate-metadata",
+          tags: ["hmlr", "boundaries"],
+        },
+      ],
+      facets: {
+        types: [{ value: "dataset", count: 1 }],
+        authority: [{ value: "source-authoritative", count: 1 }],
+        access: [{ value: "public-metadata", count: 1 }],
+        rights: [{ value: "open-with-conditions", count: 1 }],
+        freshness: [{ value: "current", count: 1 }],
+        tags: [{ value: "hmlr", count: 1 }],
+      },
+      page: { limit: 20, returned: 1, matched: 1, next_cursor: null },
+    },
+  };
+  const licenceObligations = [
+    {
+      record_id: "hmlr:dataset:inspire-index-polygons",
+      record_licence: "MIT",
+      described_resource_licence: "Open Government Licence",
+      attribution: "Contains HM Land Registry public sector information.",
+    },
+  ];
+  const software = {
+    name: "gis-ai-go-mcp-gateway" as const,
+    version: "0.1.0",
+    revision: "1111111111111111111111111111111111111111",
+  };
+  const expectedReceipt = buildInlineReceipt({
+    createdAt: "2026-08-20T08:00:00Z",
+    requestId: "request-public-catalogue-001",
+    traceId: "0123456789abcdef0123456789abcdef",
+    operation: "catalogue.search",
+    normalisedParameters,
+    authorityContext,
+    publicPolicy,
+    policyDecision,
+    catalogue,
+    transformations: [
+      { name: "load-checksum-verified-catalogue", version: "v1" },
+      { name: "normalise-parameters", version: "v1" },
+      { name: "filter-catalogue", version: "v1" },
+      { name: "project-result-core", version: "v1" },
+    ],
+    software,
+    resultCore,
+    licenceObligations,
+  });
+
+  assert.deepEqual(receipt, expectedReceipt);
+  assert.deepEqual(
+    verifyInlineReceipt(receipt, {
+      normalisedParameters,
+      resultCore,
+      publicPolicy,
+      licenceObligations,
+      expectedAuthorityContext: authorityContext,
+      expectedPolicyDecision: policyDecision,
+      expectedCatalogue: catalogue,
+      expectedSoftware: software,
+    }),
+    {
+      valid: true,
+      checks: [
+        "authority-context",
+        "catalogue-integrity",
+        "licence-obligations",
+        "normalised-parameters-digest",
+        "public-policy-decision",
+        "result-core-digest",
+        "schema",
+      ],
+      errors: [],
+    },
+  );
+});

--- a/packages/evidence/test/receipt.test.ts
+++ b/packages/evidence/test/receipt.test.ts
@@ -1,0 +1,595 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CANONICALISATION,
+  CANONICAL_DOMAINS,
+  PUBLIC_POLICY_OBLIGATIONS,
+  buildInlineReceipt,
+  buildPublicAuthorityContext,
+  buildPublicPolicyDecision,
+  canonicalJson,
+  contentAddress,
+  domainSeparatedSha256,
+  verifyInlineReceipt,
+  verifyPublicAuthorityContext,
+  verifyPublicPolicy,
+  verifyPublicPolicyDecision,
+  type InlineReceiptBuildInput,
+  type PublicAuthorityContextCore,
+  type PublicPolicy,
+  type PublicPolicyDecisionCore,
+} from "../src/index.js";
+import {
+  CATALOGUE,
+  REQUEST_ID,
+  SOFTWARE,
+  TRACE_ID,
+  makeAuthorityContext,
+  makePolicyDecision,
+  makePublicPolicy,
+  makeReceiptBuildInput,
+  makeReceiptFixture,
+} from "./fixtures.js";
+
+function mutable<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function readdress(
+  value: Record<string, unknown>,
+  identityKey: string,
+  prefix: string,
+  domain: string,
+): void {
+  delete value[identityKey];
+  value[identityKey] = contentAddress(prefix, domain, value);
+}
+
+test("builds and verifies an actual content-addressed inline search receipt", () => {
+  const fixture = makeReceiptFixture();
+  const { receipt } = fixture;
+
+  assert.equal(verifyPublicAuthorityContext(receipt.authority_context), true);
+  assert.equal(verifyPublicPolicy(fixture.publicPolicy), true);
+  assert.equal(verifyPublicPolicyDecision(receipt.policy_decision), true);
+  assert.match(receipt.receipt_id, /^gis-ai-go:evidence-receipt:sha256:[0-9a-f]{64}$/u);
+  assert.equal(receipt.evidence_handling.delivery, "inline-only");
+  assert.equal(receipt.evidence_handling.persistence, "not-persisted");
+  assert.equal(receipt.evidence_handling.attestation, "not-attested");
+  assert.equal(receipt.verification.canonicalisation, "rfc8785-jcs");
+  assert.equal(receipt.result.returned_record_count, 2);
+  assert.deepEqual(
+    receipt.licence_obligations.map((obligation) => obligation.record_id),
+    ["urn:record:\ue000", "urn:record:😀"],
+  );
+  assert.equal(canonicalJson(receipt).includes("phrase retained only in digest material"), false);
+
+  assert.deepEqual(
+    verifyInlineReceipt(receipt, {
+      normalisedParameters: fixture.normalisedParameters,
+      resultCore: fixture.resultCore,
+      publicPolicy: fixture.publicPolicy,
+      licenceObligations: receipt.licence_obligations,
+      expectedAuthorityContext: fixture.authorityContext,
+      expectedPolicyDecision: fixture.policyDecision,
+      expectedCatalogue: CATALOGUE,
+      expectedSoftware: SOFTWARE,
+    }),
+    {
+      valid: true,
+      checks: [
+        "authority-context",
+        "catalogue-integrity",
+        "licence-obligations",
+        "normalised-parameters-digest",
+        "public-policy-decision",
+        "result-core-digest",
+        "schema",
+      ],
+      errors: [],
+    },
+  );
+});
+
+test("is deterministic for insertion-order-equivalent parameter and result material", () => {
+  const first = makeReceiptBuildInput();
+  const firstReceipt = buildInlineReceipt(first);
+  const reorderedResult = {
+    data: (first.resultCore as Record<string, unknown>).data,
+    warnings: [],
+    catalogue: CATALOGUE,
+    trace_id: TRACE_ID,
+    request_id: REQUEST_ID,
+    operation: "catalogue.search",
+    schema: "gis-ai-go.catalogue-result.v1",
+  };
+  const secondReceipt = buildInlineReceipt({
+    ...first,
+    normalisedParameters: {
+      cursor: null,
+      limit: 20,
+      facets: { types: ["dataset"] },
+      query: "phrase retained only in digest material",
+    },
+    resultCore: reorderedResult,
+  });
+
+  assert.equal(firstReceipt.receipt_id, secondReceipt.receipt_id);
+  assert.equal(firstReceipt.result.sha256, secondReceipt.result.sha256);
+  assert.equal(
+    firstReceipt.operation.normalised_parameters.sha256,
+    secondReceipt.operation.normalised_parameters.sha256,
+  );
+});
+
+test("builds and verifies a catalogue description receipt", () => {
+  const authorityContext = makeAuthorityContext();
+  const publicPolicy = makePublicPolicy();
+  const policyDecision = buildPublicPolicyDecision({
+    schema: "gis-ai-go.public-policy-decision.v1",
+    canonicalisation: CANONICALISATION,
+    request_id: REQUEST_ID,
+    trace_id: TRACE_ID,
+    authority_context_id: authorityContext.context_id,
+    policy_id: publicPolicy.policy_id,
+    policy_version: publicPolicy.version,
+    policy_default_effect: "deny",
+    operation: "catalogue.describe",
+    effect: "allow-with-obligations",
+    reason_code: "public-catalogue-read-allowed",
+    obligations: PUBLIC_POLICY_OBLIGATIONS,
+  });
+  const resultCore = {
+    schema: "gis-ai-go.catalogue-result.v1",
+    operation: "catalogue.describe",
+    request_id: REQUEST_ID,
+    trace_id: TRACE_ID,
+    catalogue: CATALOGUE,
+    warnings: [],
+    data: {
+      record: {
+        id: "urn:record:one",
+        type: "dataset",
+        title: "One",
+        description: "A complete synthetic record.",
+        authority: {
+          class: "project-authoritative",
+          statement: "The project is authoritative for this synthetic record.",
+          source: "README.md",
+        },
+        publication: {
+          classification: "public",
+          contains_personal_data: false,
+          contains_protected_data: false,
+        },
+        access: {
+          tier: "open",
+          state: "public-metadata",
+          authentication: "None",
+        },
+        rights: {
+          state: "project-mit",
+          record_licence: "MIT",
+          described_resource_licence: "Open Government Licence v3.0",
+          attribution: "Example publisher",
+        },
+        freshness: {
+          observed_at: "2026-08-20T00:00:00Z",
+          reviewed_at: "2026-08-20T00:00:00Z",
+          stale_after: "2027-02-20T00:00:00Z",
+          status: "current",
+        },
+        status: "candidate",
+        source_refs: ["urn:record:source"],
+        limitations: ["Synthetic fixture only."],
+        tags: ["synthetic"],
+        details: { fixture: true },
+      },
+      included: {
+        relationships: [{ relation: "source", record_id: "urn:record:relationship-only" }],
+        sources: [
+          {
+            id: "urn:record:source",
+            title: "Source",
+            authority: "source-authoritative",
+            access: "public",
+            rights: "open-with-conditions",
+            freshness: "current",
+          },
+        ],
+      },
+    },
+  };
+  const licenceObligations = [
+    {
+      record_id: "urn:record:one",
+      record_licence: "MIT",
+      described_resource_licence: "Open Government Licence v3.0",
+      attribution: "Example publisher",
+    },
+    {
+      record_id: "urn:record:source",
+      record_licence: "MIT",
+      described_resource_licence: "Open Government Licence v3.0",
+      attribution: "Source publisher",
+    },
+  ] as const;
+  const buildInput: InlineReceiptBuildInput = {
+    createdAt: "2026-08-20T07:00:00+01:00",
+    requestId: REQUEST_ID,
+    traceId: TRACE_ID,
+    operation: "catalogue.describe",
+    normalisedParameters: { record_id: "urn:record:one", include: [] },
+    authorityContext,
+    publicPolicy,
+    policyDecision,
+    catalogue: CATALOGUE,
+    transformations: [
+      { name: "load-checksum-verified-catalogue", version: "v1" },
+      { name: "normalise-parameters", version: "v1" },
+      { name: "project-result-core", version: "v1" },
+    ],
+    software: SOFTWARE,
+    resultCore,
+    licenceObligations,
+  };
+  const receipt = buildInlineReceipt(buildInput);
+
+  assert.equal(
+    verifyInlineReceipt(receipt, {
+      normalisedParameters: { include: [], record_id: "urn:record:one" },
+      resultCore,
+      publicPolicy,
+      licenceObligations,
+    }).valid,
+    true,
+  );
+
+  const excessiveSourceRefs = mutable(resultCore);
+  excessiveSourceRefs.data.record.source_refs = Array.from(
+    { length: 100 },
+    (_, index) => `urn:record:source:${index}`,
+  );
+  assert.throws(
+    () => buildInlineReceipt({ ...buildInput, resultCore: excessiveSourceRefs }),
+    /source_refs.*1 to 99 items/u,
+  );
+
+  const readdressedReceipt = mutable(receipt) as unknown as Record<string, unknown>;
+  (readdressedReceipt.result as Record<string, unknown>).sha256 = domainSeparatedSha256(
+    CANONICAL_DOMAINS.catalogueResultCore,
+    excessiveSourceRefs,
+  );
+  readdress(
+    readdressedReceipt,
+    "receipt_id",
+    "gis-ai-go:evidence-receipt",
+    CANONICAL_DOMAINS.evidenceReceipt,
+  );
+  const verification = verifyInlineReceipt(readdressedReceipt, {
+    normalisedParameters: buildInput.normalisedParameters,
+    resultCore: excessiveSourceRefs,
+    publicPolicy,
+    licenceObligations,
+  });
+  assert.equal(verification.valid, false);
+  assert.match(verification.errors.join("\n"), /source_refs.*1 to 99 items/u);
+  assert.equal(receipt.result.returned_record_count, 2);
+  assert.equal(
+    receipt.licence_obligations.some(
+      (obligation) => obligation.record_id === "urn:record:relationship-only",
+    ),
+    false,
+  );
+});
+
+test("supports a content-addressed default-deny policy decision", () => {
+  const authority = makeAuthorityContext();
+  const policy = makePublicPolicy();
+  const core: PublicPolicyDecisionCore = {
+    schema: "gis-ai-go.public-policy-decision.v1",
+    canonicalisation: CANONICALISATION,
+    request_id: REQUEST_ID,
+    trace_id: TRACE_ID,
+    authority_context_id: authority.context_id,
+    policy_id: policy.policy_id,
+    policy_version: policy.version,
+    policy_default_effect: "deny",
+    operation: "data.query",
+    effect: "deny",
+    reason_code: "operation-not-allowed",
+    obligations: [],
+  };
+  const decision = buildPublicPolicyDecision(core);
+  assert.equal(verifyPublicPolicyDecision(decision), true);
+  assert.throws(
+    () =>
+      buildPublicPolicyDecision({
+        ...core,
+        effect: "allow-with-obligations",
+        reason_code: "public-catalogue-read-allowed",
+        obligations: PUBLIC_POLICY_OBLIGATIONS,
+      }),
+    /allow decision is limited/u,
+  );
+});
+
+test("fails verification on parameter, result and receipt tampering", () => {
+  const fixture = makeReceiptFixture();
+  const baseMaterial = {
+    normalisedParameters: fixture.normalisedParameters,
+    resultCore: fixture.resultCore,
+    publicPolicy: fixture.publicPolicy,
+    licenceObligations: fixture.receipt.licence_obligations,
+  };
+
+  assert.equal(
+    verifyInlineReceipt(fixture.receipt, {
+      ...baseMaterial,
+      normalisedParameters: { ...fixture.normalisedParameters, limit: 21 },
+    }).valid,
+    false,
+  );
+  assert.equal(
+    verifyInlineReceipt(fixture.receipt, {
+      ...baseMaterial,
+      resultCore: { ...fixture.resultCore, warnings: ["tampered"] },
+    }).valid,
+    false,
+  );
+  assert.equal(
+    verifyInlineReceipt(fixture.receipt, {
+      ...baseMaterial,
+      licenceObligations: fixture.receipt.licence_obligations.map((obligation, index) =>
+        index === 0 ? { ...obligation, attribution: "tampered attribution" } : obligation,
+      ),
+    }).valid,
+    false,
+  );
+  const tamperedReceipt = mutable(fixture.receipt) as unknown as Record<string, unknown>;
+  (tamperedReceipt.result as Record<string, unknown>).sha256 = "0".repeat(64);
+  assert.equal(verifyInlineReceipt(tamperedReceipt, baseMaterial).valid, false);
+});
+
+test("rejects forbidden semantics even when an attacker recomputes every affected identity", () => {
+  const fixture = makeReceiptFixture();
+  const hostile = mutable(fixture.receipt) as unknown as Record<string, unknown>;
+  const authority = hostile.authority_context as Record<string, unknown>;
+  (authority.construction as Record<string, unknown>).unexpected = "forbidden";
+  readdress(
+    authority,
+    "context_id",
+    "gis-ai-go:public-authority-context",
+    CANONICAL_DOMAINS.authorityContext,
+  );
+  const decision = hostile.policy_decision as Record<string, unknown>;
+  decision.authority_context_id = authority.context_id;
+  readdress(
+    decision,
+    "decision_id",
+    "gis-ai-go:public-policy-decision",
+    CANONICAL_DOMAINS.publicPolicyDecision,
+  );
+  readdress(hostile, "receipt_id", "gis-ai-go:evidence-receipt", CANONICAL_DOMAINS.evidenceReceipt);
+
+  const verification = verifyInlineReceipt(hostile, {
+    normalisedParameters: fixture.normalisedParameters,
+    resultCore: fixture.resultCore,
+    publicPolicy: fixture.publicPolicy,
+    licenceObligations: fixture.receipt.licence_obligations,
+  });
+  assert.equal(verification.valid, false);
+  assert.match(verification.errors[0] ?? "", /unexpected or missing property/u);
+
+  const persisted = mutable(fixture.receipt) as unknown as Record<string, unknown>;
+  (persisted.evidence_handling as Record<string, unknown>).persistence = "persisted";
+  readdress(persisted, "receipt_id", "gis-ai-go:evidence-receipt", CANONICAL_DOMAINS.evidenceReceipt);
+  assert.equal(
+    verifyInlineReceipt(persisted, {
+      normalisedParameters: fixture.normalisedParameters,
+      resultCore: fixture.resultCore,
+      publicPolicy: fixture.publicPolicy,
+      licenceObligations: fixture.receipt.licence_obligations,
+    }).valid,
+    false,
+  );
+});
+
+test("rejects malformed runtime-cast builders and invalid normalised calendar dates", () => {
+  const validAuthority = makeAuthorityContext();
+  const { context_id: _contextId, ...authorityCore } = validAuthority;
+  const extraAuthority = mutable(authorityCore) as PublicAuthorityContextCore & { unexpected: true };
+  extraAuthority.unexpected = true;
+  assert.throws(
+    () => buildPublicAuthorityContext(extraAuthority as PublicAuthorityContextCore),
+    /unexpected or missing property/u,
+  );
+
+  const input = makeReceiptBuildInput();
+  assert.throws(
+    () => buildInlineReceipt({ ...input, createdAt: "2026-02-31T07:00:00Z" }),
+    /real calendar date/u,
+  );
+  assert.throws(
+    () => buildInlineReceipt({ ...input, createdAt: "2026-08-20T24:00:00Z" }),
+    /bounded time components/u,
+  );
+  assert.doesNotThrow(() =>
+    buildInlineReceipt({ ...input, createdAt: "2026-08-20T07:00:00.123456789+01:30" }),
+  );
+  assert.doesNotThrow(() =>
+    buildInlineReceipt({ ...input, createdAt: "1990-12-31T15:59:60-08:00" }),
+  );
+
+  const duplicate = input.licenceObligations[0]!;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, licenceObligations: [duplicate, duplicate] }),
+    /record only once/u,
+  );
+  const wrongCoverage: InlineReceiptBuildInput = {
+    ...input,
+    licenceObligations: [
+      {
+        ...duplicate,
+        record_id: "urn:record:not-returned",
+      },
+      input.licenceObligations[1]!,
+    ],
+  };
+  assert.throws(() => buildInlineReceipt(wrongCoverage), /cover each returned record/u);
+});
+
+test("snapshots build and verification wrappers without invoking accessors or proxies", () => {
+  const input = makeReceiptBuildInput();
+  let operationReads = 0;
+  const stateful = { ...input } as Record<string, unknown>;
+  Object.defineProperty(stateful, "operation", {
+    enumerable: true,
+    get: () => {
+      operationReads += 1;
+      return operationReads < 4 ? "catalogue.search" : "catalogue.describe";
+    },
+  });
+  assert.throws(
+    () => buildInlineReceipt(stateful as unknown as InlineReceiptBuildInput),
+    /accessor properties are not supported/u,
+  );
+  assert.equal(operationReads, 0);
+  assert.throws(
+    () => buildInlineReceipt(new Proxy(input, {}) as InlineReceiptBuildInput),
+    /proxy objects are not supported/u,
+  );
+  assert.throws(
+    () =>
+      buildInlineReceipt({
+        ...input,
+        rawQuery: "must not be accepted on the wrapper",
+      } as unknown as InlineReceiptBuildInput),
+    /unexpected or missing property/u,
+  );
+
+  const receipt = buildInlineReceipt(input);
+  let resultReads = 0;
+  const material = {
+    normalisedParameters: input.normalisedParameters,
+    resultCore: input.resultCore,
+    publicPolicy: input.publicPolicy,
+    licenceObligations: input.licenceObligations,
+  } as Record<string, unknown>;
+  Object.defineProperty(material, "resultCore", {
+    enumerable: true,
+    get: () => {
+      resultReads += 1;
+      return input.resultCore;
+    },
+  });
+  assert.equal(
+    verifyInlineReceipt(receipt, material as unknown as Parameters<typeof verifyInlineReceipt>[1])
+      .valid,
+    false,
+  );
+  assert.equal(resultReads, 0);
+});
+
+test("rejects schema-invalid result cores and false transformation provenance", () => {
+  const input = makeReceiptBuildInput();
+  const resultCore = mutable(input.resultCore) as Record<string, unknown>;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: { ...resultCore, unexpected: true } }),
+    /unexpected or missing property/u,
+  );
+
+  const withoutWarnings = mutable(resultCore);
+  delete withoutWarnings.warnings;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: withoutWarnings }),
+    /unexpected or missing property/u,
+  );
+
+  const missingRecordField = mutable(resultCore);
+  const missingRecordData = missingRecordField.data as Record<string, unknown>;
+  const missingRecords = missingRecordData.records as Record<string, unknown>[];
+  delete missingRecords[0]!.description;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: missingRecordField }),
+    /unexpected or missing property/u,
+  );
+
+  const incompleteFacets = mutable(resultCore);
+  delete ((incompleteFacets.data as Record<string, unknown>).facets as Record<string, unknown>).tags;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: incompleteFacets }),
+    /unexpected or missing property/u,
+  );
+
+  const incompletePage = mutable(resultCore);
+  delete ((incompletePage.data as Record<string, unknown>).page as Record<string, unknown>).matched;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: incompletePage }),
+    /unexpected or missing property/u,
+  );
+
+  const overLimitPage = mutable(resultCore);
+  ((overLimitPage.data as Record<string, unknown>).page as Record<string, unknown>).limit = 1;
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: overLimitPage }),
+    /limit, returned and matched counts must agree/u,
+  );
+
+  const duplicateFacetValue = mutable(resultCore);
+  (((duplicateFacetValue.data as Record<string, unknown>).facets as Record<string, unknown>)
+    .types as unknown[]) = [
+    { value: "dataset", count: 1 },
+    { value: "dataset", count: 2 },
+  ];
+  assert.throws(
+    () => buildInlineReceipt({ ...input, resultCore: duplicateFacetValue }),
+    /facet values must be unique/u,
+  );
+
+  assert.throws(
+    () =>
+      buildInlineReceipt({
+        ...input,
+        transformations: [{ name: "filter-catalogue", version: "v1" }],
+      }),
+    /exact ordered catalogue.search transformation pipeline/u,
+  );
+
+  const fixture = makeReceiptFixture();
+  const readdressed = mutable(fixture.receipt) as unknown as Record<string, unknown>;
+  (readdressed.transformations as unknown[]).reverse();
+  readdress(
+    readdressed,
+    "receipt_id",
+    "gis-ai-go:evidence-receipt",
+    CANONICAL_DOMAINS.evidenceReceipt,
+  );
+  assert.equal(
+    verifyInlineReceipt(readdressed, {
+      normalisedParameters: fixture.normalisedParameters,
+      resultCore: fixture.resultCore,
+      publicPolicy: fixture.publicPolicy,
+      licenceObligations: fixture.receipt.licence_obligations,
+    }).valid,
+    false,
+  );
+});
+
+test("rejects a re-addressed public policy with schema-forbidden content", () => {
+  const fixture = makeReceiptFixture();
+  const hostilePolicy = mutable(fixture.publicPolicy) as unknown as Record<string, unknown>;
+  (hostilePolicy.compilation as Record<string, unknown>).command = "untrusted";
+  readdress(hostilePolicy, "policy_id", "gis-ai-go:public-policy", CANONICAL_DOMAINS.publicPolicy);
+  assert.equal(verifyPublicPolicy(hostilePolicy), false);
+  assert.equal(
+    verifyInlineReceipt(fixture.receipt, {
+      normalisedParameters: fixture.normalisedParameters,
+      resultCore: fixture.resultCore,
+      publicPolicy: hostilePolicy as unknown as PublicPolicy,
+      licenceObligations: fixture.receipt.licence_obligations,
+    }).valid,
+    false,
+  );
+});

--- a/packages/evidence/tsconfig.json
+++ b/packages/evidence/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/policy-client/README.md
+++ b/packages/policy-client/README.md
@@ -1,4 +1,18 @@
-# Policy-client package boundary
+# Compiled public catalogue policy
 
-Reserved for a future engine-neutral policy client. No OPA service or allow decision
-exists in Stage 0.
+This package evaluates one checked-in, content-addressed policy document for the
+anonymous public catalogue. It is a local compiled JSON allow-list with a
+default-deny outcome. Only `catalogue.search` and `catalogue.describe` can be
+allowed, and both carry all six inline evidence and licence obligations.
+
+Before allowing either operation, the evaluator checks that the catalogue is a
+bounded, metadata-only publication whose records are public, open, read-only and
+contain neither personal nor protected data. Other governed operations receive a
+hashed deny decision. An operation outside the governed vocabulary receives an
+explicit deny result without manufacturing a schema-invalid decision.
+
+The authority context is constructed inside the server package; callers cannot
+supply identity, role, device or entitlement claims. This package has no OPA
+client, remote policy decision point, authentication, identity integration or
+entitlement logic. Policy changes require a new checked-in document and content
+identity.

--- a/packages/policy-client/package.json
+++ b/packages/policy-client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@gis-ai-go/policy-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Compiled default-deny policy for the GIS AI GO public catalogue",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "prepare:test": "pnpm --filter @gis-ai-go/contracts run build && pnpm --filter @gis-ai-go/evidence run build && pnpm --filter @gis-ai-go/authority-context run build",
+    "test": "pnpm run prepare:test && pnpm run build && node --test dist/test/*.test.js"
+  },
+  "dependencies": {
+    "@gis-ai-go/authority-context": "workspace:*",
+    "@gis-ai-go/contracts": "workspace:*",
+    "@gis-ai-go/evidence": "workspace:*"
+  }
+}

--- a/packages/policy-client/src/index.ts
+++ b/packages/policy-client/src/index.ts
@@ -1,0 +1,240 @@
+import { getPublicAuthorityContext } from "@gis-ai-go/authority-context";
+import type { CatalogueBundle } from "@gis-ai-go/contracts";
+import {
+  CANONICALISATION,
+  GOVERNED_OPERATIONS,
+  PUBLIC_POLICY_OBLIGATIONS,
+  buildPublicPolicy,
+  buildPublicPolicyDecision,
+  canonicalJson,
+  canonicalJsonClone,
+  verifyPublicAuthorityContext,
+  verifyPublicPolicy,
+  type GovernedOperation,
+  type PublicAuthorityContext,
+  type PublicPolicy,
+  type PublicPolicyCore,
+  type PublicPolicyDecision,
+  type PublicPolicyReasonCode,
+} from "@gis-ai-go/evidence";
+
+import checkedInPolicy from "./public-catalogue-v1.json" with { type: "json" };
+
+const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u;
+const TRACE_ID = /^[0-9a-f]{32}$/u;
+const MAX_CATALOGUE_RECORDS = 10_000;
+
+const PUBLIC_POLICY_CORE = {
+  schema: "gis-ai-go.public-policy.v1",
+  version: "1.0.0",
+  canonicalisation: CANONICALISATION,
+  compilation: {
+    kind: "compiled-json",
+    runtime: "gis-ai-go-gateway",
+  },
+  default_effect: "deny",
+  applies_to: {
+    authority_profile: "anonymous-open",
+    access_tier: "open",
+    publication_classification: "public",
+    contains_personal_data: false,
+    contains_protected_data: false,
+    read_only: true,
+  },
+  rules: [
+    {
+      rule_id: "public-catalogue-describe",
+      operation: "catalogue.describe",
+      effect: "allow-with-obligations",
+      obligations: PUBLIC_POLICY_OBLIGATIONS,
+    },
+    {
+      rule_id: "public-catalogue-search",
+      operation: "catalogue.search",
+      effect: "allow-with-obligations",
+      obligations: PUBLIC_POLICY_OBLIGATIONS,
+    },
+  ],
+} as const satisfies PublicPolicyCore;
+
+const expectedPolicy = buildPublicPolicy(PUBLIC_POLICY_CORE);
+if (
+  !verifyPublicPolicy(checkedInPolicy) ||
+  canonicalJson(checkedInPolicy) !== canonicalJson(expectedPolicy)
+) {
+  throw new Error("The checked-in public catalogue policy failed its content identity check");
+}
+
+/** The exact checked-in compiled policy used by the anonymous public slice. */
+export const PUBLIC_CATALOGUE_POLICY: PublicPolicy = canonicalJsonClone(
+  checkedInPolicy,
+) as PublicPolicy;
+
+export class PublicPolicyInputError extends TypeError {
+  public constructor(message: string) {
+    super(message);
+    this.name = "PublicPolicyInputError";
+  }
+}
+
+export interface PublicPolicyEvaluationInput {
+  readonly requestId: string;
+  readonly traceId: string;
+  readonly operation: string;
+  /** A parsed, checksum-verified catalogue snapshot. */
+  readonly catalogue: CatalogueBundle;
+}
+
+interface PublicPolicyEvaluationBase {
+  readonly allowed: boolean;
+  readonly effect: "allow-with-obligations" | "deny";
+  readonly reasonCode: PublicPolicyReasonCode;
+  readonly authorityContext: PublicAuthorityContext;
+  readonly policy: PublicPolicy;
+}
+
+export interface PublicPolicyDecisionEvaluation extends PublicPolicyEvaluationBase {
+  readonly decision: PublicPolicyDecision;
+}
+
+export interface UnknownOperationDenial extends PublicPolicyEvaluationBase {
+  readonly allowed: false;
+  readonly effect: "deny";
+  readonly reasonCode: "operation-not-allowed";
+  readonly decision: null;
+}
+
+export type PublicPolicyEvaluation = PublicPolicyDecisionEvaluation | UnknownOperationDenial;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Check only the policy-relevant publication boundary of a parsed catalogue.
+ * No record content or caller-supplied authority claims participate.
+ */
+export function isPublicCatalogueBoundary(value: unknown): boolean {
+  try {
+    if (!isRecord(value) || value.schema !== "gis-ai-go-okf-bundle.v1") {
+      return false;
+    }
+    const scope = value.scope;
+    const records = value.records;
+    if (
+      !isRecord(scope) ||
+      scope.kind !== "bounded-public-metadata-discovery" ||
+      scope.metadataOnly !== true ||
+      scope.containsProtectedData !== false ||
+      !Array.isArray(records) ||
+      records.length < 1 ||
+      records.length > MAX_CATALOGUE_RECORDS ||
+      value.recordCount !== records.length
+    ) {
+      return false;
+    }
+    return records.every((record) => {
+      if (!isRecord(record)) return false;
+      const publication = record.publication;
+      const access = record.access;
+      return (
+        isRecord(publication) &&
+        publication.classification === "public" &&
+        publication.containsPersonalData === false &&
+        publication.containsProtectedData === false &&
+        isRecord(access) &&
+        access.tier === "open"
+      );
+    });
+  } catch {
+    return false;
+  }
+}
+
+function isGovernedOperation(operation: string): operation is GovernedOperation {
+  return (GOVERNED_OPERATIONS as readonly string[]).includes(operation);
+}
+
+function assertIdentifiers(requestId: string, traceId: string): void {
+  if (requestId.length > 128 || !REQUEST_ID.test(requestId)) {
+    throw new PublicPolicyInputError("requestId must be a valid bounded request identifier");
+  }
+  if (!TRACE_ID.test(traceId)) {
+    throw new PublicPolicyInputError("traceId must be 32 lower-case hexadecimal characters");
+  }
+}
+
+function freezeEvaluation<T extends PublicPolicyEvaluation>(evaluation: T): T {
+  return Object.freeze(evaluation);
+}
+
+/**
+ * Evaluate the compiled policy without accepting identity or entitlement input.
+ * Unknown operations are explicitly denied and are not forced into the closed
+ * governed-operation decision schema.
+ */
+export function evaluatePublicCataloguePolicy(
+  input: PublicPolicyEvaluationInput,
+): PublicPolicyEvaluation {
+  assertIdentifiers(input.requestId, input.traceId);
+  const authorityContext = getPublicAuthorityContext();
+  if (!verifyPublicAuthorityContext(authorityContext)) {
+    throw new Error("The server-owned authority context failed closed");
+  }
+
+  if (!isGovernedOperation(input.operation)) {
+    return freezeEvaluation({
+      allowed: false,
+      effect: "deny",
+      reasonCode: "operation-not-allowed",
+      authorityContext,
+      policy: PUBLIC_CATALOGUE_POLICY,
+      decision: null,
+    });
+  }
+
+  const rule = PUBLIC_CATALOGUE_POLICY.rules.find(
+    (candidate) => candidate.operation === input.operation,
+  );
+  let effect: "allow-with-obligations" | "deny" = "deny";
+  let reasonCode: PublicPolicyReasonCode = "operation-not-allowed";
+  let obligations = [] as readonly [] | typeof PUBLIC_POLICY_OBLIGATIONS;
+
+  if (rule !== undefined) {
+    if (isPublicCatalogueBoundary(input.catalogue)) {
+      effect = "allow-with-obligations";
+      reasonCode = "public-catalogue-read-allowed";
+      obligations = PUBLIC_POLICY_OBLIGATIONS;
+    } else {
+      reasonCode = "publication-not-public";
+    }
+  }
+
+  const decision = buildPublicPolicyDecision({
+    schema: "gis-ai-go.public-policy-decision.v1",
+    canonicalisation: CANONICALISATION,
+    request_id: input.requestId,
+    trace_id: input.traceId,
+    authority_context_id: authorityContext.context_id,
+    policy_id: PUBLIC_CATALOGUE_POLICY.policy_id,
+    policy_version: PUBLIC_CATALOGUE_POLICY.version,
+    policy_default_effect: "deny",
+    operation: input.operation,
+    effect,
+    reason_code: reasonCode,
+    obligations,
+  });
+
+  return freezeEvaluation({
+    allowed: effect === "allow-with-obligations",
+    effect,
+    reasonCode,
+    authorityContext,
+    policy: PUBLIC_CATALOGUE_POLICY,
+    decision,
+  });
+}

--- a/packages/policy-client/src/public-catalogue-v1.json
+++ b/packages/policy-client/src/public-catalogue-v1.json
@@ -1,0 +1,47 @@
+{
+  "schema": "gis-ai-go.public-policy.v1",
+  "policy_id": "gis-ai-go:public-policy:sha256:f39abe3f35f910dd27c9af9296bbccba33f76fec6d8d6acbba7c3b846d9a1e8f",
+  "version": "1.0.0",
+  "canonicalisation": "rfc8785-jcs",
+  "compilation": {
+    "kind": "compiled-json",
+    "runtime": "gis-ai-go-gateway"
+  },
+  "default_effect": "deny",
+  "applies_to": {
+    "authority_profile": "anonymous-open",
+    "access_tier": "open",
+    "publication_classification": "public",
+    "contains_personal_data": false,
+    "contains_protected_data": false,
+    "read_only": true
+  },
+  "rules": [
+    {
+      "rule_id": "public-catalogue-describe",
+      "operation": "catalogue.describe",
+      "effect": "allow-with-obligations",
+      "obligations": [
+        "inline-evidence-receipt",
+        "not-attested",
+        "not-persisted",
+        "preserve-attribution",
+        "preserve-described-resource-licence",
+        "preserve-record-licence"
+      ]
+    },
+    {
+      "rule_id": "public-catalogue-search",
+      "operation": "catalogue.search",
+      "effect": "allow-with-obligations",
+      "obligations": [
+        "inline-evidence-receipt",
+        "not-attested",
+        "not-persisted",
+        "preserve-attribution",
+        "preserve-described-resource-licence",
+        "preserve-record-licence"
+      ]
+    }
+  ]
+}

--- a/packages/policy-client/test/policy-client.test.ts
+++ b/packages/policy-client/test/policy-client.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CatalogueBundle } from "@gis-ai-go/contracts";
+import {
+  PUBLIC_POLICY_OBLIGATIONS,
+  canonicalJson,
+  verifyPublicPolicy,
+  verifyPublicPolicyDecision,
+} from "@gis-ai-go/evidence";
+
+import {
+  PUBLIC_CATALOGUE_POLICY,
+  PublicPolicyInputError,
+  evaluatePublicCataloguePolicy,
+  isPublicCatalogueBoundary,
+} from "../src/index.js";
+
+const REQUEST_ID = "request-public-catalogue-001";
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+function publicCatalogue(): CatalogueBundle {
+  return {
+    schema: "gis-ai-go-okf-bundle.v1",
+    id: "https://example.gov.uk/id/bundle/public",
+    title: "Public catalogue",
+    description: "A bounded public metadata catalogue.",
+    okfVersion: "0.2",
+    profile: "https://example.gov.uk/profile/public/v1/",
+    profileStatus: "candidate-pending-consumer-acceptance",
+    version: "0.0.0",
+    revision: "0123456789abcdef0123456789abcdef01234567",
+    status: "candidate",
+    authority: {
+      bundleAuthority: "Metadata publication only.",
+      officialSourceAuthority: "The named source publisher.",
+      legalAdvice: false,
+      notEndorsedBySource: true,
+    },
+    scope: {
+      kind: "bounded-public-metadata-discovery",
+      metadataOnly: true,
+      containsProtectedData: false,
+      excludes: ["Protected data."],
+    },
+    rights: {
+      statement: "Third-party records retain their terms.",
+      thirdPartyNotices: "THIRD_PARTY.md",
+    },
+    observedAt: "2026-08-19T00:00:00Z",
+    reviewedAt: "2026-08-19T00:00:00Z",
+    staleAfter: "2026-11-19T00:00:00Z",
+    recordCount: 1,
+    records: [
+      {
+        schema: "gis-ai-go-okf-concept.v1",
+        id: "dataset:public",
+        type: "dataset",
+        title: "Public dataset metadata",
+        description: "Public metadata only.",
+        authority: {
+          class: "source-authoritative",
+          statement: "The source publisher is authoritative.",
+          source: "https://example.gov.uk/dataset",
+        },
+        publication: {
+          classification: "public",
+          containsPersonalData: false,
+          containsProtectedData: false,
+        },
+        access: { tier: "open", state: "public", authentication: "None." },
+        rights: {
+          state: "open-with-conditions",
+          recordLicence: "CC BY 4.0.",
+          describedResourceLicence: "Source terms.",
+          attribution: "Example publisher.",
+        },
+        freshness: {
+          observedAt: "2026-08-19T00:00:00Z",
+          reviewedAt: "2026-08-19T00:00:00Z",
+          staleAfter: "2026-11-19T00:00:00Z",
+          status: "current",
+        },
+        status: "candidate-metadata",
+        sourceRefs: ["dataset:public"],
+        limitations: ["This is public metadata only."],
+        tags: ["public"],
+        details: {},
+      },
+    ],
+  };
+}
+
+test("loads the exact checked-in default-deny policy with a verified content identity", () => {
+  assert.equal(verifyPublicPolicy(PUBLIC_CATALOGUE_POLICY), true);
+  assert.equal(
+    PUBLIC_CATALOGUE_POLICY.policy_id,
+    "gis-ai-go:public-policy:sha256:f39abe3f35f910dd27c9af9296bbccba33f76fec6d8d6acbba7c3b846d9a1e8f",
+  );
+  assert.equal(PUBLIC_CATALOGUE_POLICY.default_effect, "deny");
+  assert.deepEqual(
+    PUBLIC_CATALOGUE_POLICY.rules.map((rule) => rule.operation),
+    ["catalogue.describe", "catalogue.search"],
+  );
+  assert.equal(Object.isFrozen(PUBLIC_CATALOGUE_POLICY.rules), true);
+
+  const tampered = structuredClone(PUBLIC_CATALOGUE_POLICY);
+  (tampered as unknown as { version: string }).version = "1.0.1";
+  assert.equal(verifyPublicPolicy(tampered), false);
+});
+
+test("allows only search and describe with exact evidence obligations", () => {
+  const catalogue = publicCatalogue();
+  assert.equal(isPublicCatalogueBoundary(catalogue), true);
+
+  for (const operation of ["catalogue.search", "catalogue.describe"] as const) {
+    const evaluation = evaluatePublicCataloguePolicy({
+      requestId: REQUEST_ID,
+      traceId: TRACE_ID,
+      operation,
+      catalogue,
+    });
+    assert.equal(evaluation.allowed, true);
+    assert.equal(evaluation.effect, "allow-with-obligations");
+    assert.equal(evaluation.reasonCode, "public-catalogue-read-allowed");
+    assert.ok(evaluation.decision);
+    assert.equal(verifyPublicPolicyDecision(evaluation.decision), true);
+    assert.deepEqual(evaluation.decision.obligations, PUBLIC_POLICY_OBLIGATIONS);
+    assert.equal(evaluation.decision.policy_id, PUBLIC_CATALOGUE_POLICY.policy_id);
+    assert.equal(evaluation.authorityContext.construction.source, "server");
+  }
+});
+
+test("returns explicit default-deny outcomes for governed and unknown operations", () => {
+  const governed = evaluatePublicCataloguePolicy({
+    requestId: REQUEST_ID,
+    traceId: TRACE_ID,
+    operation: "data.query",
+    catalogue: publicCatalogue(),
+  });
+  assert.equal(governed.allowed, false);
+  assert.equal(governed.effect, "deny");
+  assert.equal(governed.reasonCode, "operation-not-allowed");
+  assert.ok(governed.decision);
+  assert.equal(governed.decision.effect, "deny");
+  assert.deepEqual(governed.decision.obligations, []);
+  assert.equal(verifyPublicPolicyDecision(governed.decision), true);
+
+  const unknown = evaluatePublicCataloguePolicy({
+    requestId: REQUEST_ID,
+    traceId: TRACE_ID,
+    operation: "catalogue.delete",
+    catalogue: publicCatalogue(),
+  });
+  assert.equal(unknown.allowed, false);
+  assert.equal(unknown.effect, "deny");
+  assert.equal(unknown.reasonCode, "operation-not-allowed");
+  assert.equal(unknown.decision, null);
+});
+
+test("denies any catalogue that crosses the public metadata boundary", () => {
+  const mutations: Array<(catalogue: CatalogueBundle) => void> = [
+    (catalogue) => {
+      (catalogue.scope as { metadataOnly: boolean }).metadataOnly = false;
+    },
+    (catalogue) => {
+      (catalogue.scope as { containsProtectedData: boolean }).containsProtectedData = true;
+    },
+    (catalogue) => {
+      (catalogue.records[0]!.publication as { classification: string }).classification = "private";
+    },
+    (catalogue) => {
+      (catalogue.records[0]!.publication as { containsPersonalData: boolean }).containsPersonalData = true;
+    },
+    (catalogue) => {
+      (catalogue.records[0]!.publication as { containsProtectedData: boolean }).containsProtectedData = true;
+    },
+    (catalogue) => {
+      (catalogue.records[0]!.access as { tier: string }).tier = "protected";
+    },
+  ];
+
+  for (const mutate of mutations) {
+    const catalogue = structuredClone(publicCatalogue());
+    mutate(catalogue);
+    assert.equal(isPublicCatalogueBoundary(catalogue), false);
+    const evaluation = evaluatePublicCataloguePolicy({
+      requestId: REQUEST_ID,
+      traceId: TRACE_ID,
+      operation: "catalogue.search",
+      catalogue,
+    });
+    assert.equal(evaluation.allowed, false);
+    assert.equal(evaluation.reasonCode, "publication-not-public");
+    assert.ok(evaluation.decision);
+    assert.equal(evaluation.decision.effect, "deny");
+  }
+});
+
+test("rejects unbounded or malformed decision identifiers before evaluation", () => {
+  assert.throws(
+    () =>
+      evaluatePublicCataloguePolicy({
+        requestId: `request-${"x".repeat(128)}`,
+        traceId: TRACE_ID,
+        operation: "catalogue.search",
+        catalogue: publicCatalogue(),
+      }),
+    PublicPolicyInputError,
+  );
+  assert.throws(
+    () =>
+      evaluatePublicCataloguePolicy({
+        requestId: REQUEST_ID,
+        traceId: "ABC",
+        operation: "catalogue.search",
+        catalogue: publicCatalogue(),
+      }),
+    PublicPolicyInputError,
+  );
+});
+
+test("policy evaluation is deterministic for the same bounded inputs", () => {
+  const input = {
+    requestId: REQUEST_ID,
+    traceId: TRACE_ID,
+    operation: "catalogue.search",
+    catalogue: publicCatalogue(),
+  } as const;
+  const first = evaluatePublicCataloguePolicy(input);
+  const second = evaluatePublicCataloguePolicy(input);
+  assert.equal(canonicalJson(first), canonicalJson(second));
+});

--- a/packages/policy-client/tsconfig.json
+++ b/packages/policy-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "src/**/*.json", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,18 @@ importers:
 
   apps/mcp-gateway:
     dependencies:
+      '@gis-ai-go/authority-context':
+        specifier: workspace:*
+        version: link:../../packages/authority-context
       '@gis-ai-go/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      '@gis-ai-go/evidence':
+        specifier: workspace:*
+        version: link:../../packages/evidence
+      '@gis-ai-go/policy-client':
+        specifier: workspace:*
+        version: link:../../packages/policy-client
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -49,7 +58,27 @@ importers:
         specifier: 4.1.11
         version: 4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3))
 
+  packages/authority-context:
+    dependencies:
+      '@gis-ai-go/evidence':
+        specifier: workspace:*
+        version: link:../evidence
+
   packages/contracts: {}
+
+  packages/evidence: {}
+
+  packages/policy-client:
+    dependencies:
+      '@gis-ai-go/authority-context':
+        specifier: workspace:*
+        version: link:../authority-context
+      '@gis-ai-go/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@gis-ai-go/evidence':
+        specifier: workspace:*
+        version: link:../evidence
 
 packages:
 

--- a/providers/fixtures/README.md
+++ b/providers/fixtures/README.md
@@ -1,5 +1,9 @@
 # Synthetic fixtures
 
-These examples contain invented people, identities, entitlements, digests and results.
-They contain no licensed provider feature data and are not evidence of real access.
-They were adapted from the 19 August 2026 research pack.
+These examples contain invented identities, catalogue values and results. The public
+authority, policy-decision and inline-receipt examples have reproducible canonical
+content identities, but remain synthetic contract fixtures rather than evidence of
+real access. They contain no licensed provider feature data.
+
+The older authority, policy and receipt examples were adapted from the 19 August
+2026 research pack and remain candidate fixtures for deferred protected workflows.

--- a/providers/fixtures/evidence-receipt.example.json
+++ b/providers/fixtures/evidence-receipt.example.json
@@ -1,79 +1,129 @@
 {
-  "receipt_id": "receipt_demo_001",
-  "created_at": "2026-08-19T12:00:03Z",
-  "request_id": "request_demo_001",
-  "trace_id": "0123456789abcdef0123456789abcdef",
-  "authority_context_id": "authctx_demo_psga_001",
-  "policy_decision_id": "pdp_demo_001",
-  "operation": {
-    "tool": "data.query",
-    "version": "0.1.0-proposed",
-    "parameters_digest": "sha256:synthetic-parameters",
-    "workflow_id": "WF03"
+  "authority_context": {
+    "access": {
+      "authentication": "none",
+      "contains_personal_data": false,
+      "contains_protected_data": false,
+      "publication_classification": "public",
+      "read_only": true,
+      "tier": "open"
+    },
+    "canonicalisation": "rfc8785-jcs",
+    "construction": {
+      "product": "gis-ai-go-gateway",
+      "profile": "anonymous-open",
+      "source": "server"
+    },
+    "context_id": "gis-ai-go:public-authority-context:sha256:cc90ac84527a6a85bc3e02529b5b4422d1a7bdf5bdcd77346a78006eeca1d34c",
+    "evidence": {
+      "attestation": "not-attested",
+      "persistence": "not-persisted",
+      "receipt": "inline-required"
+    },
+    "permitted_operations": [
+      "catalogue.describe",
+      "catalogue.search"
+    ],
+    "schema": "gis-ai-go.public-authority-context.v1"
   },
-  "sources": [
-    {
-      "provider": "Ordnance Survey",
-      "dataset": "OS NGD Buildings",
-      "version": "synthetic-fixture-2026-08-19",
-      "uri": "urn:synthetic:os-ngd-buildings",
-      "retrieved_at": "2026-08-19T12:00:02Z",
-      "checksum": "sha256:synthetic-source",
-      "licence": "Synthetic stand-in; no licensed data included"
-    }
-  ],
-  "transformations": [
-    {
-      "name": "aggregate-count",
-      "parameters": {
-        "group_by": "accessibility-status"
-      },
-      "input_crs": "EPSG:27700",
-      "output_crs": null,
-      "software": "PostGIS synthetic fixture"
-    }
-  ],
-  "software": [
-    {
-      "name": "gis-ai-go-execution",
-      "version": "0.1.0-proposed",
-      "digest": "sha256:synthetic-image"
-    }
-  ],
-  "outputs": [
-    {
-      "artefact_id": "result_demo_001",
-      "uri": null,
-      "media_type": "application/json",
-      "sha256": "sha256:synthetic-output",
-      "size_bytes": 420,
-      "redactions": [
-        "feature geometries withheld"
-      ]
-    }
-  ],
+  "catalogue": {
+    "content_root_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "id": "gis-ai-go:bundle:public-discovery",
+    "record_count": 36,
+    "reviewed_at": "2026-08-20T00:00:00Z",
+    "revision": "1111111111111111111111111111111111111111",
+    "stale_after": "2027-02-20T00:00:00Z",
+    "version": "0.1.0"
+  },
+  "created_at": "2026-08-20T08:00:00Z",
+  "evidence_handling": {
+    "attestation": "not-attested",
+    "delivery": "inline-only",
+    "persistence": "not-persisted"
+  },
   "licence_obligations": [
     {
-      "type": "attribution",
-      "status": "applied"
+      "attribution": "Contains HM Land Registry public sector information.",
+      "described_resource_licence": "Open Government Licence",
+      "record_id": "hmlr:dataset:inspire-index-polygons",
+      "record_licence": "MIT"
+    }
+  ],
+  "operation": {
+    "contract_version": "v1",
+    "name": "catalogue.search",
+    "normalised_parameters": {
+      "domain": "gis-ai-go.catalogue-parameters.v1",
+      "sha256": "b3f8d2fb0417f06784e9ebf48ac81d434fdbf163b281df6744ecd275169db3e8"
+    }
+  },
+  "policy_decision": {
+    "authority_context_id": "gis-ai-go:public-authority-context:sha256:cc90ac84527a6a85bc3e02529b5b4422d1a7bdf5bdcd77346a78006eeca1d34c",
+    "canonicalisation": "rfc8785-jcs",
+    "decision_id": "gis-ai-go:public-policy-decision:sha256:d90bab8e8fb33ff2833d4dcb6b398a0fcf2bea8fcc469b9415c9bffecaa1cbd6",
+    "effect": "allow-with-obligations",
+    "obligations": [
+      "inline-evidence-receipt",
+      "not-attested",
+      "not-persisted",
+      "preserve-attribution",
+      "preserve-described-resource-licence",
+      "preserve-record-licence"
+    ],
+    "operation": "catalogue.search",
+    "policy_default_effect": "deny",
+    "policy_id": "gis-ai-go:public-policy:sha256:f39abe3f35f910dd27c9af9296bbccba33f76fec6d8d6acbba7c3b846d9a1e8f",
+    "policy_version": "1.0.0",
+    "reason_code": "public-catalogue-read-allowed",
+    "request_id": "request-public-catalogue-001",
+    "schema": "gis-ai-go.public-policy-decision.v1",
+    "trace_id": "0123456789abcdef0123456789abcdef"
+  },
+  "receipt_id": "gis-ai-go:evidence-receipt:sha256:fba0ab0152db4114169cca27bfa1ce2817b42155a7c35a78f7bfe6e427ecada7",
+  "request_id": "request-public-catalogue-001",
+  "result": {
+    "domain": "gis-ai-go.catalogue-result-core.v1",
+    "media_type": "application/json",
+    "returned_record_count": 1,
+    "sha256": "1fe79c3a539931e3217942de8e2390164a43ac721c857f534e0af0e2c339f7a3"
+  },
+  "schema": "gis-ai-go.evidence-receipt.v1",
+  "software": {
+    "name": "gis-ai-go-mcp-gateway",
+    "revision": "1111111111111111111111111111111111111111",
+    "version": "0.1.0"
+  },
+  "trace_id": "0123456789abcdef0123456789abcdef",
+  "transformations": [
+    {
+      "name": "load-checksum-verified-catalogue",
+      "version": "v1"
     },
     {
-      "type": "no_persistent_export",
-      "status": "enforced"
+      "name": "normalise-parameters",
+      "version": "v1"
+    },
+    {
+      "name": "filter-catalogue",
+      "version": "v1"
+    },
+    {
+      "name": "project-result-core",
+      "version": "v1"
     }
   ],
   "verification": {
-    "status": "passed",
+    "canonicalisation": "rfc8785-jcs",
     "checks": [
-      "schema",
-      "policy-obligation",
-      "source-digest"
-    ]
-  },
-  "attestation": {
-    "status": "not-attested",
-    "attester": null,
-    "receipt_digest": null
-  },
-  "retention_classification": "synthetic-demo-30-days"
+      "authority-context",
+      "catalogue-integrity",
+      "licence-obligations",
+      "normalised-parameters-digest",
+      "public-policy-decision",
+      "result-core-digest",
+      "schema"
+    ],
+    "digest_algorithm": "sha256",
+    "status": "passed"
+  }
 }

--- a/providers/fixtures/public-authority-context.example.json
+++ b/providers/fixtures/public-authority-context.example.json
@@ -1,0 +1,27 @@
+{
+  "access": {
+    "authentication": "none",
+    "contains_personal_data": false,
+    "contains_protected_data": false,
+    "publication_classification": "public",
+    "read_only": true,
+    "tier": "open"
+  },
+  "canonicalisation": "rfc8785-jcs",
+  "construction": {
+    "product": "gis-ai-go-gateway",
+    "profile": "anonymous-open",
+    "source": "server"
+  },
+  "context_id": "gis-ai-go:public-authority-context:sha256:cc90ac84527a6a85bc3e02529b5b4422d1a7bdf5bdcd77346a78006eeca1d34c",
+  "evidence": {
+    "attestation": "not-attested",
+    "persistence": "not-persisted",
+    "receipt": "inline-required"
+  },
+  "permitted_operations": [
+    "catalogue.describe",
+    "catalogue.search"
+  ],
+  "schema": "gis-ai-go.public-authority-context.v1"
+}

--- a/providers/fixtures/public-policy-decision.example.json
+++ b/providers/fixtures/public-policy-decision.example.json
@@ -1,0 +1,22 @@
+{
+  "authority_context_id": "gis-ai-go:public-authority-context:sha256:cc90ac84527a6a85bc3e02529b5b4422d1a7bdf5bdcd77346a78006eeca1d34c",
+  "canonicalisation": "rfc8785-jcs",
+  "decision_id": "gis-ai-go:public-policy-decision:sha256:d90bab8e8fb33ff2833d4dcb6b398a0fcf2bea8fcc469b9415c9bffecaa1cbd6",
+  "effect": "allow-with-obligations",
+  "obligations": [
+    "inline-evidence-receipt",
+    "not-attested",
+    "not-persisted",
+    "preserve-attribution",
+    "preserve-described-resource-licence",
+    "preserve-record-licence"
+  ],
+  "operation": "catalogue.search",
+  "policy_default_effect": "deny",
+  "policy_id": "gis-ai-go:public-policy:sha256:f39abe3f35f910dd27c9af9296bbccba33f76fec6d8d6acbba7c3b846d9a1e8f",
+  "policy_version": "1.0.0",
+  "reason_code": "public-catalogue-read-allowed",
+  "request_id": "request-public-catalogue-001",
+  "schema": "gis-ai-go.public-policy-decision.v1",
+  "trace_id": "0123456789abcdef0123456789abcdef"
+}

--- a/schemas/catalogue-result.schema.json
+++ b/schemas/catalogue-result.schema.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "urn:gis-ai-go:schema:catalogue-result:v1",
   "title": "GIS AI GO catalogue result",
-  "description": "A bounded candidate success envelope for catalogue.search or catalogue.describe. It is not yet an active transport contract.",
-  "$comment": "This candidate intentionally omits an evidence receipt. EVID-204 must introduce a reviewed inline receipt before any public catalogue tool is activated.",
+  "description": "A bounded candidate success envelope for catalogue.search or catalogue.describe with required inline public evidence. It is not yet an active transport contract.",
+  "$comment": "The evidence receipt is inline-only, not persisted and not attested. Activation remains a separate reviewed lifecycle decision.",
   "oneOf": [
     {
       "type": "object",
@@ -14,6 +14,7 @@
         "request_id",
         "trace_id",
         "catalogue",
+        "evidence_receipt",
         "warnings",
         "data"
       ],
@@ -33,6 +34,9 @@
         "catalogue": {
           "$ref": "#/$defs/catalogue_identity"
         },
+        "evidence_receipt": {
+          "$ref": "urn:gis-ai-go:schema:evidence-receipt:v1"
+        },
         "warnings": {
           "$ref": "#/$defs/warnings"
         },
@@ -50,6 +54,7 @@
         "request_id",
         "trace_id",
         "catalogue",
+        "evidence_receipt",
         "warnings",
         "data"
       ],
@@ -68,6 +73,9 @@
         },
         "catalogue": {
           "$ref": "#/$defs/catalogue_identity"
+        },
+        "evidence_receipt": {
+          "$ref": "urn:gis-ai-go:schema:evidence-receipt:v1"
         },
         "warnings": {
           "$ref": "#/$defs/warnings"
@@ -435,7 +443,7 @@
         "source_refs": {
           "type": "array",
           "minItems": 1,
-          "maxItems": 100,
+          "maxItems": 99,
           "uniqueItems": true,
           "items": {
             "$ref": "#/$defs/record_id"
@@ -799,7 +807,7 @@
         },
         "sources": {
           "type": "array",
-          "maxItems": 100,
+          "maxItems": 99,
           "uniqueItems": true,
           "items": {
             "$ref": "#/$defs/source_summary"

--- a/schemas/evidence-receipt.schema.json
+++ b/schemas/evidence-receipt.schema.json
@@ -1,269 +1,505 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "urn:gis-ai-go:schema:evidence-receipt:0",
-  "$comment": "Candidate promoted from the immutable 19 August 2026 research pack.",
-  "title": "Result Evidence Receipt",
+  "$id": "urn:gis-ai-go:schema:evidence-receipt:v1",
+  "title": "GIS AI GO inline catalogue evidence receipt",
+  "description": "A closed inline-only receipt for a successful public catalogue result. It binds canonical parameter and result digests and explicitly records that it is neither persisted nor attested.",
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "schema",
     "receipt_id",
     "created_at",
     "request_id",
     "trace_id",
-    "authority_context_id",
-    "policy_decision_id",
     "operation",
-    "sources",
+    "authority_context",
+    "policy_decision",
+    "catalogue",
     "transformations",
     "software",
-    "outputs",
+    "result",
     "licence_obligations",
     "verification",
-    "attestation",
-    "retention_classification"
+    "evidence_handling"
   ],
   "properties": {
+    "schema": {
+      "const": "gis-ai-go.evidence-receipt.v1"
+    },
     "receipt_id": {
       "type": "string",
-      "pattern": "^receipt_[A-Za-z0-9_-]+$"
+      "pattern": "^gis-ai-go:evidence-receipt:sha256:[0-9a-f]{64}$"
     },
     "created_at": {
       "type": "string",
+      "maxLength": 35,
       "format": "date-time"
     },
     "request_id": {
-      "type": "string"
+      "$ref": "#/$defs/request_id"
+    },
+    "trace_id": {
+      "$ref": "#/$defs/trace_id"
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "contract_version",
+        "normalised_parameters"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/catalogue_operation"
+        },
+        "contract_version": {
+          "const": "v1"
+        },
+        "normalised_parameters": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "domain",
+            "sha256"
+          ],
+          "properties": {
+            "domain": {
+              "const": "gis-ai-go.catalogue-parameters.v1"
+            },
+            "sha256": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        }
+      }
+    },
+    "authority_context": {
+      "$ref": "urn:gis-ai-go:schema:public-authority-context:v1"
+    },
+    "policy_decision": {
+      "allOf": [
+        {
+          "$ref": "urn:gis-ai-go:schema:public-policy-decision:v1"
+        },
+        {
+          "properties": {
+            "effect": {
+              "const": "allow-with-obligations"
+            },
+            "reason_code": {
+              "const": "public-catalogue-read-allowed"
+            }
+          }
+        }
+      ]
+    },
+    "catalogue": {
+      "$ref": "#/$defs/catalogue_identity"
+    },
+    "transformations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/transformation"
+      }
+    },
+    "software": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "revision"
+      ],
+      "properties": {
+        "name": {
+          "const": "gis-ai-go-mcp-gateway"
+        },
+        "version": {
+          "$ref": "#/$defs/semver"
+        },
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "sha256",
+        "media_type",
+        "returned_record_count"
+      ],
+      "properties": {
+        "domain": {
+          "const": "gis-ai-go.catalogue-result-core.v1"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "media_type": {
+          "const": "application/json"
+        },
+        "returned_record_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "licence_obligations": {
+      "$comment": "Entries must be sorted in ascending Unicode code-point order by record_id and contain one entry for each returned record.",
+      "type": "array",
+      "maxItems": 100,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "record_id",
+          "record_licence",
+          "described_resource_licence",
+          "attribution"
+        ],
+        "properties": {
+          "record_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "record_licence": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2048
+          },
+          "described_resource_licence": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2048
+          },
+          "attribution": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 8192
+          }
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "canonicalisation",
+        "digest_algorithm",
+        "checks"
+      ],
+      "properties": {
+        "status": {
+          "const": "passed"
+        },
+        "canonicalisation": {
+          "const": "rfc8785-jcs"
+        },
+        "digest_algorithm": {
+          "const": "sha256"
+        },
+        "checks": {
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 7,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "authority-context",
+              "public-policy-decision",
+              "catalogue-integrity",
+              "normalised-parameters-digest",
+              "result-core-digest",
+              "licence-obligations",
+              "schema"
+            ]
+          }
+        }
+      }
+    },
+    "evidence_handling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "delivery",
+        "persistence",
+        "attestation"
+      ],
+      "properties": {
+        "delivery": {
+          "const": "inline-only"
+        },
+        "persistence": {
+          "const": "not-persisted"
+        },
+        "attestation": {
+          "const": "not-attested"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "operation": {
+            "properties": {
+              "name": {
+                "const": "catalogue.search"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "operation"
+        ]
+      },
+      "then": {
+        "properties": {
+          "policy_decision": {
+            "properties": {
+              "operation": {
+                "const": "catalogue.search"
+              }
+            }
+          },
+          "transformations": {
+            "minItems": 4,
+            "maxItems": 4,
+            "prefixItems": [
+              {
+                "$ref": "#/$defs/load_catalogue_transformation"
+              },
+              {
+                "$ref": "#/$defs/normalise_parameters_transformation"
+              },
+              {
+                "$ref": "#/$defs/filter_catalogue_transformation"
+              },
+              {
+                "$ref": "#/$defs/project_result_transformation"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "operation": {
+            "properties": {
+              "name": {
+                "const": "catalogue.describe"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "operation"
+        ]
+      },
+      "then": {
+        "properties": {
+          "policy_decision": {
+            "properties": {
+              "operation": {
+                "const": "catalogue.describe"
+              }
+            }
+          },
+          "transformations": {
+            "minItems": 3,
+            "maxItems": 3,
+            "prefixItems": [
+              {
+                "$ref": "#/$defs/load_catalogue_transformation"
+              },
+              {
+                "$ref": "#/$defs/normalise_parameters_transformation"
+              },
+              {
+                "$ref": "#/$defs/project_result_transformation"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
     },
     "trace_id": {
       "type": "string",
       "pattern": "^[0-9a-f]{32}$"
     },
-    "authority_context_id": {
-      "type": "string"
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
     },
-    "policy_decision_id": {
-      "type": "string"
+    "semver": {
+      "type": "string",
+      "maxLength": 32,
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
     },
-    "operation": {
+    "catalogue_operation": {
+      "enum": [
+        "catalogue.search",
+        "catalogue.describe"
+      ]
+    },
+    "catalogue_identity": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
-        "tool",
+        "id",
         "version",
-        "parameters_digest"
+        "revision",
+        "content_root_sha256",
+        "record_count",
+        "reviewed_at",
+        "stale_after"
       ],
       "properties": {
-        "tool": {
-          "type": "string"
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
         },
         "version": {
-          "type": "string"
+          "$ref": "#/$defs/semver"
         },
-        "parameters_digest": {
-          "type": "string"
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
         },
-        "workflow_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+        "content_root_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "record_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000
+        },
+        "reviewed_at": {
+          "type": "string",
+          "maxLength": 35,
+          "format": "date-time"
+        },
+        "stale_after": {
+          "type": "string",
+          "maxLength": 35,
+          "format": "date-time"
         }
-      },
-      "additionalProperties": true
-    },
-    "sources": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "required": [
-          "provider",
-          "dataset",
-          "version",
-          "uri",
-          "retrieved_at",
-          "checksum"
-        ],
-        "properties": {
-          "provider": {
-            "type": "string"
-          },
-          "dataset": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          },
-          "retrieved_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "checksum": {
-            "type": "string"
-          },
-          "licence": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
       }
     },
-    "transformations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "name",
-          "parameters",
-          "input_crs",
-          "output_crs"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "parameters": {
-            "type": "object"
-          },
-          "input_crs": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "output_crs": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "software": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
-      }
-    },
-    "software": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "name",
-          "version"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "digest": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
-      }
-    },
-    "outputs": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "media_type",
-          "sha256"
-        ],
-        "properties": {
-          "artefact_id": {
-            "type": "string"
-          },
-          "uri": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "media_type": {
-            "type": "string"
-          },
-          "sha256": {
-            "type": "string"
-          },
-          "size_bytes": {
-            "type": "integer"
-          },
-          "redactions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": true
-      }
-    },
-    "licence_obligations": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    },
-    "verification": {
+    "transformation": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
-        "status"
+        "name",
+        "version"
       ],
       "properties": {
-        "status": {
+        "name": {
           "enum": [
-            "not-run",
-            "passed",
-            "failed",
-            "partial"
+            "normalise-parameters",
+            "load-checksum-verified-catalogue",
+            "filter-catalogue",
+            "project-result-core"
           ]
         },
-        "checks": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "version": {
+          "const": "v1"
         }
-      },
-      "additionalProperties": true
+      }
     },
-    "attestation": {
+    "load_catalogue_transformation": {
       "type": "object",
-      "required": [
-        "status"
-      ],
+      "additionalProperties": false,
       "properties": {
-        "status": {
-          "enum": [
-            "not-attested",
-            "attested",
-            "failed"
-          ]
+        "name": {
+          "const": "load-checksum-verified-catalogue"
         },
-        "attester": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "receipt_digest": {
-          "type": [
-            "string",
-            "null"
-          ]
+        "version": {
+          "const": "v1"
         }
       },
-      "additionalProperties": true
+      "required": [
+        "name",
+        "version"
+      ]
     },
-    "retention_classification": {
-      "type": "string"
+    "normalise_parameters_transformation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "const": "normalise-parameters"
+        },
+        "version": {
+          "const": "v1"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "filter_catalogue_transformation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "const": "filter-catalogue"
+        },
+        "version": {
+          "const": "v1"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "project_result_transformation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "const": "project-result-core"
+        },
+        "version": {
+          "const": "v1"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
     }
   }
 }

--- a/schemas/public-authority-context.schema.json
+++ b/schemas/public-authority-context.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:public-authority-context:v1",
+  "title": "GIS AI GO public authority context",
+  "description": "The single server-constructed anonymous-open authority context for public catalogue discovery. It contains only fixed server-owned public access attributes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "context_id",
+    "canonicalisation",
+    "construction",
+    "access",
+    "permitted_operations",
+    "evidence"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.public-authority-context.v1"
+    },
+    "context_id": {
+      "type": "string",
+      "pattern": "^gis-ai-go:public-authority-context:sha256:[0-9a-f]{64}$"
+    },
+    "canonicalisation": {
+      "const": "rfc8785-jcs"
+    },
+    "construction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "profile",
+        "product"
+      ],
+      "properties": {
+        "source": {
+          "const": "server"
+        },
+        "profile": {
+          "const": "anonymous-open"
+        },
+        "product": {
+          "const": "gis-ai-go-gateway"
+        }
+      }
+    },
+    "access": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authentication",
+        "tier",
+        "publication_classification",
+        "contains_personal_data",
+        "contains_protected_data",
+        "read_only"
+      ],
+      "properties": {
+        "authentication": {
+          "const": "none"
+        },
+        "tier": {
+          "const": "open"
+        },
+        "publication_classification": {
+          "const": "public"
+        },
+        "contains_personal_data": {
+          "const": false
+        },
+        "contains_protected_data": {
+          "const": false
+        },
+        "read_only": {
+          "const": true
+        }
+      }
+    },
+    "permitted_operations": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "catalogue.search",
+          "catalogue.describe"
+        ]
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receipt",
+        "persistence",
+        "attestation"
+      ],
+      "properties": {
+        "receipt": {
+          "const": "inline-required"
+        },
+        "persistence": {
+          "const": "not-persisted"
+        },
+        "attestation": {
+          "const": "not-attested"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public-policy-decision.schema.json
+++ b/schemas/public-policy-decision.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:public-policy-decision:v1",
+  "title": "GIS AI GO public policy decision",
+  "description": "A bounded decision produced by the compiled default-deny public catalogue policy. It contains only the governed operation, policy binding, controlled outcome and obligations.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "canonicalisation",
+    "decision_id",
+    "request_id",
+    "trace_id",
+    "authority_context_id",
+    "policy_id",
+    "policy_version",
+    "policy_default_effect",
+    "operation",
+    "effect",
+    "reason_code",
+    "obligations"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.public-policy-decision.v1"
+    },
+    "canonicalisation": {
+      "const": "rfc8785-jcs"
+    },
+    "decision_id": {
+      "type": "string",
+      "pattern": "^gis-ai-go:public-policy-decision:sha256:[0-9a-f]{64}$"
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "trace_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "authority_context_id": {
+      "type": "string",
+      "pattern": "^gis-ai-go:public-authority-context:sha256:[0-9a-f]{64}$"
+    },
+    "policy_id": {
+      "type": "string",
+      "pattern": "^gis-ai-go:public-policy:sha256:[0-9a-f]{64}$"
+    },
+    "policy_version": {
+      "type": "string",
+      "maxLength": 32,
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "policy_default_effect": {
+      "const": "deny"
+    },
+    "operation": {
+      "$ref": "#/$defs/governed_operation"
+    },
+    "effect": {
+      "enum": [
+        "allow-with-obligations",
+        "deny"
+      ]
+    },
+    "reason_code": {
+      "enum": [
+        "public-catalogue-read-allowed",
+        "operation-not-allowed",
+        "authority-context-not-applicable",
+        "publication-not-public"
+      ]
+    },
+    "obligations": {
+      "type": "array",
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/obligation"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "effect": {
+            "const": "allow-with-obligations"
+          }
+        },
+        "required": [
+          "effect"
+        ]
+      },
+      "then": {
+        "properties": {
+          "operation": {
+            "enum": [
+              "catalogue.search",
+              "catalogue.describe"
+            ]
+          },
+          "reason_code": {
+            "const": "public-catalogue-read-allowed"
+          },
+          "obligations": {
+            "minItems": 6,
+            "maxItems": 6
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "effect": {
+            "const": "deny"
+          }
+        },
+        "required": [
+          "effect"
+        ]
+      },
+      "then": {
+        "properties": {
+          "reason_code": {
+            "enum": [
+              "operation-not-allowed",
+              "authority-context-not-applicable",
+              "publication-not-public"
+            ]
+          },
+          "obligations": {
+            "maxItems": 0
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "governed_operation": {
+      "enum": [
+        "catalogue.search",
+        "catalogue.describe",
+        "selection.resolve",
+        "data.query",
+        "spatial.locate",
+        "spatial.analyse",
+        "statistics.compare",
+        "route.plan",
+        "map.render",
+        "artefact.export",
+        "evidence.inspect",
+        "workflow.execute"
+      ]
+    },
+    "obligation": {
+      "enum": [
+        "inline-evidence-receipt",
+        "preserve-record-licence",
+        "preserve-described-resource-licence",
+        "preserve-attribution",
+        "not-persisted",
+        "not-attested"
+      ]
+    }
+  }
+}

--- a/schemas/public-policy.schema.json
+++ b/schemas/public-policy.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:public-policy:v1",
+  "title": "GIS AI GO compiled public catalogue policy",
+  "description": "A versioned compiled JSON allow-list for the anonymous-open public catalogue. Every operation not named by a rule is denied.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "policy_id",
+    "version",
+    "canonicalisation",
+    "compilation",
+    "default_effect",
+    "applies_to",
+    "rules"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.public-policy.v1"
+    },
+    "policy_id": {
+      "type": "string",
+      "pattern": "^gis-ai-go:public-policy:sha256:[0-9a-f]{64}$"
+    },
+    "version": {
+      "type": "string",
+      "maxLength": 32,
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "canonicalisation": {
+      "const": "rfc8785-jcs"
+    },
+    "compilation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "runtime"
+      ],
+      "properties": {
+        "kind": {
+          "const": "compiled-json"
+        },
+        "runtime": {
+          "const": "gis-ai-go-gateway"
+        }
+      }
+    },
+    "default_effect": {
+      "const": "deny"
+    },
+    "applies_to": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_profile",
+        "access_tier",
+        "publication_classification",
+        "contains_personal_data",
+        "contains_protected_data",
+        "read_only"
+      ],
+      "properties": {
+        "authority_profile": {
+          "const": "anonymous-open"
+        },
+        "access_tier": {
+          "const": "open"
+        },
+        "publication_classification": {
+          "const": "public"
+        },
+        "contains_personal_data": {
+          "const": false
+        },
+        "contains_protected_data": {
+          "const": false
+        },
+        "read_only": {
+          "const": true
+        }
+      }
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/rule"
+      },
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "required": [
+              "operation"
+            ],
+            "properties": {
+              "operation": {
+                "const": "catalogue.search"
+              }
+            }
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": [
+              "operation"
+            ],
+            "properties": {
+              "operation": {
+                "const": "catalogue.describe"
+              }
+            }
+          },
+          "minContains": 1,
+          "maxContains": 1
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "obligation": {
+      "enum": [
+        "inline-evidence-receipt",
+        "preserve-record-licence",
+        "preserve-described-resource-licence",
+        "preserve-attribution",
+        "not-persisted",
+        "not-attested"
+      ]
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rule_id",
+        "operation",
+        "effect",
+        "obligations"
+      ],
+      "properties": {
+        "rule_id": {
+          "enum": [
+            "public-catalogue-search",
+            "public-catalogue-describe"
+          ]
+        },
+        "operation": {
+          "enum": [
+            "catalogue.search",
+            "catalogue.describe"
+          ]
+        },
+        "effect": {
+          "const": "allow-with-obligations"
+        },
+        "obligations": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/obligation"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "catalogue.search"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "rule_id": {
+                "const": "public-catalogue-search"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "catalogue.describe"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "rule_id": {
+                "const": "public-catalogue-describe"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -13,6 +13,14 @@ STABLE_SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 RELEASE_DATE = r"\d{4}-\d{2}-\d{2}"
 
 
+def npm_package_manifests(root: Path) -> tuple[str, ...]:
+    """Return every root and pnpm-workspace package manifest deterministically."""
+    manifests = [root / "package.json"]
+    manifests.extend(sorted((root / "apps").glob("*/package.json")))
+    manifests.extend(sorted((root / "packages").glob("*/package.json")))
+    return tuple(path.relative_to(root).as_posix() for path in manifests)
+
+
 def is_valid_product_version(value: str) -> bool:
     """Return whether a version is stable SemVer and valid unchanged in Python metadata."""
     return STABLE_SEMVER.fullmatch(value) is not None
@@ -102,12 +110,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(f"VERSION must be stable Semantic Versioning X.Y.Z: {version!r}")
 
     observed: dict[str, str] = {}
-    for relative in (
-        "package.json",
-        "apps/mcp-gateway/package.json",
-        "apps/public-explorer/package.json",
-        "packages/contracts/package.json",
-    ):
+    for relative in npm_package_manifests(ROOT):
         value = load_json(ROOT / relative).get("version")
         observed[relative] = str(value)
 

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -14,6 +14,25 @@ from urllib.parse import quote
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def npm_workspace_versions(root: Path) -> dict[str, str]:
+    """Return canonical versions for the root and every pnpm workspace package."""
+    manifests = [root / "package.json"]
+    manifests.extend(sorted((root / "apps").glob("*/package.json")))
+    manifests.extend(sorted((root / "packages").glob("*/package.json")))
+
+    versions: dict[str, str] = {}
+    for manifest in manifests:
+        package = json.loads(manifest.read_text(encoding="utf-8"))
+        name = package.get("name")
+        version = package.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            raise AssertionError(f"Workspace manifest lacks a package name or version: {manifest}")
+        if name in versions:
+            raise AssertionError(f"Duplicate workspace package name: {name}")
+        versions[name] = version
+    return versions
+
+
 def npm_components() -> Iterator[dict[str, str]]:
     result = subprocess.run(
         ["pnpm", "list", "--recursive", "--depth", "Infinity", "--json"],
@@ -23,11 +42,18 @@ def npm_components() -> Iterator[dict[str, str]]:
         text=True,
     )
     projects = json.loads(result.stdout)
+    workspace_versions = npm_workspace_versions(ROOT)
 
     def visit(dependencies: dict[str, Any]) -> Iterator[dict[str, str]]:
         for name, detail in dependencies.items():
             version = detail.get("version")
             if version:
+                if version.startswith("link:"):
+                    version = workspace_versions.get(name)
+                    if version is None:
+                        raise AssertionError(
+                            f"Workspace link has no matching checked-in package manifest: {name}"
+                        )
                 encoded = quote(name, safe="/")
                 yield {
                     "type": "library",

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
 
 ROOT = Path(__file__).resolve().parents[1]
 RESEARCH_DATA = (
@@ -25,6 +26,17 @@ def load_json(path: Path) -> Any:
         return json.load(handle)
 
 
+def build_schema_registry() -> Registry:
+    resources = []
+    for schema_path in sorted((ROOT / "schemas").glob("*.schema.json")):
+        schema = load_json(schema_path)
+        resources.append((schema["$id"], Resource.from_contents(schema)))
+    return Registry().with_resources(resources)
+
+
+SCHEMA_REGISTRY = build_schema_registry()
+
+
 def validate_records(
     schema_name: str,
     records: list[tuple[str, Any]],
@@ -36,7 +48,11 @@ def validate_records(
     if not schema_id.startswith("urn:gis-ai-go:schema:"):
         raise AssertionError(f"{schema_name} has an unexpected $id: {schema_id}")
 
-    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    validator = Draft202012Validator(
+        schema,
+        registry=SCHEMA_REGISTRY,
+        format_checker=FormatChecker(),
+    )
     for label, record in records:
         errors = sorted(validator.iter_errors(record), key=lambda error: list(error.path))
         if errors:
@@ -92,6 +108,24 @@ def main() -> None:
                 (
                     "policy-decision.example.json",
                     load_json(fixture_dir / "policy-decision.example.json"),
+                )
+            ],
+        ),
+        (
+            "public-authority-context.schema.json",
+            [
+                (
+                    "public-authority-context.example.json",
+                    load_json(fixture_dir / "public-authority-context.example.json"),
+                )
+            ],
+        ),
+        (
+            "public-policy-decision.schema.json",
+            [
+                (
+                    "public-policy-decision.example.json",
+                    load_json(fixture_dir / "public-policy-decision.example.json"),
                 )
             ],
         ),

--- a/tests/contract/test_catalogue_api_schemas.py
+++ b/tests/contract/test_catalogue_api_schemas.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_DIR = ROOT / "schemas"
+FIXTURE_DIR = ROOT / "providers" / "fixtures"
 
 SCHEMA_IDS = {
     "catalogue-search-request.schema.json": (
@@ -28,10 +30,25 @@ def load_schema(name: str) -> dict[str, Any]:
     return json.loads((SCHEMA_DIR / name).read_text(encoding="utf-8"))
 
 
+def build_schema_registry() -> Registry:
+    resources = []
+    for path in sorted(SCHEMA_DIR.glob("*.schema.json")):
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        resources.append((schema["$id"], Resource.from_contents(schema)))
+    return Registry().with_resources(resources)
+
+
+SCHEMA_REGISTRY = build_schema_registry()
+
+
 def validator(name: str) -> Draft202012Validator:
     schema = load_schema(name)
     Draft202012Validator.check_schema(schema)
-    return Draft202012Validator(schema, format_checker=FormatChecker())
+    return Draft202012Validator(
+        schema,
+        registry=SCHEMA_REGISTRY,
+        format_checker=FormatChecker(),
+    )
 
 
 def assert_valid(
@@ -94,6 +111,35 @@ SEARCH_RECORD = {
     "status": "candidate-metadata",
     "tags": ["hmlr", "boundaries"],
 }
+
+
+def evidence_receipt(
+    operation: str,
+    request_id: str,
+    trace_id: str,
+    returned_record_count: int,
+) -> dict[str, Any]:
+    receipt = json.loads(
+        (FIXTURE_DIR / "evidence-receipt.example.json").read_text(encoding="utf-8")
+    )
+    receipt["request_id"] = request_id
+    receipt["trace_id"] = trace_id
+    receipt["operation"]["name"] = operation
+    receipt["policy_decision"]["request_id"] = request_id
+    receipt["policy_decision"]["trace_id"] = trace_id
+    receipt["policy_decision"]["operation"] = operation
+    receipt["catalogue"] = copy.deepcopy(CATALOGUE)
+    receipt["result"]["returned_record_count"] = returned_record_count
+    if operation == "catalogue.describe":
+        receipt["transformations"] = [
+            {
+                "name": "load-checksum-verified-catalogue",
+                "version": "v1",
+            },
+            {"name": "normalise-parameters", "version": "v1"},
+            {"name": "project-result-core", "version": "v1"},
+        ]
+    return receipt
 
 
 class CatalogueApiSchemaTests(unittest.TestCase):
@@ -175,6 +221,12 @@ class CatalogueApiSchemaTests(unittest.TestCase):
             "request_id": "request-001",
             "trace_id": "0" * 32,
             "catalogue": CATALOGUE,
+            "evidence_receipt": evidence_receipt(
+                "catalogue.search",
+                "request-001",
+                "0" * 32,
+                1,
+            ),
             "warnings": [],
             "data": {
                 "records": [SEARCH_RECORD],
@@ -196,12 +248,19 @@ class CatalogueApiSchemaTests(unittest.TestCase):
         }
         assert_valid(self, schema_validator, result)
 
-        unsupported_evidence = copy.deepcopy(result)
-        unsupported_evidence["evidence"] = {
-            "receipt_id": "receipt_catalogue_001",
-            "receipt_digest": f"sha256:{'b' * 64}",
-        }
-        assert_invalid(self, schema_validator, unsupported_evidence)
+        missing_evidence = copy.deepcopy(result)
+        missing_evidence.pop("evidence_receipt")
+        assert_invalid(self, schema_validator, missing_evidence)
+
+        legacy_evidence = copy.deepcopy(result)
+        legacy_evidence["evidence"] = {"receipt_id": "receipt_catalogue_001"}
+        assert_invalid(self, schema_validator, legacy_evidence)
+
+        persisted_evidence = copy.deepcopy(result)
+        persisted_evidence["evidence_receipt"]["evidence_handling"]["persistence"] = (
+            "persisted"
+        )
+        assert_invalid(self, schema_validator, persisted_evidence)
 
         unknown = copy.deepcopy(result)
         unknown["data"]["records"][0]["details"] = {"arbitrary": True}
@@ -227,6 +286,12 @@ class CatalogueApiSchemaTests(unittest.TestCase):
             "request_id": "request-002",
             "trace_id": "1" * 32,
             "catalogue": CATALOGUE,
+            "evidence_receipt": evidence_receipt(
+                "catalogue.describe",
+                "request-002",
+                "1" * 32,
+                1,
+            ),
             "warnings": [
                 "This catalogue contains public metadata and does not execute providers."
             ],
@@ -321,6 +386,19 @@ class CatalogueApiSchemaTests(unittest.TestCase):
         unsafe_key = copy.deepcopy(result)
         unsafe_key["data"]["record"]["details"] = {"trusted\u202eevil": True}
         assert_invalid(self, schema_validator, unsafe_key)
+
+        excessive_source_refs = copy.deepcopy(result)
+        excessive_source_refs["data"]["record"]["source_refs"] = [
+            f"source:{index}" for index in range(100)
+        ]
+        assert_invalid(self, schema_validator, excessive_source_refs)
+
+        excessive_sources = copy.deepcopy(result)
+        source = excessive_sources["data"]["included"]["sources"][0]
+        excessive_sources["data"]["included"]["sources"] = [
+            {**source, "id": f"source:{index}"} for index in range(100)
+        ]
+        assert_invalid(self, schema_validator, excessive_sources)
 
     def test_problem_envelope_rejects_unbounded_or_unknown_data(self) -> None:
         schema_validator = validator("catalogue-problem.schema.json")

--- a/tests/contract/test_evidence_schemas.py
+++ b/tests/contract/test_evidence_schemas.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas"
+FIXTURE_DIR = ROOT / "providers" / "fixtures"
+
+SCHEMA_IDS = {
+    "public-authority-context.schema.json": (
+        "urn:gis-ai-go:schema:public-authority-context:v1"
+    ),
+    "public-policy.schema.json": "urn:gis-ai-go:schema:public-policy:v1",
+    "public-policy-decision.schema.json": (
+        "urn:gis-ai-go:schema:public-policy-decision:v1"
+    ),
+    "evidence-receipt.schema.json": "urn:gis-ai-go:schema:evidence-receipt:v1",
+}
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+PUBLIC_POLICY = load_json(
+    ROOT / "packages" / "policy-client" / "src" / "public-catalogue-v1.json"
+)
+
+
+def build_schema_registry() -> Registry:
+    resources = []
+    for path in sorted(SCHEMA_DIR.glob("*.schema.json")):
+        schema = load_json(path)
+        resources.append((schema["$id"], Resource.from_contents(schema)))
+    return Registry().with_resources(resources)
+
+
+SCHEMA_REGISTRY = build_schema_registry()
+
+
+def validator(name: str) -> Draft202012Validator:
+    schema = load_json(SCHEMA_DIR / name)
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(
+        schema,
+        registry=SCHEMA_REGISTRY,
+        format_checker=FormatChecker(),
+    )
+
+
+def assert_valid(
+    test_case: unittest.TestCase,
+    schema_validator: Draft202012Validator,
+    instance: object,
+) -> None:
+    errors = sorted(schema_validator.iter_errors(instance), key=lambda error: list(error.path))
+    test_case.assertEqual([], [error.message for error in errors])
+
+
+def assert_invalid(
+    test_case: unittest.TestCase,
+    schema_validator: Draft202012Validator,
+    instance: object,
+) -> None:
+    test_case.assertTrue(list(schema_validator.iter_errors(instance)))
+
+
+def assert_contract_objects_are_closed(
+    test_case: unittest.TestCase,
+    node: object,
+    path: str = "$",
+) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object" and ".contains" not in path:
+            test_case.assertIs(
+                node.get("additionalProperties"),
+                False,
+                f"{path} must reject unknown properties",
+            )
+        for key, value in node.items():
+            assert_contract_objects_are_closed(test_case, value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            assert_contract_objects_are_closed(test_case, value, f"{path}[{index}]")
+
+
+def keys_in(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value).union(*(keys_in(item) for item in value.values()))
+    if isinstance(value, list):
+        return set().union(*(keys_in(item) for item in value))
+    return set()
+
+
+class EvidenceSchemaTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.authority_context = load_json(
+            FIXTURE_DIR / "public-authority-context.example.json"
+        )
+        self.policy_decision = load_json(
+            FIXTURE_DIR / "public-policy-decision.example.json"
+        )
+        self.receipt = load_json(FIXTURE_DIR / "evidence-receipt.example.json")
+
+    def test_v1_schema_ids_are_stable_and_contract_objects_are_closed(self) -> None:
+        for name, expected_id in SCHEMA_IDS.items():
+            with self.subTest(schema=name):
+                schema = load_json(SCHEMA_DIR / name)
+                Draft202012Validator.check_schema(schema)
+                self.assertEqual(expected_id, schema["$id"])
+                assert_contract_objects_are_closed(self, schema)
+
+    def test_anonymous_open_context_is_server_constructed_and_contains_no_identity(self) -> None:
+        schema_validator = validator("public-authority-context.schema.json")
+        assert_valid(self, schema_validator, self.authority_context)
+
+        self.assertEqual("server", self.authority_context["construction"]["source"])
+        self.assertEqual(
+            "anonymous-open",
+            self.authority_context["construction"]["profile"],
+        )
+        self.assertEqual("none", self.authority_context["access"]["authentication"])
+        self.assertEqual(
+            {"catalogue.search", "catalogue.describe"},
+            set(self.authority_context["permitted_operations"]),
+        )
+        forbidden = {
+            "actor",
+            "subject",
+            "user_id",
+            "organisation",
+            "role",
+            "client",
+            "device",
+            "workload",
+            "credential",
+            "token",
+        }
+        self.assertTrue(forbidden.isdisjoint(keys_in(self.authority_context)))
+
+        protected = copy.deepcopy(self.authority_context)
+        protected["access"]["contains_protected_data"] = True
+        assert_invalid(self, schema_validator, protected)
+
+        identified = copy.deepcopy(self.authority_context)
+        identified["actor"] = {"id": "unexpected"}
+        assert_invalid(self, schema_validator, identified)
+
+        incomplete = copy.deepcopy(self.authority_context)
+        incomplete["permitted_operations"] = ["catalogue.search"]
+        assert_invalid(self, schema_validator, incomplete)
+
+    def test_compiled_public_policy_is_an_exact_allow_list_with_default_deny(self) -> None:
+        schema_validator = validator("public-policy.schema.json")
+        assert_valid(self, schema_validator, PUBLIC_POLICY)
+        self.assertEqual("deny", PUBLIC_POLICY["default_effect"])
+        self.assertEqual(
+            {"catalogue.search", "catalogue.describe"},
+            {rule["operation"] for rule in PUBLIC_POLICY["rules"]},
+        )
+
+        for mutation in (
+            {"default_effect": "allow"},
+            {"rules": PUBLIC_POLICY["rules"][:1]},
+            {"rules": [PUBLIC_POLICY["rules"][0], PUBLIC_POLICY["rules"][0]]},
+            {"unexpected": True},
+        ):
+            invalid = copy.deepcopy(PUBLIC_POLICY)
+            invalid.update(mutation)
+            with self.subTest(mutation=mutation):
+                assert_invalid(self, schema_validator, invalid)
+
+        wrong_effect = copy.deepcopy(PUBLIC_POLICY)
+        wrong_effect["rules"][0]["effect"] = "allow"
+        assert_invalid(self, schema_validator, wrong_effect)
+
+    def test_public_policy_decision_supports_allow_and_default_deny_without_raw_input(self) -> None:
+        schema_validator = validator("public-policy-decision.schema.json")
+        assert_valid(self, schema_validator, self.policy_decision)
+        self.assertEqual(PUBLIC_POLICY["policy_id"], self.policy_decision["policy_id"])
+        self.assertEqual("rfc8785-jcs", self.policy_decision["canonicalisation"])
+        self.assertEqual("deny", self.policy_decision["policy_default_effect"])
+
+        denied = copy.deepcopy(self.policy_decision)
+        denied["operation"] = "data.query"
+        denied["effect"] = "deny"
+        denied["reason_code"] = "operation-not-allowed"
+        denied["obligations"] = []
+        assert_valid(self, schema_validator, denied)
+
+        denied_with_obligations = copy.deepcopy(denied)
+        denied_with_obligations["obligations"] = ["not-persisted"]
+        assert_invalid(self, schema_validator, denied_with_obligations)
+
+        unsupported_allow = copy.deepcopy(self.policy_decision)
+        unsupported_allow["operation"] = "data.query"
+        assert_invalid(self, schema_validator, unsupported_allow)
+
+        raw_input = copy.deepcopy(self.policy_decision)
+        raw_input["raw_query"] = "unnecessary input"
+        assert_invalid(self, schema_validator, raw_input)
+
+    def test_inline_receipt_is_self_contained_not_persisted_and_not_attested(self) -> None:
+        schema_validator = validator("evidence-receipt.schema.json")
+        assert_valid(self, schema_validator, self.receipt)
+
+        self.assertEqual(self.authority_context, self.receipt["authority_context"])
+        self.assertEqual(self.policy_decision, self.receipt["policy_decision"])
+        self.assertEqual(
+            {
+                "delivery": "inline-only",
+                "persistence": "not-persisted",
+                "attestation": "not-attested",
+            },
+            self.receipt["evidence_handling"],
+        )
+        self.assertEqual(
+            sorted(
+                self.receipt["licence_obligations"],
+                key=lambda obligation: obligation["record_id"],
+            ),
+            self.receipt["licence_obligations"],
+        )
+        forbidden = {
+            "uri",
+            "store_uri",
+            "receipt_uri",
+            "raw_query",
+            "query",
+            "machine_path",
+            "prompt",
+            "token",
+            "credential",
+        }
+        self.assertTrue(forbidden.isdisjoint(keys_in(self.receipt)))
+
+        for handling_key, unsupported_value in (
+            ("delivery", "reference"),
+            ("persistence", "persisted"),
+            ("attestation", "attested"),
+        ):
+            invalid = copy.deepcopy(self.receipt)
+            invalid["evidence_handling"][handling_key] = unsupported_value
+            with self.subTest(handling_key=handling_key):
+                assert_invalid(self, schema_validator, invalid)
+
+        external_reference = copy.deepcopy(self.receipt)
+        external_reference["store_uri"] = "urn:unexpected:evidence"
+        assert_invalid(self, schema_validator, external_reference)
+
+        raw_input = copy.deepcopy(self.receipt)
+        raw_input["operation"]["raw_query"] = "public boundary"
+        assert_invalid(self, schema_validator, raw_input)
+
+        incomplete_rights = copy.deepcopy(self.receipt)
+        incomplete_rights["licence_obligations"][0].pop("attribution")
+        assert_invalid(self, schema_validator, incomplete_rights)
+
+        duplicate_rights = copy.deepcopy(self.receipt)
+        duplicate_rights["licence_obligations"].append(
+            copy.deepcopy(duplicate_rights["licence_obligations"][0])
+        )
+        assert_invalid(self, schema_validator, duplicate_rights)
+
+        unbounded_result = copy.deepcopy(self.receipt)
+        unbounded_result["result"]["returned_record_count"] = 101
+        assert_invalid(self, schema_validator, unbounded_result)
+
+        incomplete_pipeline = copy.deepcopy(self.receipt)
+        incomplete_pipeline["transformations"].pop()
+        assert_invalid(self, schema_validator, incomplete_pipeline)
+
+        reordered_pipeline = copy.deepcopy(self.receipt)
+        reordered_pipeline["transformations"][0:2] = reversed(
+            reordered_pipeline["transformations"][0:2]
+        )
+        assert_invalid(self, schema_validator, reordered_pipeline)
+
+        denied_success = copy.deepcopy(self.receipt)
+        denied_success["policy_decision"]["effect"] = "deny"
+        denied_success["policy_decision"]["reason_code"] = "operation-not-allowed"
+        denied_success["policy_decision"]["obligations"] = []
+        assert_invalid(self, schema_validator, denied_success)
+
+        mismatched_operation = copy.deepcopy(self.receipt)
+        mismatched_operation["policy_decision"]["operation"] = "catalogue.describe"
+        assert_invalid(self, schema_validator, mismatched_operation)
+
+    def test_content_id_and_digest_domains_are_explicit_and_distinct(self) -> None:
+        self.assertTrue(
+            self.authority_context["context_id"].startswith(
+                "gis-ai-go:public-authority-context:sha256:"
+            )
+        )
+        self.assertTrue(
+            PUBLIC_POLICY["policy_id"].startswith("gis-ai-go:public-policy:sha256:")
+        )
+        self.assertTrue(
+            self.policy_decision["decision_id"].startswith(
+                "gis-ai-go:public-policy-decision:sha256:"
+            )
+        )
+        self.assertTrue(
+            self.receipt["receipt_id"].startswith(
+                "gis-ai-go:evidence-receipt:sha256:"
+            )
+        )
+        self.assertNotEqual(
+            self.receipt["operation"]["normalised_parameters"]["domain"],
+            self.receipt["result"]["domain"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contract/test_release_metadata.py
+++ b/tests/contract/test_release_metadata.py
@@ -6,7 +6,10 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import quote
 
+import scripts.check_versions as check_versions
 from scripts.check_versions import (
     is_valid_product_version,
     release_metadata_errors,
@@ -18,7 +21,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class ReleaseMetadataTests(unittest.TestCase):
-    def test_product_version_is_stable_semver(self) -> None:
+    def test_product_version_is_stable_semver_and_rejects_workspace_drift(self) -> None:
         for value in ("0.0.0", "0.1.0", "1.0.0", "10.23.456"):
             with self.subTest(value=value):
                 self.assertTrue(is_valid_product_version(value))
@@ -36,6 +39,58 @@ class ReleaseMetadataTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertFalse(is_valid_product_version(value))
 
+        expected_manifests = (
+            "package.json",
+            "apps/mcp-gateway/package.json",
+            "apps/public-explorer/package.json",
+            "packages/authority-context/package.json",
+            "packages/contracts/package.json",
+            "packages/evidence/package.json",
+            "packages/policy-client/package.json",
+        )
+        self.assertEqual(check_versions.npm_package_manifests(ROOT), expected_manifests)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "VERSION").write_text("0.1.0\n", encoding="utf-8")
+            for relative in expected_manifests:
+                manifest = root / relative
+                manifest.parent.mkdir(parents=True, exist_ok=True)
+                version = "9.9.9" if relative == "packages/evidence/package.json" else "0.1.0"
+                manifest.write_text(json.dumps({"version": version}), encoding="utf-8")
+            (root / "pyproject.toml").write_text(
+                '[project]\nname = "gis-ai-go"\nversion = "0.1.0"\n',
+                encoding="utf-8",
+            )
+            execution = root / "services" / "geo-execution" / "pyproject.toml"
+            execution.parent.mkdir(parents=True)
+            execution.write_text(
+                '[project]\nname = "gis-ai-go-execution"\nversion = "0.1.0"\n',
+                encoding="utf-8",
+            )
+            (root / "uv.lock").write_text(
+                '[[package]]\nname = "gis-ai-go"\nversion = "0.1.0"\n\n'
+                '[[package]]\nname = "gis-ai-go-execution"\nversion = "0.1.0"\n',
+                encoding="utf-8",
+            )
+
+            with patch.object(check_versions, "ROOT", root):
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    r"packages/evidence/package\.json=9\.9\.9",
+                ):
+                    check_versions.main([])
+
+            extra_manifest = root / "packages" / "future-package" / "package.json"
+            extra_manifest.parent.mkdir(parents=True)
+            extra_manifest.write_text(json.dumps({"version": "9.9.9"}), encoding="utf-8")
+            with patch.object(check_versions, "ROOT", root):
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    r"packages/future-package/package\.json=9\.9\.9",
+                ):
+                    check_versions.main([])
+
     def test_sbom_uses_canonical_product_version(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             output = Path(temporary_directory) / "sbom.cdx.json"
@@ -51,6 +106,24 @@ class ReleaseMetadataTests(unittest.TestCase):
         expected = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
         self.assertEqual(sbom["metadata"]["component"]["version"], expected)
         self.assertNotIn("Stage 0", sbom["metadata"]["properties"][0]["value"])
+        workspace_components = {
+            "@gis-ai-go/authority-context",
+            "@gis-ai-go/contracts",
+            "@gis-ai-go/evidence",
+            "@gis-ai-go/policy-client",
+        }
+        for name in workspace_components:
+            with self.subTest(package=name):
+                manifest_path = next(
+                    path
+                    for path in (ROOT / "packages").glob("*/package.json")
+                    if json.loads(path.read_text(encoding="utf-8"))["name"] == name
+                )
+                version = json.loads(manifest_path.read_text(encoding="utf-8"))["version"]
+                matches = [item for item in sbom["components"] if item["name"] == name]
+                self.assertEqual(len(matches), 1)
+                self.assertEqual(matches[0]["version"], version)
+                self.assertEqual(matches[0]["purl"], f"pkg:npm/{quote(name, safe='/')}@{version}")
 
     def test_bootstrap_version_does_not_claim_release_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/contract/test_repository_boundary.py
+++ b/tests/contract/test_repository_boundary.py
@@ -7,6 +7,8 @@ import tomllib
 import unittest
 from pathlib import Path
 
+from scripts.check_versions import npm_package_manifests
+
 ROOT = Path(__file__).resolve().parents[2]
 RESEARCH = ROOT / "docs" / "research" / "2026-08-19"
 
@@ -28,12 +30,7 @@ class RepositoryBoundaryTests(unittest.TestCase):
             self.assertNotIn("locus-accord", schema["$id"])
 
     def test_repository_uses_mit_licence_metadata(self) -> None:
-        for relative in (
-            "package.json",
-            "apps/mcp-gateway/package.json",
-            "apps/public-explorer/package.json",
-            "packages/contracts/package.json",
-        ):
+        for relative in npm_package_manifests(ROOT):
             package = json.loads((ROOT / relative).read_text(encoding="utf-8"))
             self.assertTrue(package["private"])
             self.assertEqual(package["license"], "MIT")
@@ -53,7 +50,10 @@ class RepositoryBoundaryTests(unittest.TestCase):
                 encoding="utf-8"
             )
         )
-        self.assertEqual(receipt["software"][0]["name"], "gis-ai-go-execution")
+        self.assertEqual(receipt["schema"], "gis-ai-go.evidence-receipt.v1")
+        self.assertEqual(receipt["software"]["name"], "gis-ai-go-mcp-gateway")
+        self.assertEqual(receipt["evidence_handling"]["persistence"], "not-persisted")
+        self.assertEqual(receipt["evidence_handling"]["attestation"], "not-attested")
 
     def test_package_uv_run_commands_are_lock_strict(self) -> None:
         excluded_parts = {".git", "artifacts", "dist", "node_modules"}


### PR DESCRIPTION
## Summary

- add RFC 8785 canonical JSON and domain-separated SHA-256 identities for public authority, policy decisions and inline evidence receipts
- require every inactive in-process catalogue success to carry a self-contained receipt that independently binds parameters, catalogue identity, result core, software and record-specific licence evidence
- add closed schemas, reproducible fixtures, default-deny public-policy evaluation, release/SBOM inventory hardening and the ADR/verification record

## Boundary

This is the bounded EVID-204A foundation only. It does not add an MCP listener, catalogue route, advertised tool, provider call, evidence store, persistence, attestation, receipt freshness/expiry checks, nonce or one-time replay prevention. Readiness remains blocked with empty active tool and API-operation lists. The supported public product remains the static v0.1.0 Explorer.

Relates to #22; it does not close the wider EVID-204 work item.

## Verification

- `pnpm run check`
- 19 shared-contract, 20 evidence, 2 authority-context, 6 policy and 41 gateway tests
- 16 Explorer build-policy, 42 Explorer unit/component, 94 repository Python, 2 execution-boundary and 27 real-browser tests
- two clean builds reproduced archive SHA-256 `f6adb7998c26bef62a651ec825e3a4426d955af4a09167b264dfa221d0ef28b0`
- 15 schemas and 55 records; 11 manifests and locks; 149-component canonical SBOM; 508-file secret/path scan
- immutable research tree unchanged
- independent integration and security reviews: SHIP, no P0–P2 findings
