### PR TITLE
docs(mcp): record transport acceptance evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,20 +97,28 @@ and [attestation 41836254](https://github.com/chris-page-gov/gis-ai-go/attestati
 binds the exact source archive to that commit. There is still no live provider
 adapter, external policy service, identity integration or evidence store.
 
-A third MCP-201 slice is now a local, unaccepted candidate at exact implementation
-commit `fb0234b9a6a968fe68c2fbe98388f2415393c9c1`, based on protected-main commit
-`997d5fdd478797b20b05d1980be8f986645d410e`. It implements bounded direct
+The third MCP-201 slice merged through
+[pull request 31](https://github.com/chris-page-gov/gis-ai-go/pull/31) as
+`edc26c0396ecd230570de1ab0fd402338567f67d`. It implements bounded direct
 `POST /catalogue/search` and `POST /catalogue/describe` handlers and modern MCP
-2026-07-28 HTTP and STDIO transports over that same application path. Explicit
+2026-07-28 HTTP and STDIO transports over the accepted application path. Exact
+pull-request assurance passed in
+[run 32389353007](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389353007),
+CodeQL passed in
+[run 32389350801](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389350801),
+protected-main assurance and provenance passed in
+[run 32389721338](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721338),
+and protected-main CodeQL passed in
+[run 32389721461](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721461).
+[Attestation 41912276](https://github.com/chris-page-gov/gis-ai-go/attestations/41912276)
+binds the verified source archive to that exact merge commit and run. Explicit
 constructor options can register the two tools, matching API operations and
 read-only catalogue resources for local conformance tests. The production/default
 tool and API arrays remain empty, resources default to none, readiness remains
-`503`, and the shipped entry points provide no activation override. The candidate
-has no pull request, CI evidence, deployment, public service URL or
-registry entry. Its exact local bytes pass the complete locked repository
-gate and independent architecture, integration and security reviews with no
-P0–P2 finding. Pinned SDK conformance does not replace the still-pending independent
-host and non-App fallback evidence required before activation.
+`503`, and the shipped entry points provide no activation override. There is no
+deployment, public service URL or registry entry. Pinned SDK conformance does not
+replace the still-pending independent host and non-App fallback evidence required
+before activation.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -116,25 +116,25 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Next
 
-1. Push the reviewed blocked transport candidate and pass the protected
-   pull-request gate without changing its zero-activation boundary.
-2. Verify independent major-host interoperability and the complete non-App fallback
+1. Verify independent major-host interoperability and the complete non-App fallback
    and lifecycle journeys before considering activation or deployment of
    `catalogue.search` and `catalogue.describe`.
+2. Make any activation a separate reviewed change with explicit rollback and
+   publication evidence; do not reuse the constructor-only conformance seam.
 3. Add `evidence.inspect`, durable evidence handling, `selection.resolve` and
    `data.query` only after their separate evidence gates pass; keep the other seven
    profiles planned.
 
 ## Current blockers
 
-- No local implementation or review blocker remains for the blocked transport
-  slice; its exact candidate commit exists and protected pull-request evidence is
-  pending.
+- The inactive transport foundation is accepted on protected `main`; there is no
+  remaining implementation, pull-request, assurance, CodeQL or attestation blocker
+  for that zero-activation slice.
 - Activating or publishing a catalogue service remains hard-blocked. Raw protocol
   transcripts and the pinned SDK client do not establish independent major-host
   interoperability, and host-specific non-App fallback and lifecycle evidence is
   still pending.
-- Direct routes and MCP transports now exist only on the local candidate branch. The
+- Direct routes and MCP transports now exist on protected `main`, but the
   production/default capability arrays are empty, readiness is `503`, and there is
   no public service deployment or activation override.
 - The candidate has no provider adapter, provider call, evidence store or durable
@@ -145,7 +145,7 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Latest evidence
 
-- MCP-201 blocked transport candidate: exact local implementation commit
+- MCP-201 blocked transport foundation: exact local implementation commit
   `fb0234b9a6a968fe68c2fbe98388f2415393c9c1`, based on protected-main commit
   `997d5fdd478797b20b05d1980be8f986645d410e`, passes the complete locked gate with
   19 contract, 20 evidence, 2 authority-context, 6 policy, 86 gateway, 16 Explorer
@@ -157,9 +157,23 @@ The supported target active set is exactly `catalogue.search`,
   15 schemas, 55 records and 3 evaluation manifests validate; 308 links, 183
   research hashes, 2 ledgers and 71 source identifiers resolve; the 516-file scan,
   9 diagrams and 163-component SBOM pass; two independent current-byte reviews and
-  the completed security diff review report no P0–P2 finding; pull request, CI,
-  CodeQL and attestation remain pending, and no deployment or independent
-  major-host evidence is claimed;
+  the completed security diff review report no P0–P2 finding;
+- MCP-201 transport acceptance: protected
+  [pull request 31](https://github.com/chris-page-gov/gis-ai-go/pull/31) at exact
+  head `3a92c005e67ca1d239c1f4a3c0a955b19c59bd7a` passed assurance in
+  [run 32389353007](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389353007)
+  and CodeQL in
+  [run 32389350801](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389350801),
+  then merged as `edc26c0396ecd230570de1ab0fd402338567f67d`; protected-main
+  assurance and provenance passed in
+  [run 32389721338](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721338),
+  CodeQL passed in
+  [run 32389721461](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721461),
+  and [attestation 41912276](https://github.com/chris-page-gov/gis-ai-go/attestations/41912276)
+  binds archive SHA-256
+  `20ddcfeb54d40ed3c55784856d608d94e81e6a73f7870d03f2cf7a85e11b8fd5`
+  to that exact commit and run; no deployment or independent major-host evidence
+  is claimed;
 - MCP-201 shared catalogue contract: protected-main commit
   `e5e6d4db5ac7036198cde64279e815f214f3defd`, passing assurance and provenance in
   [run 32338916345](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32338916345),

--- a/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
+++ b/docs/operations/MCP-201_GATEWAY_CANDIDATE.md
@@ -1,15 +1,29 @@
-# MCP-201 blocked transport candidate
+# MCP-201 inactive transport boundary
 
-- status: local candidate; acceptance, activation and publication blocked
+- status: accepted on protected `main`; activation and publication blocked
 - work item: [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19)
 - protected-main base: `997d5fdd478797b20b05d1980be8f986645d410e`
+- implementation commit: `fb0234b9a6a968fe68c2fbe98388f2415393c9c1`
+- pull-request head: `3a92c005e67ca1d239c1f4a3c0a955b19c59bd7a`
+- pull request: [31](https://github.com/chris-page-gov/gis-ai-go/pull/31)
+- pull-request assurance:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389353007)
+- pull-request CodeQL:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389350801)
+- protected-main merge: `edc26c0396ecd230570de1ab0fd402338567f67d`
+- protected-main assurance and provenance:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721338)
+- protected-main CodeQL:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721461)
+- protected-main provenance:
+  [attestation 41912276](https://github.com/chris-page-gov/gis-ai-go/attestations/41912276)
 - supported public product: immutable
   [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
 - current activation block: `transport-and-interoperability-unverified`
 
 ## Purpose
 
-This local slice adds MCP 2026-07-28 HTTP and STDIO transports and direct HTTP
+This accepted slice adds MCP 2026-07-28 HTTP and STDIO transports and direct HTTP
 `catalogue.search` and `catalogue.describe` routes over the already accepted shared
 application. The MCP and direct faces use the same canonical request and result
 schemas, policy decisions and inline evidence receipts.
@@ -135,11 +149,11 @@ repository-level canonical schema files. The compiled gateway therefore depends 
 the full checkout layout retaining `schemas/`; `apps/mcp-gateway/dist/` is not a
 standalone package.
 
-This candidate has no public deployment, service URL or registry entry; provider
-adapter or provider call; external policy decision point, OPA or identity
-integration; durable rate service; or evidence store, ledger, lookup or
-attestation. The static Explorer remains the only supported public product and has
-no dependency on this process.
+This accepted inactive foundation has no public deployment, service URL or registry
+entry. It has no provider adapter or provider call; external policy decision point,
+OPA or identity integration; durable rate service; or evidence store, ledger,
+lookup or runtime receipt attestation. The static Explorer remains the only
+supported public product and has no dependency on this process.
 
 ## Activation gate
 
@@ -149,11 +163,11 @@ does not change the frozen activation document and is not used by either executa
 
 Raw transcript and pinned SDK-client conformance can establish the protocol shape,
 but they do not prove interoperability with independent major MCP hosts. Complete
-non-App result representations exist in the candidate, but host-specific fallback,
-lifecycle and usability evidence is still pending. The complete locked local gate
-and independent reviews now pass, but protected pull-request checks, an explicit
-reviewed activation decision and deployment rollback evidence must also pass before
-activation or publication. Until then, the supported capability list remains empty.
+non-App result representations exist in the accepted slice, but host-specific fallback,
+lifecycle and usability evidence is still pending. The complete locked local and
+protected pull-request/main gates pass, but an explicit reviewed activation decision
+and deployment rollback evidence must also pass before activation or publication.
+Until then, the supported capability list remains empty.
 
 See the [MCP-201 verification record](MCP-201_VERIFICATION.md) and
 [EVID-204A evidence boundary](EVID-204_INLINE_EVIDENCE.md) for the distinction

--- a/docs/operations/MCP-201_VERIFICATION.md
+++ b/docs/operations/MCP-201_VERIFICATION.md
@@ -1,7 +1,7 @@
 # MCP-201 verification record
 
-- status: shared catalogue, inactive gateway and EVID-204A slices accepted on
-  protected `main`; MCP and direct-API transport slice remains a local candidate
+- status: shared catalogue, inactive gateway, EVID-204A and inactive transport
+  slices accepted on protected `main`; activation and publication remain blocked
 - reviewed on: 20 August 2026
 - work item: [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19)
 
@@ -181,19 +181,32 @@ The pull-request head and protected-main merge both resolve to tree
 code-scanning alerts at the end of that window. No job failed: GitHub created no
 check suite or workflow run for the merge.
 
-## Local MCP and direct-API transport candidate
+## Accepted MCP and direct-API transport foundation
 
 - protected-main base: `997d5fdd478797b20b05d1980be8f986645d410e`
 - candidate implementation commit:
   `fb0234b9a6a968fe68c2fbe98388f2415393c9c1`
-- pull request, remote CI, CodeQL and attestation: not yet created
+- pull-request head: `3a92c005e67ca1d239c1f4a3c0a955b19c59bd7a`
+- pull request: [31](https://github.com/chris-page-gov/gis-ai-go/pull/31)
+- pull-request assurance:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389353007)
+- pull-request provenance: skipped as designed for the pull-request event
+- pull-request CodeQL:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389350801)
+- protected-main merge: `edc26c0396ecd230570de1ab0fd402338567f67d`
+- protected-main assurance and provenance:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721338)
+- protected-main CodeQL:
+  [passing](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32389721461)
+- protected-main provenance:
+  [attestation 41912276](https://github.com/chris-page-gov/gis-ai-go/attestations/41912276)
 - deployment, public service URL and registry entry: none
 - activation state: blocked; default MCP tool and direct-API arrays empty;
   resources default to none
 
-### Candidate outcome
+### Accepted outcome
 
-The exact local candidate commit adds direct POST search and description handlers,
+The exact implementation commit adds direct POST search and description handlers,
 an MCP 2026-07-28 HTTP route and a protocol-clean STDIO entry point. All use one
 checksum-verified catalogue snapshot, the same application, exact canonical
 request and result schemas, and the existing canonical inline evidence path.
@@ -258,7 +271,7 @@ concurrency limit returns a face-appropriate `429` response with `Retry-After: 1
 capacity is released after a completed or abandoned request. Shutdown is
 idempotent and closes MCP state before the HTTP listener.
 
-### Current verification state
+### Accepted verification state
 
 Focused development checks exercise:
 
@@ -274,7 +287,7 @@ Focused development checks exercise:
   rejection, concurrent admission and clean shutdown; and
 - built-runtime entry points and the full-checkout canonical-schema dependency.
 
-The exact frozen local candidate passes:
+The exact implementation candidate passed:
 
 - 19 of 19 shared-contract, 20 of 20 canonical-evidence, 2 of 2
   authority-context, 6 of 6 policy-client and 86 of 86 gateway tests;
@@ -294,11 +307,23 @@ The exact frozen local candidate passes:
 - two independent final reviews with no P0–P2 finding in the frozen
   post-remediation working tree. A separate completed security diff review also
   found no P0–P2 issue but retained its original snapshot warning. Post-snapshot
-  corrections were manually reviewed and dynamically tested; the candidate commit,
-  tree and attestation remain the durable identity.
+  corrections were manually reviewed and dynamically tested. The implementation
+  commit, pull-request head, protected merge, archive and attestation provide the
+  durable identities.
 
-Pull-request assurance, CodeQL and protected-main evidence remain pending. None of
-the historical accepted evidence above accepts these candidate bytes.
+The exact pull-request head passed assurance, all three CodeQL language analyses
+and the aggregate CodeQL check. Protected-main assurance and provenance then passed
+in run 32389721338, and protected-main CodeQL passed in run 32389721461 with zero
+open code-scanning alerts. The accepted Pages-source artefact is
+`pages-source-edc26c0396ecd230570de1ab0fd402338567f67d`, artefact ID `9414404528`,
+with uploaded ZIP digest
+`91e543fd4aba13b4ddaa3b445126d1fd09fe615336742bc4c507b163d658d227`.
+Independent download and archive verification passed at archive SHA-256
+`20ddcfeb54d40ed3c55784856d608d94e81e6a73f7870d03f2cf7a85e11b8fd5`
+and payload root
+`47f23253421feef5be1fd2ed20f865ed188c889d70a9a6a804d21108216122e7`.
+Strict attestation verification bound that archive to the exact repository,
+`ci.yml`, protected-main ref, merge commit and GitHub-hosted runner.
 
 Pinned SDK-client conformance is not independent major-host interoperability.
 Complete non-App result values exist, but host-specific fallback, lifecycle and
@@ -307,19 +332,19 @@ documentation.
 
 ## Activation and publication boundary
 
-No service or new public endpoint is published by any accepted or local slice. The
+No service or new public endpoint is published by any accepted slice. The
 supported public product remains the static `v0.1.0` Explorer.
 
 EVID-204A changed the activation reason to
 `transport-and-interoperability-unverified` after adding reviewed public policy
-decisions and required canonical inline result receipts. The current local slice
-implements the transport and direct route code without changing that activation
-document. Independent major-host interoperability, fallback and lifecycle evidence,
-protected pull-request and protected-main assurance, and a separate reviewed
-activation decision are still required before either operation can be advertised or
+decisions and required canonical inline result receipts. The accepted transport
+slice implements the transport and direct route code without changing that
+activation document. Independent major-host interoperability, fallback and
+lifecycle evidence, a separate reviewed activation decision, and deployment
+rollback evidence are still required before either operation can be advertised or
 published.
 
 The durable candidate boundary is documented in
-[MCP-201 blocked transport candidate](MCP-201_GATEWAY_CANDIDATE.md).
+[MCP-201 inactive transport boundary](MCP-201_GATEWAY_CANDIDATE.md).
 
 [sdk-header-defect]: https://github.com/modelcontextprotocol/typescript-sdk/issues/2589

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,10 +5,10 @@ as historical evidence. Current authority and status are in [`CONTEXT.md`](../..
 and [`PROGRESS.md`](../../PROGRESS.md); ADR-0004 records progression beyond the local
 pause. The static Explorer is the supported
 [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
-public discovery product. A blocked local gateway candidate now contains MCP
-2026-07-28 HTTP and STDIO transports plus direct catalogue route implementations,
-but its default capability lists are empty and no public MCP service or catalogue
-API is deployed.
+public discovery product. An accepted inactive gateway foundation on protected
+`main` contains MCP 2026-07-28 HTTP and STDIO transports plus direct catalogue route
+implementations. Its default capability lists are empty, activation and publication
+remain blocked, and no public MCP service or catalogue API is deployed.
 
 - [Stage 0 boundary](STAGE_0_BOUNDARY.md)
 - [Dependency baseline](DEPENDENCIES.md)
@@ -19,6 +19,6 @@ API is deployed.
 - [DISC-104 GitHub Pages verification record](DISC-104_VERIFICATION.md)
 - [QUAL-105 release-assurance verification record](QUAL-105_VERIFICATION.md)
 - [`v0.1.0` supported-release evidence](V0.1.0_RELEASE_EVIDENCE.md)
-- [MCP-201 blocked transport candidate boundary](MCP-201_GATEWAY_CANDIDATE.md)
+- [MCP-201 inactive transport boundary](MCP-201_GATEWAY_CANDIDATE.md)
 - [MCP-201 verification record](MCP-201_VERIFICATION.md)
 - [EVID-204 canonical public inline evidence](EVID-204_INLINE_EVIDENCE.md)


### PR DESCRIPTION
## Summary

Records the accepted protected-main evidence for the inactive MCP-201 transport
foundation merged through #31.

- records exact pull-request and merge commits;
- records PR and protected-main assurance and CodeQL runs;
- records Pages-source artefact, archive and payload identities;
- records the constrained SLSA attestation; and
- removes stale local-candidate and pending-remote-evidence wording.

## Verification

- 308 local links, 183 immutable research hashes, 2 ledgers and 71 source
  identifiers passed;
- 468 current-checkout text files passed the secret and machine-path scan;
- whitespace, line length, immutable research and British English checks passed;
  and
- an independent live-evidence review found no P0–P2 issue.

## Boundary

This changes documentation only. Default MCP tools, APIs and resources remain
empty, readiness remains `503`, and no service is deployed. Independent major-host
interoperability, non-App fallback/lifecycle evidence, a separate activation
decision and rollback proof remain required before activation or publication.

Progresses #19; it does not close the issue.
