### PR TITLE
docs(evidence): record EVID-204A acceptance

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,7 +42,7 @@ whose accepted implementation commit is
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
 at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
 recorded below. There is no public MCP listener or catalogue API, live provider
-adapter, policy engine, identity integration or evidence store.
+adapter, external policy service, identity integration or evidence store.
 
 The owner has authorised autonomous implementation in the open under
 [`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The repository
@@ -84,12 +84,18 @@ checksum-verified catalogue loader and deterministic transport-neutral
 `catalogue.search`/`catalogue.describe` application. Its loopback listener exposes
 only health, deliberately blocked readiness and its OpenAPI contract. It exposes
 no catalogue route, starts no MCP listener, registers no tool and is not publicly
-deployed. The local EVID-204A candidate adds server-constructed anonymous-open
-policy decisions and canonical inline receipts that state they are not persisted
-and not attested, without changing that activation boundary. Its complete locked
-local gate passes; protected pull-request and main evidence remain pending. There
-is still no live provider adapter, external policy service, identity integration or
-evidence store.
+deployed. EVID-204A merged through
+[pull request 29](https://github.com/chris-page-gov/gis-ai-go/pull/29) as
+`af9043955470568c146397d1a25dd8813eb7aa55`. It adds server-constructed
+anonymous-open policy decisions and canonical inline receipts that state they are
+not persisted and not attested, without changing that activation boundary.
+Protected-main assurance and provenance passed in
+[run 32357424957](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357424957),
+CodeQL passed in
+[run 32357427549](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357427549),
+and [attestation 41836254](https://github.com/chris-page-gov/gis-ai-go/attestations/41836254)
+binds the exact source archive to that commit. There is still no live provider
+adapter, external policy service, identity integration or evidence store.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -105,23 +105,26 @@ The supported target active set is exactly `catalogue.search`,
 - the candidate verifies the immutable catalogue, supplies deterministic bounded
   in-process search and description, and exposes only loopback health, blocked
   readiness and OpenAPI with zero active tools or API operations; and
-- the local EVID-204A candidate adds RFC 8785 canonicalisation, content-addressed
-  anonymous-open authority and policy decisions, and independently verified inline
-  receipts to every in-process catalogue success while keeping activation blocked.
+- EVID-204A merged through
+  [pull request 29](https://github.com/chris-page-gov/gis-ai-go/pull/29) as
+  `af9043955470568c146397d1a25dd8813eb7aa55`; it adds RFC 8785
+  canonicalisation, content-addressed anonymous-open authority and policy decisions,
+  and independently verified inline receipts to every in-process catalogue success
+  while keeping activation blocked.
 
 ## Next
 
-1. Complete independent review and the protected pull-request gate for the bounded
-   EVID-204A inline-evidence candidate.
-2. Add and verify the protocol-conformant MCP listener and direct catalogue routes,
-   then activate `catalogue.search` and `catalogue.describe` only when their full
+1. Add and verify the protocol-conformant MCP listener and direct catalogue routes,
+   while keeping operations inactive during transport conformance work.
+2. Activate `catalogue.search` and `catalogue.describe` only when their full
    policy, evidence, lifecycle and interoperability gates pass.
-3. Activate `evidence.inspect`, `selection.resolve` and `data.query` only after
-   their separate evidence gates pass; keep the other seven profiles planned.
+3. Add `evidence.inspect`, durable evidence handling, `selection.resolve` and
+   `data.query` only after their separate evidence gates pass; keep the other seven
+   profiles planned.
 
 ## Current blockers
 
-- No blocker is known for the bounded EVID-204A pull-request gate.
+- No blocker is known for the next inactive transport slice.
 - Activating or publishing a catalogue service remains hard-blocked until transport
   conformance and interoperability are implemented and reviewed. The current
   candidate has no activation override.
@@ -149,7 +152,17 @@ The supported target active set is exactly `catalogue.search`,
   [run 32344358198](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32344358198),
   then merged as `4948890c10adb4f0ac6f427cda21cb0c0c4607dd`; the candidate exposes no
   catalogue operation, MCP tool or public deployment;
-- EVID-204A local candidate: 19 shared-contract tests, 20 canonical-evidence tests,
+- EVID-204A accepted slice: protected
+  [pull request 29](https://github.com/chris-page-gov/gis-ai-go/pull/29) merged as
+  `af9043955470568c146397d1a25dd8813eb7aa55`; assurance and provenance passed in
+  [run 32357424957](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357424957),
+  CodeQL passed in
+  [run 32357427549](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357427549),
+  and [attestation 41836254](https://github.com/chris-page-gov/gis-ai-go/attestations/41836254)
+  binds archive SHA-256
+  `5253b24944e2579791bcb22f42fa6792fa5a27e34e6b36f29ffde0162b509362`
+  to that exact protected-main commit and workflow;
+- EVID-204A complete gate: 19 shared-contract tests, 20 canonical-evidence tests,
   2 authority-context tests, 6 public-policy tests and 41 gateway tests pass; all
   94 repository Python tests, 2 execution-boundary tests, 16 Explorer build-policy
   tests, 42 Explorer unit and component tests and 27 real-browser tests also pass;

--- a/docs/operations/EVID-204_INLINE_EVIDENCE.md
+++ b/docs/operations/EVID-204_INLINE_EVIDENCE.md
@@ -1,9 +1,9 @@
 # EVID-204 canonical public inline evidence
 
-- status: local candidate; complete locked local gate passing
+- status: accepted on protected `main`; operations remain inactive
 - work item: [EVID-204](https://github.com/chris-page-gov/gis-ai-go/issues/22)
 - decision: [ADR-0010](../decisions/ADR-0010-canonical-public-inline-evidence.md)
-- supported public release: [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
+- supported public release: [`v0.1.0`][release]
 
 ## Outcome boundary
 
@@ -62,16 +62,16 @@ The candidate must pass all of the following before a pull request is opened:
 
 | Evidence | State |
 | --- | --- |
-| Local implementation commit | pending |
-| Focused schema and package tests | passing: 19 contracts, 20 evidence, 2 authority, 6 policy and 41 gateway tests |
-| Complete locked local gate | passing on the uncommitted candidate working tree |
+| Local implementation commit | `9d4b3148a23925a91e5e44c3fba7b966bae958c5` |
+| Focused package tests | passing: 19/20/2/6/41 |
+| Complete locked local gate | passing on the exact candidate bytes before commit |
 | Independent evidence-core review | `SHIP`; no P0, P1 or P2 finding |
-| Independent whole-diff security and contract review | `SHIP`; no P0, P1 or P2 finding across all 60 candidate files |
-| Pull request assurance and CodeQL | pending |
-| Protected-main assurance, provenance and attestation | pending |
+| Whole-diff reviews | `SHIP`; 60/60 files; no P0–P2 finding |
+| Pull-request assurance and CodeQL | passing on [pull request 29][pr29] |
+| Main assurance, provenance and attestation | passing: `af9043955470568c146397d1a25dd8813eb7aa55` |
 
-Pending rows are not capability claims. Update them only from exact retained
-evidence after the corresponding gate succeeds.
+These passing rows accept only this bounded inactive slice. They do not claim a
+listener, route, advertised tool, public service or durable evidence store.
 
 The complete gate also passed 94 repository Python tests, 2 execution-boundary
 tests, 16 Explorer build-policy tests, 42 Explorer unit and component tests and 27
@@ -85,5 +85,33 @@ slice does not change or deploy that static product.
 The final independent integration review found no material evidence error. The
 final security diff review sealed exact snapshot
 `codex-security-snapshot/v1:sha256:f0233f6a5d8a4d5b3d31f17ea9b9f65effdf3998f3d5acc833d87da147525f90`
-after reviewing all 31 modified and 29 added files. The remaining pending rows are
-remote publication evidence, not local implementation gaps.
+after reviewing all 31 modified and 29 added files. The protected pull-request and
+main evidence is recorded below.
+
+The candidate commit passed assurance in
+[run 32357195428](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357195428)
+and CodeQL in
+[run 32357192770](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357192770).
+It then squash-merged through
+[pull request 29](https://github.com/chris-page-gov/gis-ai-go/pull/29) as protected-main
+commit `af9043955470568c146397d1a25dd8813eb7aa55`.
+
+Protected-main assurance and provenance passed in
+[run 32357424957](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357424957),
+and all three CodeQL analyses passed in
+[run 32357427549](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32357427549)
+with no open code-scanning alert. The retained Pages-source artefact
+`9402226353` has GitHub transport digest
+`sha256:bb5b30081d43ed30afb271aaa860a89e8dd1c91d67afe5e713a66904b33cbebd`.
+Independent archive verification passed for SHA-256
+`5253b24944e2579791bcb22f42fa6792fa5a27e34e6b36f29ffde0162b509362`,
+payload root `8d15da326f7a0fb4abfadbc3629166bb741050e24ae17044243673b599b3d7a8`
+and OKF content root
+`99f3d0419aba2a1a6f18fd05f0c3f87123d6d8f2db4520ca3d0f9d6df45f5bd7`.
+Strict `gh attestation verify` passed with the exact repository, signer workflow,
+source ref, source commit and GitHub-hosted-runner requirement;
+[attestation 41836254](https://github.com/chris-page-gov/gis-ai-go/attestations/41836254)
+contains SLSA provenance for run 32357424957 attempt 1 and that archive digest.
+
+[pr29]: https://github.com/chris-page-gov/gis-ai-go/pull/29
+[release]: https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- record the accepted EVID-204A implementation and its protected-main identity
- link the exact pull-request, assurance, provenance, CodeQL and attestation evidence
- retain the inactive boundary: no listener, catalogue route, advertised tool, public service or durable evidence store

## Verification

- exact three-file documentation delta reviewed independently: SHIP, no P0-P2
- `git diff --check`
- link and integrity validation: 308 local links, 183 research hashes, 2 ledgers and 71 source identifiers
- secret and machine-path scan: 508 files
- protected-main CI and provenance: run 32357424957
- protected-main CodeQL: run 32357427549, no open code-scanning alerts
- strict attestation verification: attestation 41836254
- fresh archive verification: SHA-256 `5253b24944e2579791bcb22f42fa6792fa5a27e34e6b36f29ffde0162b509362`

## Boundary

This evidence-only change does not activate or deploy any MCP listener, direct catalogue route, provider adapter, tool or evidence store. The supported public product remains v0.1.0. Issue #22 remains open for the later durable evidence and `evidence.inspect` work.

Relates to #22.
