### PR TITLE
feat(tools): add bounded profile registry

### DIFF
--- a/changelog.d/TOOLS-205.added.md
+++ b/changelog.d/TOOLS-205.added.md
@@ -1,0 +1,2 @@
+- Add the closed 12-profile tool registry with immutable helpers, lifecycle and
+  release-target separation, research provenance and a fail-closed empty callable set.

--- a/docs/operations/DEPENDENCIES.md
+++ b/docs/operations/DEPENDENCIES.md
@@ -41,6 +41,10 @@ The Explorer has no production runtime dependency. The private
 `@gis-ai-go/provider-adapter-sdk` workspace package reuses the existing evidence
 package for RFC 8785 bytes and adds no third-party dependency. No external provider
 SDK, geospatial runtime, OPA binary, database driver or cloud dependency is present.
+The private `@gis-ai-go/tool-registry` package also has no dependency. Its root
+development-only workspace link ensures that the first-party package identity is
+locked and included in the dependency SBOM without importing it into the gateway or
+creating a runtime activation path.
 EXEC-202 adds no Python package dependency: its geometry, HTTP and cancellation
 acceptance use the standard library over checked-in synthetic records. Its official
 Python base is tag-and-digest pinned, runs non-root and is bound into the repository

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -25,3 +25,4 @@ remain blocked, and no public MCP service or catalogue API is deployed.
 - [EVID-204 durable public evidence candidate](EVID-204_DURABLE_LEDGER.md)
 - [EXEC-202 private execution service](EXEC-202_EXECUTION_SERVICE.md)
 - [ADAPT-203 provider contract and ONS preflight](ADAPT-203_PROVIDER_PREFLIGHT.md)
+- [TOOLS-205 non-activating tool registry candidate](TOOLS-205_TOOL_REGISTRY.md)

--- a/docs/operations/TOOLS-205_TOOL_REGISTRY.md
+++ b/docs/operations/TOOLS-205_TOOL_REGISTRY.md
@@ -1,0 +1,116 @@
+# TOOLS-205 non-activating tool registry candidate
+
+- status: local candidate; not activated, advertised or deployed
+- work item: `TOOLS-205`
+- decision: [ADR-0009](../decisions/ADR-0009-read-only-mcp-tool-lifecycle.md)
+- base: protected `main` commit `364c8680ad11399e0547a843be2a04da7a737301`
+
+## Implemented boundary
+
+The candidate adds a closed
+[`tool-registry.v1.json`](../../profiles/tool-registry.v1.json) profile, its Draft
+2020-12 [schema](../../schemas/tool-registry.schema.json) and the private,
+zero-third-party-dependency `@gis-ai-go/tool-registry` package. The registry has
+exactly 12 unique IDs and names in ADR-0009 order. Every profile records lifecycle,
+mutability, release target, implementation and discovery state, runtime schema
+references, provider and operation support, controlled errors, cursor and artefact
+status, CRS requirements, provenance, fallback, threats and immutable research
+provenance.
+
+| ID | Profile | Current implementation | Current lifecycle | `v0.2.0` target | Release target | Effect |
+| --- | --- | --- | --- | --- | --- | --- |
+| T01 | `catalogue.search` | implemented | suspended | active | `v0.2.0` | read-only |
+| T02 | `catalogue.describe` | implemented | suspended | active | `v0.2.0` | read-only |
+| T03 | `selection.resolve` | not implemented | planned | active | `v0.2.0` | read-only |
+| T04 | `data.query` | not implemented | planned | active | `v0.2.0` | read-only |
+| T05 | `spatial.locate` | not implemented | planned | planned | later reviewed release | read-only |
+| T06 | `spatial.analyse` | not implemented | planned | planned | later reviewed release | read-only |
+| T07 | `statistics.compare` | not implemented | planned | planned | later reviewed release | read-only |
+| T08 | `route.plan` | not implemented | planned | planned | later reviewed release | read-only |
+| T09 | `map.render` | not implemented | planned | planned | later reviewed release | read-only |
+| T10 | `artefact.export` | not implemented | planned | planned | later reviewed release | read-only |
+| T11 | `evidence.inspect` | implemented | suspended | active | `v0.2.0` | read-only |
+| T12 | `workflow.execute` | not implemented | planned | planned | `v0.3.0` | mutating |
+
+All current discovery flags and activation gates are false. The v0.2 target is
+explicitly marked as having no runtime authority. In particular,
+`selection.resolve` and `data.query` are target-active governance requirements, not
+implemented or callable tools.
+
+## Runtime API and fail-closed rules
+
+The package exposes:
+
+- `listToolProfiles()` for a frozen copy of the canonical ordered list;
+- `getToolProfile(name)` for an exact-name lookup with a controlled unknown-profile
+  error;
+- `filterToolProfiles(filter)` for a closed metadata filter which preserves
+  canonical order; and
+- `listCurrentCallableTools()` for the set which passes every current ADR-0009
+  condition.
+
+The current callable result is an empty frozen array. The helper considers only
+`current` state and accepted runtime input, output and problem schema references;
+it never reads `v02Target`. `evidence.inspect` intentionally has no accepted
+runtime problem schema reference yet, although its transport-neutral application,
+request and result contracts exist.
+
+`controlledErrors` preserves the governance vocabulary from the research profile;
+it is not by itself a runtime error contract. Runtime error availability is
+declared separately by `runtimeSchemas.problem`, preventing a planned source field
+from being mistaken for an implemented transport guarantee.
+
+Registry construction clones caller data, rejects unknown or missing fields,
+wrong order, duplicate or substituted IDs, lifecycle contradictions, inappropriate
+mutability, incomplete schema state and target metadata presented as runtime
+authority. Returned documents, profiles and arrays are recursively frozen. Safe
+errors do not reflect rejected input.
+
+## Provenance and dependency boundary
+
+The source research remains byte-for-byte unchanged. The registry binds:
+
+- path `docs/research/2026-08-19/research-pack/data/tool-catalogue.json`;
+- SHA-256 `851f626bae4d63e8355ff9ca4021b56041ffa7e432d41f7f682c214151b5a8c3`;
+- Git blob `0514fba4ff4765c951c632f6a1c122fe02b1d178`; and
+- exact `/tools/0` to `/tools/11` source and research-schema pointers.
+
+Research pointers are provenance only and are never dereferenced as runtime
+schemas. The Python contract test compares every mirrored purpose, provider,
+access, policy, cost, error, cursor, provenance, fallback and threat field with the
+immutable source.
+
+The new package has no dependency. A root development-only workspace link makes
+the first-party component explicit in `pnpm-lock.yaml` and the dependency SBOM;
+the release-metadata test verifies its product version and exact npm package URL.
+
+## Non-activation and residual boundary
+
+No gateway source, activation array, provider adapter, execution operation, route,
+listener or deployment is changed. The registry never reads environment variables.
+Production activation remains solely in
+`apps/mcp-gateway/src/activation.ts`, whose tool and API arrays remain empty.
+
+This slice does not implement `selection.resolve`, `data.query` or any other
+planned operation. It does not complete provider, schema, policy, evidence,
+interoperability or fallback gates, and it does not authorise the mutating
+`workflow.execute` profile. A later activation change must supply its own reviewed
+contracts, threat evidence and lifecycle decision.
+
+## Verification
+
+Focused verification commands are:
+
+```bash
+pnpm --filter @gis-ai-go/tool-registry run typecheck
+pnpm --filter @gis-ai-go/tool-registry run test
+uv run --locked --cache-dir .uv-cache python -m unittest tests.contract.test_tool_registry
+pnpm run build:okf
+pnpm run validate:contracts
+pnpm run validate:versions
+uv run --locked --cache-dir .uv-cache python -m unittest tests.contract.test_release_metadata
+```
+
+The full repository gate remains required before integration. Activation,
+deployment, release, GitHub and live-provider checks are deliberately outside this
+candidate.

--- a/docs/threat-model/README.md
+++ b/docs/threat-model/README.md
@@ -55,3 +55,13 @@ production deployment.
 | Version, dimension or rights drift | Exact dataset, edition, version, native dimension order, source date, official URIs and OGL evidence are schema-locked. Unknown or changed rights must fail closed. | Source and rights need revalidation before activation and after provider change. |
 | Error and payload leakage | Closed safe error vocabulary; fixture tests reject hostile structures and prove raw exception details are not reflected. No live payload is committed. Accepted EXEC-202 supplies the generic safe-error and log boundary. | Provider-specific live response parsing and redaction must be implemented and tested in the later live-adapter slice. |
 | Partial provider suspension | Discovery and invocation lifecycle planes are independent and suspended by default. | Gateway registry and execution dispatch must enforce the same state after integration. |
+
+## TOOLS-205 non-activating registry scope
+
+| Research risk | Control in this slice | Residual boundary |
+| --- | --- | --- |
+| RK02 tool poisoning and RK24 model/tool hallucination | Closed schema and runtime validation require the exact 12 IDs and names in deterministic ADR-0009 order. Planned profiles cannot enter the current callable helper. | Future descriptions and implementation-specific schemas still need adversarial review before activation. |
+| RK03 confused deputy and RK08 policy bypass | Current implementation, lifecycle, discovery and seven assurance gates are separate from explicitly non-runtime `v02Target` metadata. All current gates are false and the callable set is empty. | The gateway remains the sole runtime authority; any later activation must enforce policy on discovery and invocation. |
+| RK11 licence/data exfiltration and RK30 operational drift | Every profile records provider dependencies, access tiers, policy attributes, controlled errors, provenance and fallback requirements. Mutating `workflow.execute` is explicitly deferred to `v0.3.0`. | Provider, entitlement and cross-tier enforcement are metadata only until their operation slices are implemented and tested. |
+| RK20 provenance spoofing and RK21 audit tampering | The profile binds the immutable research path, SHA-256, Git blob and per-tool JSON pointers; Python tests compare every mirrored research field. Runtime documents and helper results are recursively frozen. | The profile is unsigned repository data; release provenance and protected-main controls remain necessary. |
+| RK23 supply-chain compromise | The private package has no dependency and its identity is locked and included in the SBOM. It has no environment override or gateway import. | Existing Node.js, package-manager and CI supply-chain controls remain release gates. |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "pnpm run build:okf && pnpm --recursive --if-present run build",
     "typecheck": "pnpm --recursive --if-present run typecheck",
-    "test:typescript": "pnpm --filter @gis-ai-go/contracts run test && pnpm --filter @gis-ai-go/evidence run test && pnpm --filter @gis-ai-go/authority-context run test && pnpm --filter @gis-ai-go/policy-client run test && pnpm --filter @gis-ai-go/provider-adapter-sdk run test && pnpm --filter @gis-ai-go/mcp-gateway run test",
+    "test:typescript": "pnpm --filter @gis-ai-go/contracts run test && pnpm --filter @gis-ai-go/evidence run test && pnpm --filter @gis-ai-go/authority-context run test && pnpm --filter @gis-ai-go/policy-client run test && pnpm --filter @gis-ai-go/provider-adapter-sdk run test && pnpm --filter @gis-ai-go/tool-registry run test && pnpm --filter @gis-ai-go/mcp-gateway run test",
     "test:explorer": "pnpm --filter @gis-ai-go/public-explorer run test:unit",
     "test:browser": "pnpm run build:explorer && pnpm --filter @gis-ai-go/public-explorer run test:browser",
     "test:python": "uv run --locked --cache-dir .uv-cache python -m unittest discover -s tests -p 'test_*.py' && uv run --locked --cache-dir .uv-cache python -m unittest discover -s services/geo-execution/tests -p 'test_*.py'",
@@ -31,6 +31,7 @@
     "check": "pnpm run typecheck && pnpm run test && pnpm run test:browser && pnpm run validate:release-reproducibility && pnpm run validate:versions && pnpm run validate:contracts && pnpm run validate:links && pnpm run validate:secrets && pnpm run render:diagrams && pnpm run sbom"
   },
   "devDependencies": {
+    "@gis-ai-go/tool-registry": "workspace:*",
     "@types/node": "24.13.3",
     "@viz-js/viz": "3.29.0",
     "typescript": "7.0.2"

--- a/packages/tool-registry/README.md
+++ b/packages/tool-registry/README.md
@@ -1,0 +1,25 @@
+# Tool registry package boundary
+
+This private first-party package reads the checked-in
+[`tool-registry.v1.json`](../../profiles/tool-registry.v1.json) profile, validates
+its closed structure and lifecycle invariants, and exposes frozen list, get and
+filter helpers. It has no third-party or workspace runtime dependency.
+
+The registry contains exactly the 12 ADR-0009 canonical profiles. Profile
+existence is governance information, not a runtime availability claim. The
+`v02Target` field is explicitly non-runtime metadata and is never used by
+`listCurrentCallableTools`. A profile can appear in that helper only when its
+current implementation, lifecycle, discovery, release, policy, read-only,
+schema, threat, evidence, interoperability and fallback conditions all pass,
+including accepted input, output and problem schema references. The current
+result is an empty frozen array.
+
+`catalogue.search`, `catalogue.describe` and `evidence.inspect` are implemented
+but suspended. `selection.resolve` and `data.query` are required for the
+`v0.2.0` target but are not implemented. The other profiles remain planned;
+mutating `workflow.execute` is a `v0.3.0` target only.
+
+The package does not import the gateway, register a tool, inspect environment
+variables or provide an activation override. Production activation remains
+owned solely by `apps/mcp-gateway/src/activation.ts`, which this slice does not
+change.

--- a/packages/tool-registry/package.json
+++ b/packages/tool-registry/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@gis-ai-go/tool-registry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Closed non-activating governance profiles for the GIS AI GO tool surface",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json && node scripts/copy-profile.mjs",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "test": "pnpm run build && node --test dist/test/*.test.js"
+  }
+}

--- a/packages/tool-registry/scripts/copy-profile.mjs
+++ b/packages/tool-registry/scripts/copy-profile.mjs
@@ -1,0 +1,8 @@
+import { copyFile, mkdir } from "node:fs/promises";
+
+const source = new URL("../../../profiles/tool-registry.v1.json", import.meta.url);
+const destinationDirectory = new URL("../dist/profile/", import.meta.url);
+const destination = new URL("tool-registry.v1.json", destinationDirectory);
+
+await mkdir(destinationDirectory, { recursive: true });
+await copyFile(source, destination);

--- a/packages/tool-registry/src/index.ts
+++ b/packages/tool-registry/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./registry.js";
+export * from "./types.js";

--- a/packages/tool-registry/src/registry.ts
+++ b/packages/tool-registry/src/registry.ts
@@ -1,0 +1,756 @@
+import { readFileSync } from "node:fs";
+
+import {
+  ACTIVATION_REQUIREMENTS,
+  TOOL_PROFILE_IDS,
+  TOOL_PROFILE_NAMES,
+  V02_TARGET_ACTIVE_TOOL_NAMES,
+  type AcceptedRuntimeSchemaReference,
+  type ActivationGates,
+  type ImplementationState,
+  type LifecycleState,
+  type ReleaseTarget,
+  type RuntimeSchemaReference,
+  type ToolProfile,
+  type ToolProfileId,
+  type ToolProfileName,
+  type ToolRegistry,
+  type ToolRegistryDocument,
+  type ToolRegistryFilter,
+  type V02LifecycleState,
+} from "./types.js";
+
+export const TOOL_REGISTRY_ERROR_CODES = Object.freeze([
+  "INVALID_TOOL_REGISTRY",
+  "INVALID_TOOL_REGISTRY_FILTER",
+  "UNKNOWN_TOOL_PROFILE",
+] as const);
+
+export type ToolRegistryErrorCode = (typeof TOOL_REGISTRY_ERROR_CODES)[number];
+
+const SAFE_MESSAGES: Readonly<Record<ToolRegistryErrorCode, string>> = Object.freeze({
+  INVALID_TOOL_REGISTRY: "The tool registry failed closed validation.",
+  INVALID_TOOL_REGISTRY_FILTER: "The tool registry filter is invalid.",
+  UNKNOWN_TOOL_PROFILE: "The requested tool profile is not recognised.",
+});
+
+const RESEARCH_SHA256 =
+  "851f626bae4d63e8355ff9ca4021b56041ffa7e432d41f7f682c214151b5a8c3";
+const RESEARCH_GIT_BLOB = "0514fba4ff4765c951c632f6a1c122fe02b1d178";
+const TOOL_NAME_PATTERN = /^[a-z]+\.[a-z]+$/u;
+const ERROR_CODE_PATTERN = /^[A-Z][A-Z0-9_]*$/u;
+const RUNTIME_SCHEMA_PATTERN = /^schemas\/[a-z0-9-]+\.schema\.json$/u;
+const TOOL_POINTER_PATTERN = /^\/tools\/(?:[0-9]|1[01])$/u;
+
+const CURRENT_IMPLEMENTED_IDS = Object.freeze(["T01", "T02", "T11"] as const);
+
+const RELEASE_TARGET_BY_ID: Readonly<Record<ToolProfileId, ReleaseTarget>> = Object.freeze({
+  T01: "v0.2.0",
+  T02: "v0.2.0",
+  T03: "v0.2.0",
+  T04: "v0.2.0",
+  T05: "later-reviewed-release",
+  T06: "later-reviewed-release",
+  T07: "later-reviewed-release",
+  T08: "later-reviewed-release",
+  T09: "later-reviewed-release",
+  T10: "later-reviewed-release",
+  T11: "v0.2.0",
+  T12: "v0.3.0",
+});
+
+const RUNTIME_SCHEMA_REFS_BY_ID: Readonly<
+  Record<
+    ToolProfileId,
+    {
+      readonly input: string | null;
+      readonly output: string | null;
+      readonly problem: string | null;
+    }
+  >
+> = Object.freeze({
+  T01: {
+    input: "schemas/catalogue-search-request.schema.json",
+    output: "schemas/catalogue-result.schema.json",
+    problem: "schemas/catalogue-problem.schema.json",
+  },
+  T02: {
+    input: "schemas/catalogue-describe-request.schema.json",
+    output: "schemas/catalogue-result.schema.json",
+    problem: "schemas/catalogue-problem.schema.json",
+  },
+  T03: { input: null, output: null, problem: null },
+  T04: { input: null, output: null, problem: null },
+  T05: { input: null, output: null, problem: null },
+  T06: { input: null, output: null, problem: null },
+  T07: { input: null, output: null, problem: null },
+  T08: { input: null, output: null, problem: null },
+  T09: { input: null, output: null, problem: null },
+  T10: { input: null, output: null, problem: null },
+  T11: {
+    input: "schemas/evidence-inspect-request.schema.json",
+    output: "schemas/evidence-inspect-result.schema.json",
+    problem: null,
+  },
+  T12: { input: null, output: null, problem: null },
+});
+
+const PROFILE_KEYS = Object.freeze([
+  "id",
+  "name",
+  "namespace",
+  "purpose",
+  "readOnly",
+  "mutating",
+  "releaseTarget",
+  "current",
+  "v02Target",
+  "runtimeSchemas",
+  "support",
+  "accessTiers",
+  "policyAttributes",
+  "costPerformance",
+  "controlledErrors",
+  "cursor",
+  "crs",
+  "provenance",
+  "fallback",
+  "threats",
+  "source",
+] as const);
+
+const FILTER_KEYS = Object.freeze([
+  "ids",
+  "names",
+  "implementationState",
+  "lifecycleState",
+  "v02LifecycleState",
+  "releaseTarget",
+  "readOnly",
+  "mutating",
+  "discoveryEligible",
+] as const);
+
+export class ToolRegistryFault extends Error {
+  public readonly code: ToolRegistryErrorCode;
+
+  public constructor(code: ToolRegistryErrorCode) {
+    super(SAFE_MESSAGES[code]);
+    this.name = "ToolRegistryFault";
+    this.code = code;
+  }
+}
+
+function invalidRegistry(): never {
+  throw new ToolRegistryFault("INVALID_TOOL_REGISTRY");
+}
+
+function invalidFilter(): never {
+  throw new ToolRegistryFault("INVALID_TOOL_REGISTRY_FILTER");
+}
+
+function assertPassiveJsonTree(value: unknown, seen = new WeakSet<object>()): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("non-finite registry number");
+    return;
+  }
+  if (typeof value !== "object") throw new TypeError("non-JSON registry value");
+  if (seen.has(value)) throw new TypeError("shared or cyclic registry value");
+  seen.add(value);
+
+  const array = Array.isArray(value);
+  const prototype = Object.getPrototypeOf(value);
+  if (
+    (array && prototype !== Array.prototype) ||
+    (!array && prototype !== Object.prototype && prototype !== null)
+  ) {
+    throw new TypeError("non-plain registry object");
+  }
+
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key === "symbol")) {
+    throw new TypeError("symbol registry key");
+  }
+  if (array) {
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    if (
+      lengthDescriptor === undefined ||
+      !("value" in lengthDescriptor) ||
+      !Number.isSafeInteger(lengthDescriptor.value) ||
+      lengthDescriptor.value < 0 ||
+      lengthDescriptor.value > 64
+    ) {
+      throw new TypeError("invalid registry array length");
+    }
+    const expected = new Set<string>(["length"]);
+    for (let index = 0; index < lengthDescriptor.value; index += 1) {
+      expected.add(String(index));
+    }
+    if (keys.length !== expected.size) {
+      throw new TypeError("sparse or extended registry array");
+    }
+    for (const key of keys) {
+      if (typeof key !== "string" || !expected.has(key)) {
+        throw new TypeError("extended registry array");
+      }
+    }
+  }
+
+  for (const key of keys) {
+    if (array && key === "length") continue;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (
+      descriptor === undefined ||
+      !("value" in descriptor) ||
+      !descriptor.enumerable
+    ) {
+      throw new TypeError("active or hidden registry property");
+    }
+    assertPassiveJsonTree(descriptor.value, seen);
+  }
+}
+
+function cloneInput(value: unknown, code: "registry" | "filter"): unknown {
+  try {
+    assertPassiveJsonTree(value);
+    return structuredClone(value);
+  } catch {
+    return code === "registry" ? invalidRegistry() : invalidFilter();
+  }
+}
+
+function asRecord(value: unknown, code: "registry" | "filter" = "registry"):
+  Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return code === "registry" ? invalidRegistry() : invalidFilter();
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return code === "registry" ? invalidRegistry() : invalidFilter();
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertExactKeys(
+  record: Readonly<Record<string, unknown>>,
+  expected: readonly string[],
+  code: "registry" | "filter" = "registry",
+): void {
+  const actual = Object.keys(record).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    if (code === "registry") invalidRegistry();
+    invalidFilter();
+  }
+}
+
+function assertString(value: unknown, minimum: number, maximum: number): asserts value is string {
+  if (typeof value !== "string" || value.length < minimum || value.length > maximum) {
+    invalidRegistry();
+  }
+}
+
+function assertBoolean(value: unknown): asserts value is boolean {
+  if (typeof value !== "boolean") invalidRegistry();
+}
+
+function assertEnum<T extends string>(value: unknown, allowed: readonly T[]): asserts value is T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) invalidRegistry();
+}
+
+function validateStringArray(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+  pattern?: RegExp,
+): readonly string[] {
+  if (!Array.isArray(value) || value.length < minimum || value.length > maximum) {
+    invalidRegistry();
+  }
+  const observed = value as unknown[];
+  for (const item of observed) {
+    assertString(item, 1, 256);
+    if (pattern !== undefined && !pattern.test(item)) invalidRegistry();
+  }
+  if (new Set(observed).size !== observed.length) invalidRegistry();
+  return observed as readonly string[];
+}
+
+function assertExactSequence(value: unknown, expected: readonly string[]): void {
+  if (
+    !Array.isArray(value) ||
+    value.length !== expected.length ||
+    value.some((item, index) => item !== expected[index])
+  ) {
+    invalidRegistry();
+  }
+}
+
+function validateActivationGates(value: unknown): ActivationGates {
+  const record = asRecord(value);
+  assertExactKeys(record, [
+    "releaseEnabled",
+    "policy",
+    "schema",
+    "threat",
+    "evidence",
+    "interoperability",
+    "fallback",
+  ]);
+  for (const field of Object.keys(record)) assertBoolean(record[field]);
+  return record as unknown as ActivationGates;
+}
+
+function validateRuntimeSchemaReference(value: unknown): RuntimeSchemaReference {
+  const record = asRecord(value);
+  assertExactKeys(record, ["state", "ref"]);
+  assertEnum(record.state, ["accepted", "missing"] as const);
+  if (record.state === "accepted") {
+    assertString(record.ref, 1, 128);
+    if (!RUNTIME_SCHEMA_PATTERN.test(record.ref)) invalidRegistry();
+    return record as unknown as AcceptedRuntimeSchemaReference;
+  }
+  if (record.ref !== null) invalidRegistry();
+  return record as unknown as RuntimeSchemaReference;
+}
+
+function validateProfile(value: unknown, index: number): ToolProfile {
+  const profile = asRecord(value);
+  assertExactKeys(profile, PROFILE_KEYS);
+
+  const expectedId = TOOL_PROFILE_IDS[index];
+  const expectedName = TOOL_PROFILE_NAMES[index];
+  if (expectedId === undefined || expectedName === undefined) invalidRegistry();
+  if (profile.id !== expectedId || profile.name !== expectedName) invalidRegistry();
+
+  assertString(profile.namespace, 1, 32);
+  assertString(profile.purpose, 1, 256);
+  assertBoolean(profile.readOnly);
+  assertBoolean(profile.mutating);
+  assertEnum(profile.releaseTarget, [
+    "v0.2.0",
+    "later-reviewed-release",
+    "v0.3.0",
+  ] as const);
+  if (
+    !TOOL_NAME_PATTERN.test(expectedName) ||
+    profile.namespace !== expectedName.split(".")[0] ||
+    profile.readOnly === profile.mutating ||
+    profile.releaseTarget !== RELEASE_TARGET_BY_ID[expectedId]
+  ) {
+    invalidRegistry();
+  }
+
+  const current = asRecord(profile.current);
+  assertExactKeys(current, [
+    "implementationState",
+    "lifecycleState",
+    "discoveryEligible",
+    "activationGates",
+  ]);
+  assertEnum(current.implementationState, ["implemented", "not-implemented"] as const);
+  assertEnum(current.lifecycleState, ["active", "planned", "retired", "suspended"] as const);
+  assertBoolean(current.discoveryEligible);
+  const gates = validateActivationGates(current.activationGates);
+
+  const implemented = CURRENT_IMPLEMENTED_IDS.includes(expectedId as never);
+  if (
+    current.implementationState !== (implemented ? "implemented" : "not-implemented") ||
+    current.lifecycleState !== (implemented ? "suspended" : "planned") ||
+    current.discoveryEligible ||
+    Object.values(gates).some(Boolean)
+  ) {
+    invalidRegistry();
+  }
+
+  const target = asRecord(profile.v02Target);
+  assertExactKeys(target, ["lifecycleState", "discoveryIntended", "runtimeAuthority"]);
+  assertEnum(target.lifecycleState, ["active", "planned"] as const);
+  assertBoolean(target.discoveryIntended);
+  if (target.runtimeAuthority !== false) invalidRegistry();
+  const targetActive = V02_TARGET_ACTIVE_TOOL_NAMES.includes(expectedName as never);
+  if (
+    target.lifecycleState !== (targetActive ? "active" : "planned") ||
+    target.discoveryIntended !== targetActive
+  ) {
+    invalidRegistry();
+  }
+
+  const runtimeSchemas = asRecord(profile.runtimeSchemas);
+  assertExactKeys(runtimeSchemas, ["input", "output", "problem"]);
+  const inputSchema = validateRuntimeSchemaReference(runtimeSchemas.input);
+  const outputSchema = validateRuntimeSchemaReference(runtimeSchemas.output);
+  const problemSchema = validateRuntimeSchemaReference(runtimeSchemas.problem);
+  const expectedSchemas = RUNTIME_SCHEMA_REFS_BY_ID[expectedId];
+  if (
+    inputSchema.ref !== expectedSchemas.input ||
+    outputSchema.ref !== expectedSchemas.output ||
+    problemSchema.ref !== expectedSchemas.problem
+  ) {
+    invalidRegistry();
+  }
+  if (implemented) {
+    if (inputSchema.state !== "accepted" || outputSchema.state !== "accepted") {
+      invalidRegistry();
+    }
+    if (
+      expectedId === "T11"
+        ? problemSchema.state !== "missing"
+        : problemSchema.state !== "accepted"
+    ) {
+      invalidRegistry();
+    }
+  } else if (
+    inputSchema.state !== "missing" ||
+    outputSchema.state !== "missing" ||
+    problemSchema.state !== "missing"
+  ) {
+    invalidRegistry();
+  }
+
+  const support = asRecord(profile.support);
+  assertExactKeys(support, [
+    "operation",
+    "operationState",
+    "providerState",
+    "providerDependencies",
+  ]);
+  if (support.operation !== expectedName) invalidRegistry();
+  assertEnum(support.operationState, ["implemented-inactive", "not-implemented"] as const);
+  assertEnum(support.providerState, ["candidate-partial", "planned"] as const);
+  validateStringArray(support.providerDependencies, 1, 32);
+  if (
+    support.operationState !== (implemented ? "implemented-inactive" : "not-implemented") ||
+    support.providerState !== (implemented ? "candidate-partial" : "planned")
+  ) {
+    invalidRegistry();
+  }
+
+  validateStringArray(profile.accessTiers, 1, 32);
+  validateStringArray(profile.policyAttributes, 1, 32);
+  assertString(profile.costPerformance, 1, 256);
+  validateStringArray(profile.controlledErrors, 1, 16, ERROR_CODE_PATTERN);
+
+  const cursor = asRecord(profile.cursor);
+  assertExactKeys(cursor, ["state", "maxLength", "artefactFallback", "researchStatement"]);
+  assertEnum(cursor.state, ["none", "optional", "not-implemented"] as const);
+  assertEnum(cursor.artefactFallback, ["implemented", "not-implemented"] as const);
+  assertString(cursor.researchStatement, 1, 256);
+  const maxLength = cursor.maxLength;
+  if (
+    maxLength !== null &&
+    (typeof maxLength !== "number" ||
+      !Number.isSafeInteger(maxLength) ||
+      maxLength < 1 ||
+      maxLength > 4_096)
+  ) {
+    invalidRegistry();
+  }
+  if ((cursor.state === "optional") !== (maxLength !== null)) invalidRegistry();
+  if (cursor.artefactFallback !== "not-implemented") invalidRegistry();
+
+  const crs = asRecord(profile.crs);
+  assertExactKeys(crs, ["state", "requirements"]);
+  assertEnum(crs.state, ["not-applicable", "required-before-implementation"] as const);
+  const crsRequirements = validateStringArray(crs.requirements, 0, 4);
+  if ((crs.state === "not-applicable") !== (crsRequirements.length === 0)) {
+    invalidRegistry();
+  }
+
+  const provenance = asRecord(profile.provenance);
+  assertExactKeys(provenance, ["requiredFields"]);
+  validateStringArray(provenance.requiredFields, 1, 32);
+
+  const fallback = asRecord(profile.fallback);
+  assertExactKeys(fallback, ["state", "behaviour"]);
+  assertEnum(fallback.state, ["implemented", "partial", "not-implemented"] as const);
+  assertString(fallback.behaviour, 1, 256);
+
+  const threats = asRecord(profile.threats);
+  assertExactKeys(threats, ["risks"]);
+  validateStringArray(threats.risks, 1, 32);
+
+  const source = asRecord(profile.source);
+  assertExactKeys(source, [
+    "researchId",
+    "pointer",
+    "inputSchemaPointer",
+    "outputSchemaPointer",
+  ]);
+  const expectedPointer = `/tools/${index}`;
+  if (
+    source.researchId !== expectedId ||
+    source.pointer !== expectedPointer ||
+    source.inputSchemaPointer !== `${expectedPointer}/input_schema` ||
+    source.outputSchemaPointer !== `${expectedPointer}/output_schema` ||
+    !TOOL_POINTER_PATTERN.test(expectedPointer)
+  ) {
+    invalidRegistry();
+  }
+
+  if (
+    (expectedId === "T12" && (!profile.mutating || profile.readOnly)) ||
+    (expectedId !== "T12" && (profile.mutating || !profile.readOnly))
+  ) {
+    invalidRegistry();
+  }
+  return profile as unknown as ToolProfile;
+}
+
+function validateDocument(value: unknown): ToolRegistryDocument {
+  const document = asRecord(value);
+  assertExactKeys(document, [
+    "schema",
+    "version",
+    "canonicalOrder",
+    "activationRequirements",
+    "runtimeAuthority",
+    "source",
+    "tools",
+  ]);
+  if (document.schema !== "gis-ai-go.tool-registry.v1" || document.version !== "1.0.0") {
+    invalidRegistry();
+  }
+  assertExactSequence(document.canonicalOrder, TOOL_PROFILE_NAMES);
+  assertExactSequence(document.activationRequirements, ACTIVATION_REQUIREMENTS);
+
+  const runtimeAuthority = asRecord(document.runtimeAuthority);
+  assertExactKeys(runtimeAuthority, [
+    "source",
+    "registryCanActivate",
+    "environmentOverride",
+    "productionRegistration",
+  ]);
+  if (
+    runtimeAuthority.source !== "apps/mcp-gateway/src/activation.ts" ||
+    runtimeAuthority.registryCanActivate !== false ||
+    runtimeAuthority.environmentOverride !== false ||
+    runtimeAuthority.productionRegistration !== false
+  ) {
+    invalidRegistry();
+  }
+
+  const source = asRecord(document.source);
+  assertExactKeys(source, ["decision", "research"]);
+  const decision = asRecord(source.decision);
+  assertExactKeys(decision, ["path", "status"]);
+  if (
+    decision.path !== "docs/decisions/ADR-0009-read-only-mcp-tool-lifecycle.md" ||
+    decision.status !== "accepted"
+  ) {
+    invalidRegistry();
+  }
+  const research = asRecord(source.research);
+  assertExactKeys(research, [
+    "path",
+    "retrieved",
+    "sha256",
+    "gitBlob",
+    "immutable",
+    "records",
+  ]);
+  if (
+    research.path !== "docs/research/2026-08-19/research-pack/data/tool-catalogue.json" ||
+    research.retrieved !== "2026-08-19" ||
+    research.sha256 !== RESEARCH_SHA256 ||
+    research.gitBlob !== RESEARCH_GIT_BLOB ||
+    research.immutable !== true
+  ) {
+    invalidRegistry();
+  }
+  assertExactSequence(research.records, TOOL_PROFILE_IDS);
+
+  if (!Array.isArray(document.tools) || document.tools.length !== TOOL_PROFILE_NAMES.length) {
+    invalidRegistry();
+  }
+  const profiles = document.tools.map((profile, index) => validateProfile(profile, index));
+  if (
+    new Set(profiles.map(({ id }) => id)).size !== profiles.length ||
+    new Set(profiles.map(({ name }) => name)).size !== profiles.length
+  ) {
+    invalidRegistry();
+  }
+  return document as unknown as ToolRegistryDocument;
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (value === null || typeof value !== "object") return value;
+  const object = value as object;
+  if (seen.has(object)) return value;
+  seen.add(object);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child, seen);
+  }
+  return Object.freeze(value);
+}
+
+function isAccepted(reference: RuntimeSchemaReference):
+  reference is AcceptedRuntimeSchemaReference {
+  return reference.state === "accepted";
+}
+
+function isCurrentCallable(profile: ToolProfile): boolean {
+  const gates = profile.current.activationGates;
+  return (
+    profile.current.implementationState === "implemented" &&
+    profile.current.lifecycleState === "active" &&
+    profile.current.discoveryEligible &&
+    profile.readOnly &&
+    !profile.mutating &&
+    gates.releaseEnabled &&
+    gates.policy &&
+    gates.schema &&
+    gates.threat &&
+    gates.evidence &&
+    gates.interoperability &&
+    gates.fallback &&
+    isAccepted(profile.runtimeSchemas.input) &&
+    isAccepted(profile.runtimeSchemas.output) &&
+    isAccepted(profile.runtimeSchemas.problem)
+  );
+}
+
+function validateFilter(value: ToolRegistryFilter): ToolRegistryFilter {
+  const snapshot = asRecord(cloneInput(value, "filter"), "filter");
+  const actualKeys = Object.keys(snapshot);
+  if (actualKeys.some((key) => !FILTER_KEYS.includes(key as never))) invalidFilter();
+
+  const validateKnownList = <T extends string>(
+    candidate: unknown,
+    allowed: readonly T[],
+  ): readonly T[] => {
+    if (
+      !Array.isArray(candidate) ||
+      candidate.length < 1 ||
+      candidate.length > allowed.length ||
+      candidate.some((item) => typeof item !== "string" || !allowed.includes(item as T)) ||
+      new Set(candidate).size !== candidate.length
+    ) {
+      invalidFilter();
+    }
+    return candidate as readonly T[];
+  };
+
+  if (Object.hasOwn(snapshot, "ids")) validateKnownList(snapshot.ids, TOOL_PROFILE_IDS);
+  if (Object.hasOwn(snapshot, "names")) validateKnownList(snapshot.names, TOOL_PROFILE_NAMES);
+  if (
+    Object.hasOwn(snapshot, "implementationState") &&
+    !(["implemented", "not-implemented"] as const).includes(
+      snapshot.implementationState as ImplementationState,
+    )
+  ) {
+    invalidFilter();
+  }
+  if (
+    Object.hasOwn(snapshot, "lifecycleState") &&
+    !(["active", "planned", "retired", "suspended"] as const).includes(
+      snapshot.lifecycleState as LifecycleState,
+    )
+  ) {
+    invalidFilter();
+  }
+  if (
+    Object.hasOwn(snapshot, "v02LifecycleState") &&
+    !(["active", "planned"] as const).includes(
+      snapshot.v02LifecycleState as V02LifecycleState,
+    )
+  ) {
+    invalidFilter();
+  }
+  if (
+    Object.hasOwn(snapshot, "releaseTarget") &&
+    !(["v0.2.0", "later-reviewed-release", "v0.3.0"] as const).includes(
+      snapshot.releaseTarget as ReleaseTarget,
+    )
+  ) {
+    invalidFilter();
+  }
+  for (const field of ["readOnly", "mutating", "discoveryEligible"] as const) {
+    if (Object.hasOwn(snapshot, field) && typeof snapshot[field] !== "boolean") invalidFilter();
+  }
+  return deepFreeze(snapshot) as unknown as ToolRegistryFilter;
+}
+
+function matchesFilter(profile: ToolProfile, filter: ToolRegistryFilter): boolean {
+  return (
+    (filter.ids === undefined || filter.ids.includes(profile.id)) &&
+    (filter.names === undefined || filter.names.includes(profile.name)) &&
+    (filter.implementationState === undefined ||
+      profile.current.implementationState === filter.implementationState) &&
+    (filter.lifecycleState === undefined ||
+      profile.current.lifecycleState === filter.lifecycleState) &&
+    (filter.v02LifecycleState === undefined ||
+      profile.v02Target.lifecycleState === filter.v02LifecycleState) &&
+    (filter.releaseTarget === undefined || profile.releaseTarget === filter.releaseTarget) &&
+    (filter.readOnly === undefined || profile.readOnly === filter.readOnly) &&
+    (filter.mutating === undefined || profile.mutating === filter.mutating) &&
+    (filter.discoveryEligible === undefined ||
+      profile.current.discoveryEligible === filter.discoveryEligible)
+  );
+}
+
+/** Build an immutable view after closed structural and lifecycle validation. */
+export function createToolRegistry(value: unknown): ToolRegistry {
+  const document = deepFreeze(validateDocument(cloneInput(value, "registry")));
+  const byName = new Map<ToolProfileName, ToolProfile>(
+    document.tools.map((profile) => [profile.name, profile]),
+  );
+  const list = (): readonly ToolProfile[] => Object.freeze([...document.tools]);
+  const filter = (criteria: ToolRegistryFilter): readonly ToolProfile[] => {
+    const validated = validateFilter(criteria);
+    return Object.freeze(document.tools.filter((profile) => matchesFilter(profile, validated)));
+  };
+  const registry: ToolRegistry = {
+    document,
+    list,
+    get: (name: string): ToolProfile => {
+      const profile = byName.get(name as ToolProfileName);
+      if (profile === undefined) throw new ToolRegistryFault("UNKNOWN_TOOL_PROFILE");
+      return profile;
+    },
+    filter,
+    listCurrentCallable: (): readonly ToolProfile[] =>
+      Object.freeze(document.tools.filter(isCurrentCallable)),
+  };
+  return Object.freeze(registry);
+}
+
+function loadBundledRegistry(): unknown {
+  try {
+    const path = new URL("../profile/tool-registry.v1.json", import.meta.url);
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return invalidRegistry();
+  }
+}
+
+export const CANONICAL_TOOL_REGISTRY: ToolRegistry = createToolRegistry(loadBundledRegistry());
+export const TOOL_REGISTRY_DOCUMENT: ToolRegistryDocument = CANONICAL_TOOL_REGISTRY.document;
+
+/** Return all 12 profiles in ADR-0009 order. Profiles and the returned array are frozen. */
+export function listToolProfiles(): readonly ToolProfile[] {
+  return CANONICAL_TOOL_REGISTRY.list();
+}
+
+/** Return one frozen profile or a controlled `UNKNOWN_TOOL_PROFILE` failure. */
+export function getToolProfile(name: string): ToolProfile {
+  return CANONICAL_TOOL_REGISTRY.get(name);
+}
+
+/** Apply a closed metadata filter while retaining canonical order. */
+export function filterToolProfiles(filter: ToolRegistryFilter): readonly ToolProfile[] {
+  return CANONICAL_TOOL_REGISTRY.filter(filter);
+}
+
+/**
+ * Return profiles that satisfy every current activation gate and have complete
+ * accepted runtime schema references. The candidate deliberately returns none.
+ * `v02Target` is never consulted by this helper.
+ */
+export function listCurrentCallableTools(): readonly ToolProfile[] {
+  return CANONICAL_TOOL_REGISTRY.listCurrentCallable();
+}

--- a/packages/tool-registry/src/types.ts
+++ b/packages/tool-registry/src/types.ts
@@ -1,0 +1,217 @@
+export const TOOL_PROFILE_IDS = Object.freeze([
+  "T01",
+  "T02",
+  "T03",
+  "T04",
+  "T05",
+  "T06",
+  "T07",
+  "T08",
+  "T09",
+  "T10",
+  "T11",
+  "T12",
+] as const);
+
+export const TOOL_PROFILE_NAMES = Object.freeze([
+  "catalogue.search",
+  "catalogue.describe",
+  "selection.resolve",
+  "data.query",
+  "spatial.locate",
+  "spatial.analyse",
+  "statistics.compare",
+  "route.plan",
+  "map.render",
+  "artefact.export",
+  "evidence.inspect",
+  "workflow.execute",
+] as const);
+
+export const V02_TARGET_ACTIVE_TOOL_NAMES = Object.freeze([
+  "catalogue.search",
+  "catalogue.describe",
+  "selection.resolve",
+  "data.query",
+  "evidence.inspect",
+] as const);
+
+export const ACTIVATION_REQUIREMENTS = Object.freeze([
+  "implementation",
+  "release",
+  "policy",
+  "read-only",
+  "schema",
+  "threat",
+  "evidence",
+  "interoperability",
+  "fallback",
+] as const);
+
+export type ToolProfileId = (typeof TOOL_PROFILE_IDS)[number];
+export type ToolProfileName = (typeof TOOL_PROFILE_NAMES)[number];
+export type V02TargetActiveToolName = (typeof V02_TARGET_ACTIVE_TOOL_NAMES)[number];
+export type ActivationRequirement = (typeof ACTIVATION_REQUIREMENTS)[number];
+
+export type ImplementationState = "implemented" | "not-implemented";
+export type LifecycleState = "active" | "planned" | "retired" | "suspended";
+export type V02LifecycleState = "active" | "planned";
+export type ReleaseTarget = "v0.2.0" | "later-reviewed-release" | "v0.3.0";
+
+export interface ActivationGates {
+  readonly releaseEnabled: boolean;
+  readonly policy: boolean;
+  readonly schema: boolean;
+  readonly threat: boolean;
+  readonly evidence: boolean;
+  readonly interoperability: boolean;
+  readonly fallback: boolean;
+}
+
+export interface CurrentToolState {
+  readonly implementationState: ImplementationState;
+  readonly lifecycleState: LifecycleState;
+  readonly discoveryEligible: boolean;
+  readonly activationGates: ActivationGates;
+}
+
+export interface V02TargetState {
+  readonly lifecycleState: V02LifecycleState;
+  readonly discoveryIntended: boolean;
+  /** Target lifecycle data is governance metadata and has no runtime authority. */
+  readonly runtimeAuthority: false;
+}
+
+export interface AcceptedRuntimeSchemaReference {
+  readonly state: "accepted";
+  readonly ref: string;
+}
+
+export interface MissingRuntimeSchemaReference {
+  readonly state: "missing";
+  readonly ref: null;
+}
+
+export type RuntimeSchemaReference =
+  | AcceptedRuntimeSchemaReference
+  | MissingRuntimeSchemaReference;
+
+export interface RuntimeSchemaReferences {
+  readonly input: RuntimeSchemaReference;
+  readonly output: RuntimeSchemaReference;
+  readonly problem: RuntimeSchemaReference;
+}
+
+export interface ToolSupport {
+  readonly operation: ToolProfileName;
+  readonly operationState: "implemented-inactive" | "not-implemented";
+  readonly providerState: "candidate-partial" | "planned";
+  readonly providerDependencies: readonly string[];
+}
+
+export interface CursorMetadata {
+  readonly state: "none" | "optional" | "not-implemented";
+  readonly maxLength: number | null;
+  readonly artefactFallback: "implemented" | "not-implemented";
+  readonly researchStatement: string;
+}
+
+export interface CrsMetadata {
+  readonly state: "not-applicable" | "required-before-implementation";
+  readonly requirements: readonly string[];
+}
+
+export interface ProvenanceMetadata {
+  readonly requiredFields: readonly string[];
+}
+
+export interface FallbackMetadata {
+  readonly state: "implemented" | "partial" | "not-implemented";
+  readonly behaviour: string;
+}
+
+export interface ThreatMetadata {
+  readonly risks: readonly string[];
+}
+
+export interface ToolSource {
+  readonly researchId: ToolProfileId;
+  readonly pointer: string;
+  readonly inputSchemaPointer: string;
+  readonly outputSchemaPointer: string;
+}
+
+export interface ToolProfile {
+  readonly id: ToolProfileId;
+  readonly name: ToolProfileName;
+  readonly namespace: string;
+  readonly purpose: string;
+  readonly readOnly: boolean;
+  readonly mutating: boolean;
+  readonly releaseTarget: ReleaseTarget;
+  readonly current: CurrentToolState;
+  readonly v02Target: V02TargetState;
+  readonly runtimeSchemas: RuntimeSchemaReferences;
+  readonly support: ToolSupport;
+  readonly accessTiers: readonly string[];
+  readonly policyAttributes: readonly string[];
+  readonly costPerformance: string;
+  /** Research-profile vocabulary; runtime availability is `runtimeSchemas.problem`. */
+  readonly controlledErrors: readonly string[];
+  readonly cursor: CursorMetadata;
+  readonly crs: CrsMetadata;
+  readonly provenance: ProvenanceMetadata;
+  readonly fallback: FallbackMetadata;
+  readonly threats: ThreatMetadata;
+  readonly source: ToolSource;
+}
+
+export interface ToolRegistrySource {
+  readonly decision: {
+    readonly path: "docs/decisions/ADR-0009-read-only-mcp-tool-lifecycle.md";
+    readonly status: "accepted";
+  };
+  readonly research: {
+    readonly path: "docs/research/2026-08-19/research-pack/data/tool-catalogue.json";
+    readonly retrieved: "2026-08-19";
+    readonly sha256: string;
+    readonly gitBlob: string;
+    readonly immutable: true;
+    readonly records: readonly ToolProfileId[];
+  };
+}
+
+export interface ToolRegistryDocument {
+  readonly schema: "gis-ai-go.tool-registry.v1";
+  readonly version: "1.0.0";
+  readonly canonicalOrder: readonly ToolProfileName[];
+  readonly activationRequirements: readonly ActivationRequirement[];
+  readonly runtimeAuthority: {
+    readonly source: "apps/mcp-gateway/src/activation.ts";
+    readonly registryCanActivate: false;
+    readonly environmentOverride: false;
+    readonly productionRegistration: boolean;
+  };
+  readonly source: ToolRegistrySource;
+  readonly tools: readonly ToolProfile[];
+}
+
+export interface ToolRegistryFilter {
+  readonly ids?: readonly ToolProfileId[];
+  readonly names?: readonly ToolProfileName[];
+  readonly implementationState?: ImplementationState;
+  readonly lifecycleState?: LifecycleState;
+  readonly v02LifecycleState?: V02LifecycleState;
+  readonly releaseTarget?: ReleaseTarget;
+  readonly readOnly?: boolean;
+  readonly mutating?: boolean;
+  readonly discoveryEligible?: boolean;
+}
+
+export interface ToolRegistry {
+  readonly document: ToolRegistryDocument;
+  list(): readonly ToolProfile[];
+  get(name: string): ToolProfile;
+  filter(filter: ToolRegistryFilter): readonly ToolProfile[];
+  listCurrentCallable(): readonly ToolProfile[];
+}

--- a/packages/tool-registry/test/tool-registry.test.ts
+++ b/packages/tool-registry/test/tool-registry.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  TOOL_PROFILE_IDS,
+  TOOL_PROFILE_NAMES,
+  TOOL_REGISTRY_DOCUMENT,
+  ToolRegistryFault,
+  V02_TARGET_ACTIVE_TOOL_NAMES,
+  createToolRegistry,
+  filterToolProfiles,
+  getToolProfile,
+  listCurrentCallableTools,
+  listToolProfiles,
+} from "../src/index.js";
+
+function profileRecord(): Record<string, unknown> {
+  const url = new URL("../../../../profiles/tool-registry.v1.json", import.meta.url);
+  return JSON.parse(readFileSync(url, "utf8")) as Record<string, unknown>;
+}
+
+function assertRecursivelyFrozen(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  assert.equal(Object.isFrozen(value), true);
+  for (const child of Object.values(value)) assertRecursivelyFrozen(child);
+}
+
+function expectInvalidRegistry(value: unknown): void {
+  assert.throws(
+    () => createToolRegistry(value),
+    (error: unknown) =>
+      error instanceof ToolRegistryFault &&
+      error.code === "INVALID_TOOL_REGISTRY" &&
+      error.message === "The tool registry failed closed validation.",
+  );
+}
+
+test("loads exactly 12 deterministic frozen profiles from the canonical data", () => {
+  const first = listToolProfiles();
+  const second = listToolProfiles();
+
+  assert.notEqual(first, second);
+  assert.deepEqual(first.map(({ id }) => id), TOOL_PROFILE_IDS);
+  assert.deepEqual(first.map(({ name }) => name), TOOL_PROFILE_NAMES);
+  assert.deepEqual(TOOL_REGISTRY_DOCUMENT, profileRecord());
+  assertRecursivelyFrozen(TOOL_REGISTRY_DOCUMENT);
+  assertRecursivelyFrozen(first);
+
+  assert.deepEqual(
+    first
+      .filter(({ current }) => current.implementationState === "implemented")
+      .map(({ name }) => name),
+    ["catalogue.search", "catalogue.describe", "evidence.inspect"],
+  );
+  assert.deepEqual(
+    first
+      .filter(({ v02Target }) => v02Target.lifecycleState === "active")
+      .map(({ name }) => name),
+    V02_TARGET_ACTIVE_TOOL_NAMES,
+  );
+  assert.equal(getToolProfile("workflow.execute").mutating, true);
+  assert.equal(getToolProfile("workflow.execute").releaseTarget, "v0.3.0");
+});
+
+test("keeps target lifecycle metadata separate from an empty current callable set", () => {
+  const target = filterToolProfiles({ v02LifecycleState: "active" });
+  assert.deepEqual(target.map(({ name }) => name), V02_TARGET_ACTIVE_TOOL_NAMES);
+  assert.equal(getToolProfile("selection.resolve").current.implementationState, "not-implemented");
+  assert.equal(getToolProfile("data.query").current.implementationState, "not-implemented");
+  assert.deepEqual(listCurrentCallableTools(), []);
+  assert.equal(Object.isFrozen(listCurrentCallableTools()), true);
+
+  const planned = filterToolProfiles({ implementationState: "not-implemented" });
+  assert.equal(planned.length, 9);
+  assert.equal(planned.some(({ current }) => current.discoveryEligible), false);
+  assert.equal(
+    planned.some(({ name }) => listCurrentCallableTools().some((tool) => tool.name === name)),
+    false,
+  );
+});
+
+test("provides closed deterministic get and filter helpers", () => {
+  assert.deepEqual(
+    filterToolProfiles({ readOnly: true, releaseTarget: "v0.2.0" }).map(({ name }) => name),
+    [
+      "catalogue.search",
+      "catalogue.describe",
+      "selection.resolve",
+      "data.query",
+      "evidence.inspect",
+    ],
+  );
+  assert.deepEqual(
+    filterToolProfiles({ ids: ["T11", "T02"] }).map(({ id }) => id),
+    ["T02", "T11"],
+  );
+  assert.throws(
+    () => getToolProfile("catalogue.unknown"),
+    (error: unknown) =>
+      error instanceof ToolRegistryFault && error.code === "UNKNOWN_TOOL_PROFILE",
+  );
+  assert.throws(
+    () => filterToolProfiles({ unexpected: true } as never),
+    (error: unknown) =>
+      error instanceof ToolRegistryFault && error.code === "INVALID_TOOL_REGISTRY_FILTER",
+  );
+  assert.throws(
+    () => filterToolProfiles({ names: ["catalogue.unknown"] as never }),
+    (error: unknown) =>
+      error instanceof ToolRegistryFault && error.code === "INVALID_TOOL_REGISTRY_FILTER",
+  );
+  assert.throws(
+    () => filterToolProfiles({ ids: ["T01", "T01"] }),
+    (error: unknown) =>
+      error instanceof ToolRegistryFault && error.code === "INVALID_TOOL_REGISTRY_FILTER",
+  );
+});
+
+test("rejects duplicate IDs, reordered profiles and unknown fields", () => {
+  const duplicate = structuredClone(profileRecord()) as {
+    tools: { id: string }[];
+  };
+  duplicate.tools[1]!.id = duplicate.tools[0]!.id;
+  expectInvalidRegistry(duplicate);
+
+  const reordered = structuredClone(profileRecord()) as {
+    tools: Record<string, unknown>[];
+  };
+  [reordered.tools[0], reordered.tools[1]] = [reordered.tools[1]!, reordered.tools[0]!];
+  expectInvalidRegistry(reordered);
+
+  const unknownRoot = structuredClone(profileRecord());
+  unknownRoot.unexpected = true;
+  expectInvalidRegistry(unknownRoot);
+
+  const unknownNested = structuredClone(profileRecord()) as {
+    tools: { current: Record<string, unknown> }[];
+  };
+  unknownNested.tools[0]!.current.environmentOverride = true;
+  expectInvalidRegistry(unknownNested);
+});
+
+test("rejects lifecycle, mutability, schema and target substitutions", () => {
+  const advertisedPlanned = structuredClone(profileRecord()) as {
+    tools: { current: { discoveryEligible: boolean } }[];
+  };
+  advertisedPlanned.tools[2]!.current.discoveryEligible = true;
+  expectInvalidRegistry(advertisedPlanned);
+
+  const missingSchema = structuredClone(profileRecord()) as {
+    tools: { runtimeSchemas: { problem: { state: string; ref: string | null } } }[];
+  };
+  missingSchema.tools[0]!.runtimeSchemas.problem = { state: "missing", ref: null };
+  expectInvalidRegistry(missingSchema);
+
+  const substitutedSchema = structuredClone(profileRecord()) as {
+    tools: { runtimeSchemas: { input: { state: string; ref: string | null } } }[];
+  };
+  substitutedSchema.tools[0]!.runtimeSchemas.input = {
+    state: "accepted",
+    ref: "schemas/catalogue-describe-request.schema.json",
+  };
+  expectInvalidRegistry(substitutedSchema);
+
+  const workflowReadOnly = structuredClone(profileRecord()) as {
+    tools: { readOnly: boolean; mutating: boolean }[];
+  };
+  workflowReadOnly.tools[11]!.readOnly = true;
+  workflowReadOnly.tools[11]!.mutating = false;
+  expectInvalidRegistry(workflowReadOnly);
+
+  const targetAsRuntime = structuredClone(profileRecord()) as {
+    tools: { v02Target: { runtimeAuthority: boolean } }[];
+  };
+  targetAsRuntime.tools[0]!.v02Target.runtimeAuthority = true;
+  expectInvalidRegistry(targetAsRuntime);
+});
+
+test("clones caller data, rejects mutation and ignores environment state", (t) => {
+  const input = profileRecord();
+  const registry = createToolRegistry(input);
+  const first = registry.get("catalogue.search");
+
+  (input.tools as { purpose: string }[])[0]!.purpose = "Substituted after validation";
+  assert.notEqual(registry.get("catalogue.search").purpose, "Substituted after validation");
+  assert.throws(
+    () => {
+      (first as unknown as { purpose: string }).purpose = "Mutation";
+    },
+    TypeError,
+  );
+  assert.throws(
+    () => {
+      (registry.list() as unknown as unknown[]).push(first);
+    },
+    TypeError,
+  );
+
+  const environmentKey = "GIS_AI_GO_TOOL_REGISTRY";
+  const previous = process.env[environmentKey];
+  process.env[environmentKey] = "activate-all";
+  t.after(() => {
+    if (previous === undefined) delete process.env[environmentKey];
+    else process.env[environmentKey] = previous;
+  });
+  assert.deepEqual(listCurrentCallableTools(), []);
+  assert.equal(TOOL_REGISTRY_DOCUMENT.runtimeAuthority.environmentOverride, false);
+});
+
+test("rejects active input properties without invoking them", () => {
+  const input = profileRecord();
+  let invoked = false;
+  Object.defineProperty(input, "tools", {
+    enumerable: true,
+    get: () => {
+      invoked = true;
+      return [];
+    },
+  });
+
+  expectInvalidRegistry(input);
+  assert.equal(invoked, false);
+});

--- a/packages/tool-registry/tsconfig.json
+++ b/packages/tool-registry/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@gis-ai-go/tool-registry':
+        specifier: workspace:*
+        version: link:packages/tool-registry
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -92,6 +95,8 @@ importers:
       '@gis-ai-go/evidence':
         specifier: workspace:*
         version: link:../evidence
+
+  packages/tool-registry: {}
 
 packages:
 

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,15 @@
+# Governed profiles
+
+Profiles in this directory are checked-in governance data. They do not register,
+advertise or activate a runtime capability.
+
+[`tool-registry.v1.json`](tool-registry.v1.json) contains exactly the 12 canonical
+tool profiles accepted by ADR-0009. Its `current` fields describe the repository
+candidate, while `v02Target` records a non-runtime release objective. Only the
+gateway activation document can authorise production registration, and the
+registry package has no environment override or gateway integration.
+
+The profile is validated by
+[`tool-registry.schema.json`](../schemas/tool-registry.schema.json), the repository
+contract validator, Python source-provenance tests and the private
+`@gis-ai-go/tool-registry` TypeScript package.

--- a/profiles/tool-registry.v1.json
+++ b/profiles/tool-registry.v1.json
@@ -1,0 +1,1450 @@
+{
+  "schema": "gis-ai-go.tool-registry.v1",
+  "version": "1.0.0",
+  "canonicalOrder": [
+    "catalogue.search",
+    "catalogue.describe",
+    "selection.resolve",
+    "data.query",
+    "spatial.locate",
+    "spatial.analyse",
+    "statistics.compare",
+    "route.plan",
+    "map.render",
+    "artefact.export",
+    "evidence.inspect",
+    "workflow.execute"
+  ],
+  "activationRequirements": [
+    "implementation",
+    "release",
+    "policy",
+    "read-only",
+    "schema",
+    "threat",
+    "evidence",
+    "interoperability",
+    "fallback"
+  ],
+  "runtimeAuthority": {
+    "source": "apps/mcp-gateway/src/activation.ts",
+    "registryCanActivate": false,
+    "environmentOverride": false,
+    "productionRegistration": false
+  },
+  "source": {
+    "decision": {
+      "path": "docs/decisions/ADR-0009-read-only-mcp-tool-lifecycle.md",
+      "status": "accepted"
+    },
+    "research": {
+      "path": "docs/research/2026-08-19/research-pack/data/tool-catalogue.json",
+      "retrieved": "2026-08-19",
+      "sha256": "851f626bae4d63e8355ff9ca4021b56041ffa7e432d41f7f682c214151b5a8c3",
+      "gitBlob": "0514fba4ff4765c951c632f6a1c122fe02b1d178",
+      "immutable": true,
+      "records": [
+        "T01",
+        "T02",
+        "T03",
+        "T04",
+        "T05",
+        "T06",
+        "T07",
+        "T08",
+        "T09",
+        "T10",
+        "T11",
+        "T12"
+      ]
+    }
+  },
+  "tools": [
+    {
+      "id": "T01",
+      "name": "catalogue.search",
+      "namespace": "catalogue",
+      "purpose": "Search policy-visible OKF and provider catalogue records.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "v0.2.0",
+      "current": {
+        "implementationState": "implemented",
+        "lifecycleState": "suspended",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "active",
+        "discoveryIntended": true,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "accepted",
+          "ref": "schemas/catalogue-search-request.schema.json"
+        },
+        "output": {
+          "state": "accepted",
+          "ref": "schemas/catalogue-result.schema.json"
+        },
+        "problem": {
+          "state": "accepted",
+          "ref": "schemas/catalogue-problem.schema.json"
+        }
+      },
+      "support": {
+        "operation": "catalogue.search",
+        "operationState": "implemented-inactive",
+        "providerState": "candidate-partial",
+        "providerDependencies": [
+          "OKF index",
+          "OGC API – Records adapters"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "actor",
+        "organisation",
+        "discover",
+        "provider",
+        "dataset",
+        "licence_tier",
+        "purpose"
+      ],
+      "costPerformance": "Low; static index first, provider catalogue fallback",
+      "controlledErrors": [
+        "INVALID_QUERY",
+        "POLICY_DENY",
+        "CATALOGUE_UNAVAILABLE",
+        "CURSOR_INVALID"
+      ],
+      "cursor": {
+        "state": "optional",
+        "maxLength": 1024,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "not-applicable",
+        "requirements": []
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "implemented",
+        "behaviour": "Return static governed snapshot with freshness warning."
+      },
+      "threats": {
+        "risks": [
+          "Unauthorised capability disclosure",
+          "prompt injection in metadata"
+        ]
+      },
+      "source": {
+        "researchId": "T01",
+        "pointer": "/tools/0",
+        "inputSchemaPointer": "/tools/0/input_schema",
+        "outputSchemaPointer": "/tools/0/output_schema"
+      }
+    },
+    {
+      "id": "T02",
+      "name": "catalogue.describe",
+      "namespace": "catalogue",
+      "purpose": "Return a richly linked record, relationships, rights, freshness and source evidence.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "v0.2.0",
+      "current": {
+        "implementationState": "implemented",
+        "lifecycleState": "suspended",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "active",
+        "discoveryIntended": true,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "accepted",
+          "ref": "schemas/catalogue-describe-request.schema.json"
+        },
+        "output": {
+          "state": "accepted",
+          "ref": "schemas/catalogue-result.schema.json"
+        },
+        "problem": {
+          "state": "accepted",
+          "ref": "schemas/catalogue-problem.schema.json"
+        }
+      },
+      "support": {
+        "operation": "catalogue.describe",
+        "operationState": "implemented-inactive",
+        "providerState": "candidate-partial",
+        "providerDependencies": [
+          "OKF bundle",
+          "provider datapacks"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "actor",
+        "discover",
+        "resource",
+        "field_projection"
+      ],
+      "costPerformance": "Low",
+      "controlledErrors": [
+        "NOT_FOUND",
+        "POLICY_DENY",
+        "STALE_RECORD"
+      ],
+      "cursor": {
+        "state": "none",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "not-applicable",
+        "requirements": []
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "partial",
+        "behaviour": "Return the last approved record and mark unavailable live checks."
+      },
+      "threats": {
+        "risks": [
+          "Protected metadata disclosure",
+          "stale record"
+        ]
+      },
+      "source": {
+        "researchId": "T02",
+        "pointer": "/tools/1",
+        "inputSchemaPointer": "/tools/1/input_schema",
+        "outputSchemaPointer": "/tools/1/output_schema"
+      }
+    },
+    {
+      "id": "T03",
+      "name": "selection.resolve",
+      "namespace": "selection",
+      "purpose": "Resolve human or agent intent into a non-executing, provider-native selection plan.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "v0.2.0",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "active",
+        "discoveryIntended": true,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "selection.resolve",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "OKF selection metadata",
+          "provider schema registry"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "actor",
+        "purpose",
+        "resource_visibility",
+        "resolution_limit"
+      ],
+      "costPerformance": "Low-to-medium; deterministic constraints plus bounded language assistance",
+      "controlledErrors": [
+        "AMBIGUOUS_SELECTION",
+        "MISSING_DIMENSION",
+        "POLICY_DENY",
+        "NO_COMPATIBLE_PROVIDER"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "not-applicable",
+        "requirements": []
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Return required choices and no executable plan."
+      },
+      "threats": {
+        "risks": [
+          "Intent injection",
+          "selection of unavailable dataset"
+        ]
+      },
+      "source": {
+        "researchId": "T03",
+        "pointer": "/tools/2",
+        "inputSchemaPointer": "/tools/2/input_schema",
+        "outputSchemaPointer": "/tools/2/output_schema"
+      }
+    },
+    {
+      "id": "T04",
+      "name": "data.query",
+      "namespace": "data",
+      "purpose": "Execute a bounded provider-native or cached data query and return a canonical result envelope.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "v0.2.0",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "active",
+        "discoveryIntended": true,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "data.query",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "provider adapters",
+          "PostGIS",
+          "object storage"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "query",
+        "dataset",
+        "fields",
+        "purpose",
+        "legal_authority",
+        "licence_entitlement",
+        "output_destination",
+        "feature_count"
+      ],
+      "costPerformance": "Variable; preflight estimate and quotas required",
+      "controlledErrors": [
+        "POLICY_DENY",
+        "PROVIDER_UNAVAILABLE",
+        "QUERY_TOO_EXPENSIVE",
+        "OUTPUT_REQUIRES_APPROVAL",
+        "LICENCE_CONSTRAINT"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "required-before-implementation",
+        "requirements": [
+          "Declare CRS and axis order for spatial results."
+        ]
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Use approved cache only when policy permits and show freshness."
+      },
+      "threats": {
+        "risks": [
+          "Data exfiltration",
+          "expensive query",
+          "provider limit breach"
+        ]
+      },
+      "source": {
+        "researchId": "T04",
+        "pointer": "/tools/3",
+        "inputSchemaPointer": "/tools/3/input_schema",
+        "outputSchemaPointer": "/tools/3/output_schema"
+      }
+    },
+    {
+      "id": "T05",
+      "name": "spatial.locate",
+      "namespace": "spatial",
+      "purpose": "Resolve coordinates, identifiers or place text and return containing/current/historic geographies.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "later-reviewed-release",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "spatial.locate",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "ONS geography cache",
+          "OS Names/Places where entitled"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "location_precision",
+        "dataset",
+        "as_of",
+        "licence_tier"
+      ],
+      "costPerformance": "Low indexed lookup; provider call when needed",
+      "controlledErrors": [
+        "LOCATION_INVALID",
+        "NO_MATCH",
+        "POLICY_DOWNGRADE",
+        "TEMPORAL_VERSION_UNKNOWN"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "required-before-implementation",
+        "requirements": [
+          "Declare CRS and axis order for coordinate input and output."
+        ]
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Return coarser open geography or no result with explanation."
+      },
+      "threats": {
+        "risks": [
+          "Sensitive location inference",
+          "false precision"
+        ]
+      },
+      "source": {
+        "researchId": "T05",
+        "pointer": "/tools/4",
+        "inputSchemaPointer": "/tools/4/input_schema",
+        "outputSchemaPointer": "/tools/4/output_schema"
+      }
+    },
+    {
+      "id": "T06",
+      "name": "spatial.analyse",
+      "namespace": "spatial",
+      "purpose": "Run deterministic spatial operations such as intersect, buffer, nearest, join or aggregate.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "later-reviewed-release",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "spatial.analyse",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "Python geospatial service",
+          "PostGIS",
+          "PROJ"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "operation",
+        "datasets",
+        "resolution",
+        "area",
+        "record_count",
+        "derived_output",
+        "purpose"
+      ],
+      "costPerformance": "Variable; geometry complexity and record count bounded",
+      "controlledErrors": [
+        "INVALID_GEOMETRY",
+        "CRS_ERROR",
+        "COMPLEXITY_LIMIT",
+        "POLICY_DENY",
+        "TOPOLOGY_ERROR"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "required-before-implementation",
+        "requirements": [
+          "Declare source and output CRS and axis order."
+        ]
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Offer simplified/aggregated operation or artefact job."
+      },
+      "threats": {
+        "risks": [
+          "Pathological geometry",
+          "inference",
+          "DoS",
+          "licence contamination"
+        ]
+      },
+      "source": {
+        "researchId": "T06",
+        "pointer": "/tools/5",
+        "inputSchemaPointer": "/tools/5/input_schema",
+        "outputSchemaPointer": "/tools/5/output_schema"
+      }
+    },
+    {
+      "id": "T07",
+      "name": "statistics.compare",
+      "namespace": "statistics",
+      "purpose": "Compare statistical observations across compatible geographies, periods or groups.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "later-reviewed-release",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "statistics.compare",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "ONS Data API",
+          "Nomis",
+          "statistical metadata"
+        ]
+      },
+      "accessTiers": [
+        "open"
+      ],
+      "policyAttributes": [
+        "dataset",
+        "measure",
+        "geography",
+        "time",
+        "disclosure",
+        "output"
+      ],
+      "costPerformance": "Medium; dataset queries and compatibility checks",
+      "controlledErrors": [
+        "INCOMPATIBLE_MEASURES",
+        "SUPPRESSED",
+        "GEOGRAPHY_VERSION_MISMATCH",
+        "MISSING_DENOMINATOR"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "not-applicable",
+        "requirements": []
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Return comparability explanation without a numeric comparison."
+      },
+      "threats": {
+        "risks": [
+          "Invalid denominator",
+          "suppression disclosure",
+          "incomparable vintages"
+        ]
+      },
+      "source": {
+        "researchId": "T07",
+        "pointer": "/tools/6",
+        "inputSchemaPointer": "/tools/6/input_schema",
+        "outputSchemaPointer": "/tools/6/output_schema"
+      }
+    },
+    {
+      "id": "T08",
+      "name": "route.plan",
+      "namespace": "route",
+      "purpose": "Plan a deterministic route using an approved network and routing profile.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "later-reviewed-release",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "route.plan",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "approved network data",
+          "pgRouting or provider routing service"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "network_dataset",
+        "profile",
+        "purpose",
+        "location_sensitivity",
+        "cost"
+      ],
+      "costPerformance": "Medium; bounded graph search",
+      "controlledErrors": [
+        "NO_ROUTE",
+        "PROFILE_UNAVAILABLE",
+        "POLICY_DENY",
+        "NETWORK_STALE"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "required-before-implementation",
+        "requirements": [
+          "Declare CRS and axis order for coordinate inputs and route geometry."
+        ]
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Return route-not-available and provider/source options; never invent a route."
+      },
+      "threats": {
+        "risks": [
+          "Unsafe route interpretation",
+          "network licence leakage",
+          "location sensitivity"
+        ]
+      },
+      "source": {
+        "researchId": "T08",
+        "pointer": "/tools/7",
+        "inputSchemaPointer": "/tools/7/input_schema",
+        "outputSchemaPointer": "/tools/7/output_schema"
+      }
+    },
+    {
+      "id": "T09",
+      "name": "map.render",
+      "namespace": "map",
+      "purpose": "Render a deterministic map specification or static image from policy-approved layers.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "later-reviewed-release",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "map.render",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "MapLibre style registry",
+          "tile services",
+          "static renderer"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "layers",
+        "fields",
+        "resolution",
+        "audience",
+        "watermark",
+        "attribution"
+      ],
+      "costPerformance": "Low-to-medium; tile/render bounded",
+      "controlledErrors": [
+        "LAYER_DENIED",
+        "STYLE_INVALID",
+        "ATTRIBUTION_MISSING",
+        "RENDER_LIMIT"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "required-before-implementation",
+        "requirements": [
+          "Declare CRS and axis order for every spatial layer and rendered output."
+        ]
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Return accessible map specification and text summary."
+      },
+      "threats": {
+        "risks": [
+          "Protected feature leakage",
+          "missing attribution",
+          "visual misrepresentation"
+        ]
+      },
+      "source": {
+        "researchId": "T09",
+        "pointer": "/tools/8",
+        "inputSchemaPointer": "/tools/8/input_schema",
+        "outputSchemaPointer": "/tools/8/output_schema"
+      }
+    },
+    {
+      "id": "T10",
+      "name": "artefact.export",
+      "namespace": "artefact",
+      "purpose": "Create a governed downloadable result with manifest, expiry and audience constraints.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "later-reviewed-release",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "artefact.export",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "object storage",
+          "malware/content scanner",
+          "approval workflow"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "export",
+        "format",
+        "destination",
+        "audience",
+        "retention",
+        "feature_count",
+        "licence",
+        "approval"
+      ],
+      "costPerformance": "Variable storage/egress",
+      "controlledErrors": [
+        "APPROVAL_REQUIRED",
+        "EXPORT_DENIED",
+        "FORMAT_UNAVAILABLE",
+        "RETENTION_INVALID",
+        "SCAN_FAILED"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "required-before-implementation",
+        "requirements": [
+          "Preserve or explicitly transform CRS and axis order in spatial artefacts."
+        ]
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Offer smaller inline result or approved aggregate."
+      },
+      "threats": {
+        "risks": [
+          "Bulk exfiltration",
+          "licence breach",
+          "long-lived signed URL"
+        ]
+      },
+      "source": {
+        "researchId": "T10",
+        "pointer": "/tools/9",
+        "inputSchemaPointer": "/tools/9/input_schema",
+        "outputSchemaPointer": "/tools/9/output_schema"
+      }
+    },
+    {
+      "id": "T11",
+      "name": "evidence.inspect",
+      "namespace": "evidence",
+      "purpose": "Retrieve the policy decision, source lineage, transformations and receipt for an operation.",
+      "readOnly": true,
+      "mutating": false,
+      "releaseTarget": "v0.2.0",
+      "current": {
+        "implementationState": "implemented",
+        "lifecycleState": "suspended",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "active",
+        "discoveryIntended": true,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "accepted",
+          "ref": "schemas/evidence-inspect-request.schema.json"
+        },
+        "output": {
+          "state": "accepted",
+          "ref": "schemas/evidence-inspect-result.schema.json"
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "evidence.inspect",
+        "operationState": "implemented-inactive",
+        "providerState": "candidate-partial",
+        "providerDependencies": [
+          "evidence store",
+          "policy decision store",
+          "source ledger"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial",
+        "auditor"
+      ],
+      "policyAttributes": [
+        "audit_access",
+        "subject_relationship",
+        "case_reference",
+        "redaction"
+      ],
+      "costPerformance": "Low",
+      "controlledErrors": [
+        "NOT_FOUND",
+        "AUDIT_DENY",
+        "REDACTED",
+        "EVIDENCE_INTEGRITY_FAILURE"
+      ],
+      "cursor": {
+        "state": "none",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "not-applicable",
+        "requirements": []
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "partial",
+        "behaviour": "Return a redacted public receipt or challenge route."
+      },
+      "threats": {
+        "risks": [
+          "Audit data privacy",
+          "evidence tampering"
+        ]
+      },
+      "source": {
+        "researchId": "T11",
+        "pointer": "/tools/10",
+        "inputSchemaPointer": "/tools/10/input_schema",
+        "outputSchemaPointer": "/tools/10/output_schema"
+      }
+    },
+    {
+      "id": "T12",
+      "name": "workflow.execute",
+      "namespace": "workflow",
+      "purpose": "Start or resume a registered, policy-approved workflow and return explicit state.",
+      "readOnly": false,
+      "mutating": true,
+      "releaseTarget": "v0.3.0",
+      "current": {
+        "implementationState": "not-implemented",
+        "lifecycleState": "planned",
+        "discoveryEligible": false,
+        "activationGates": {
+          "releaseEnabled": false,
+          "policy": false,
+          "schema": false,
+          "threat": false,
+          "evidence": false,
+          "interoperability": false,
+          "fallback": false
+        }
+      },
+      "v02Target": {
+        "lifecycleState": "planned",
+        "discoveryIntended": false,
+        "runtimeAuthority": false
+      },
+      "runtimeSchemas": {
+        "input": {
+          "state": "missing",
+          "ref": null
+        },
+        "output": {
+          "state": "missing",
+          "ref": null
+        },
+        "problem": {
+          "state": "missing",
+          "ref": null
+        }
+      },
+      "support": {
+        "operation": "workflow.execute",
+        "operationState": "not-implemented",
+        "providerState": "planned",
+        "providerDependencies": [
+          "workflow registry",
+          "Arazzo definitions",
+          "Tasks store",
+          "approval service"
+        ]
+      },
+      "accessTiers": [
+        "open",
+        "PSGA",
+        "commercial"
+      ],
+      "policyAttributes": [
+        "workflow",
+        "actor",
+        "permit",
+        "purpose",
+        "risk_tier",
+        "approval",
+        "budget"
+      ],
+      "costPerformance": "Workflow-specific; preflight estimate",
+      "controlledErrors": [
+        "WORKFLOW_NOT_FOUND",
+        "PERMIT_REQUIRED",
+        "PERMIT_EXPIRED",
+        "APPROVAL_REQUIRED",
+        "STATE_CONFLICT",
+        "CANCELLED"
+      ],
+      "cursor": {
+        "state": "not-implemented",
+        "maxLength": null,
+        "artefactFallback": "not-implemented",
+        "researchStatement": "Bounded inline response; cursor pagination or immutable artefact when limits are exceeded."
+      },
+      "crs": {
+        "state": "not-applicable",
+        "requirements": []
+      },
+      "provenance": {
+        "requiredFields": [
+          "request_id",
+          "trace_id",
+          "provider",
+          "dataset",
+          "dataset_version",
+          "source_uris",
+          "retrieved_at",
+          "policy_decision_id",
+          "transformation",
+          "software",
+          "output_hash",
+          "licence_obligations"
+        ]
+      },
+      "fallback": {
+        "state": "not-implemented",
+        "behaviour": "Return current state and required human action; no implicit continuation."
+      },
+      "threats": {
+        "risks": [
+          "Workflow confusion",
+          "replay",
+          "approval bypass",
+          "partial side effects"
+        ]
+      },
+      "source": {
+        "researchId": "T12",
+        "pointer": "/tools/11",
+        "inputSchemaPointer": "/tools/11/input_schema",
+        "outputSchemaPointer": "/tools/11/output_schema"
+      }
+    }
+  ]
+}

--- a/schemas/tool-registry.schema.json
+++ b/schemas/tool-registry.schema.json
@@ -1,0 +1,644 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:tool-registry:v1",
+  "title": "GIS AI GO tool registry",
+  "description": "Closed governance profiles for the 12 canonical GIS AI GO tools. This contract does not activate or advertise a runtime capability.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "canonicalOrder",
+    "activationRequirements",
+    "runtimeAuthority",
+    "source",
+    "tools"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.tool-registry.v1"
+    },
+    "version": {
+      "const": "1.0.0"
+    },
+    "canonicalOrder": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "catalogue.search" },
+        { "const": "catalogue.describe" },
+        { "const": "selection.resolve" },
+        { "const": "data.query" },
+        { "const": "spatial.locate" },
+        { "const": "spatial.analyse" },
+        { "const": "statistics.compare" },
+        { "const": "route.plan" },
+        { "const": "map.render" },
+        { "const": "artefact.export" },
+        { "const": "evidence.inspect" },
+        { "const": "workflow.execute" }
+      ],
+      "items": false,
+      "minItems": 12,
+      "maxItems": 12
+    },
+    "activationRequirements": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "implementation" },
+        { "const": "release" },
+        { "const": "policy" },
+        { "const": "read-only" },
+        { "const": "schema" },
+        { "const": "threat" },
+        { "const": "evidence" },
+        { "const": "interoperability" },
+        { "const": "fallback" }
+      ],
+      "items": false,
+      "minItems": 9,
+      "maxItems": 9
+    },
+    "runtimeAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "registryCanActivate",
+        "environmentOverride",
+        "productionRegistration"
+      ],
+      "properties": {
+        "source": {
+          "const": "apps/mcp-gateway/src/activation.ts"
+        },
+        "registryCanActivate": {
+          "const": false
+        },
+        "environmentOverride": {
+          "const": false
+        },
+        "productionRegistration": {
+          "type": "boolean"
+        }
+      }
+    },
+    "source": {
+      "$ref": "#/$defs/registrySource"
+    },
+    "tools": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T01" },
+                "name": { "const": "catalogue.search" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T02" },
+                "name": { "const": "catalogue.describe" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T03" },
+                "name": { "const": "selection.resolve" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T04" },
+                "name": { "const": "data.query" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T05" },
+                "name": { "const": "spatial.locate" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T06" },
+                "name": { "const": "spatial.analyse" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T07" },
+                "name": { "const": "statistics.compare" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T08" },
+                "name": { "const": "route.plan" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T09" },
+                "name": { "const": "map.render" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T10" },
+                "name": { "const": "artefact.export" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T11" },
+                "name": { "const": "evidence.inspect" }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/toolProfile" },
+            {
+              "properties": {
+                "id": { "const": "T12" },
+                "name": { "const": "workflow.execute" }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false,
+      "minItems": 12,
+      "maxItems": 12,
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "registrySource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "research"],
+      "properties": {
+        "decision": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "status"],
+          "properties": {
+            "path": {
+              "const": "docs/decisions/ADR-0009-read-only-mcp-tool-lifecycle.md"
+            },
+            "status": {
+              "const": "accepted"
+            }
+          }
+        },
+        "research": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "path",
+            "retrieved",
+            "sha256",
+            "gitBlob",
+            "immutable",
+            "records"
+          ],
+          "properties": {
+            "path": {
+              "const": "docs/research/2026-08-19/research-pack/data/tool-catalogue.json"
+            },
+            "retrieved": {
+              "const": "2026-08-19"
+            },
+            "sha256": {
+              "const": "851f626bae4d63e8355ff9ca4021b56041ffa7e432d41f7f682c214151b5a8c3"
+            },
+            "gitBlob": {
+              "const": "0514fba4ff4765c951c632f6a1c122fe02b1d178"
+            },
+            "immutable": {
+              "const": true
+            },
+            "records": {
+              "type": "array",
+              "prefixItems": [
+                { "const": "T01" },
+                { "const": "T02" },
+                { "const": "T03" },
+                { "const": "T04" },
+                { "const": "T05" },
+                { "const": "T06" },
+                { "const": "T07" },
+                { "const": "T08" },
+                { "const": "T09" },
+                { "const": "T10" },
+                { "const": "T11" },
+                { "const": "T12" }
+              ],
+              "items": false,
+              "minItems": 12,
+              "maxItems": 12
+            }
+          }
+        }
+      }
+    },
+    "toolProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "namespace",
+        "purpose",
+        "readOnly",
+        "mutating",
+        "releaseTarget",
+        "current",
+        "v02Target",
+        "runtimeSchemas",
+        "support",
+        "accessTiers",
+        "policyAttributes",
+        "costPerformance",
+        "controlledErrors",
+        "cursor",
+        "crs",
+        "provenance",
+        "fallback",
+        "threats",
+        "source"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^T(?:0[1-9]|1[0-2])$"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z]+\\.[a-z]+$",
+          "maxLength": 64
+        },
+        "namespace": {
+          "type": "string",
+          "pattern": "^[a-z]+$",
+          "maxLength": 32
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "mutating": {
+          "type": "boolean"
+        },
+        "releaseTarget": {
+          "enum": ["v0.2.0", "later-reviewed-release", "v0.3.0"]
+        },
+        "current": {
+          "$ref": "#/$defs/currentState"
+        },
+        "v02Target": {
+          "$ref": "#/$defs/v02Target"
+        },
+        "runtimeSchemas": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input", "output", "problem"],
+          "properties": {
+            "input": { "$ref": "#/$defs/runtimeSchemaReference" },
+            "output": { "$ref": "#/$defs/runtimeSchemaReference" },
+            "problem": { "$ref": "#/$defs/runtimeSchemaReference" }
+          }
+        },
+        "support": {
+          "$ref": "#/$defs/support"
+        },
+        "accessTiers": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "policyAttributes": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "costPerformance": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "controlledErrors": {
+          "description": "Governance error-code vocabulary mirrored from the immutable research profile. Runtime error-contract availability is declared separately by runtimeSchemas.problem.",
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]*$",
+            "maxLength": 64
+          }
+        },
+        "cursor": {
+          "$ref": "#/$defs/cursor"
+        },
+        "crs": {
+          "$ref": "#/$defs/crs"
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["requiredFields"],
+          "properties": {
+            "requiredFields": {
+              "$ref": "#/$defs/nonEmptyStringArray"
+            }
+          }
+        },
+        "fallback": {
+          "$ref": "#/$defs/fallback"
+        },
+        "threats": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["risks"],
+          "properties": {
+            "risks": {
+              "$ref": "#/$defs/nonEmptyStringArray"
+            }
+          }
+        },
+        "source": {
+          "$ref": "#/$defs/toolSource"
+        }
+      }
+    },
+    "currentState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementationState",
+        "lifecycleState",
+        "discoveryEligible",
+        "activationGates"
+      ],
+      "properties": {
+        "implementationState": {
+          "enum": ["implemented", "not-implemented"]
+        },
+        "lifecycleState": {
+          "enum": ["active", "planned", "suspended", "retired"]
+        },
+        "discoveryEligible": {
+          "type": "boolean"
+        },
+        "activationGates": {
+          "$ref": "#/$defs/activationGates"
+        }
+      }
+    },
+    "activationGates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "releaseEnabled",
+        "policy",
+        "schema",
+        "threat",
+        "evidence",
+        "interoperability",
+        "fallback"
+      ],
+      "properties": {
+        "releaseEnabled": { "type": "boolean" },
+        "policy": { "type": "boolean" },
+        "schema": { "type": "boolean" },
+        "threat": { "type": "boolean" },
+        "evidence": { "type": "boolean" },
+        "interoperability": { "type": "boolean" },
+        "fallback": { "type": "boolean" }
+      }
+    },
+    "v02Target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lifecycleState", "discoveryIntended", "runtimeAuthority"],
+      "properties": {
+        "lifecycleState": {
+          "enum": ["active", "planned"]
+        },
+        "discoveryIntended": {
+          "type": "boolean"
+        },
+        "runtimeAuthority": {
+          "const": false
+        }
+      }
+    },
+    "runtimeSchemaReference": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "ref"],
+          "properties": {
+            "state": { "const": "accepted" },
+            "ref": {
+              "type": "string",
+              "pattern": "^schemas/[a-z0-9-]+\\.schema\\.json$",
+              "maxLength": 128
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "ref"],
+          "properties": {
+            "state": { "const": "missing" },
+            "ref": { "type": "null" }
+          }
+        }
+      ]
+    },
+    "support": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "operationState",
+        "providerState",
+        "providerDependencies"
+      ],
+      "properties": {
+        "operation": {
+          "type": "string",
+          "pattern": "^[a-z]+\\.[a-z]+$",
+          "maxLength": 64
+        },
+        "operationState": {
+          "enum": ["implemented-inactive", "not-implemented"]
+        },
+        "providerState": {
+          "enum": ["candidate-partial", "planned"]
+        },
+        "providerDependencies": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        }
+      }
+    },
+    "cursor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "maxLength", "artefactFallback", "researchStatement"],
+      "properties": {
+        "state": {
+          "enum": ["none", "optional", "not-implemented"]
+        },
+        "maxLength": {
+          "oneOf": [
+            { "type": "integer", "minimum": 1, "maximum": 4096 },
+            { "type": "null" }
+          ]
+        },
+        "artefactFallback": {
+          "enum": ["implemented", "not-implemented"]
+        },
+        "researchStatement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    },
+    "crs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "requirements"],
+      "properties": {
+        "state": {
+          "enum": ["not-applicable", "required-before-implementation"]
+        },
+        "requirements": {
+          "type": "array",
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          }
+        }
+      }
+    },
+    "fallback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "behaviour"],
+      "properties": {
+        "state": {
+          "enum": ["implemented", "partial", "not-implemented"]
+        },
+        "behaviour": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    },
+    "toolSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "researchId",
+        "pointer",
+        "inputSchemaPointer",
+        "outputSchemaPointer"
+      ],
+      "properties": {
+        "researchId": {
+          "type": "string",
+          "pattern": "^T(?:0[1-9]|1[0-2])$"
+        },
+        "pointer": {
+          "type": "string",
+          "pattern": "^/tools/(?:[0-9]|1[01])$"
+        },
+        "inputSchemaPointer": {
+          "type": "string",
+          "pattern": "^/tools/(?:[0-9]|1[01])/input_schema$"
+        },
+        "outputSchemaPointer": {
+          "type": "string",
+          "pattern": "^/tools/(?:[0-9]|1[01])/output_schema$"
+        }
+      }
+    },
+    "nonEmptyStringArray": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256
+      }
+    }
+  }
+}

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -297,6 +297,15 @@ def main() -> None:
             ],
         ),
         (
+            "tool-registry.schema.json",
+            [
+                (
+                    "profiles/tool-registry.v1.json",
+                    load_json(ROOT / "profiles" / "tool-registry.v1.json"),
+                )
+            ],
+        ),
+        (
             "decision.schema.json",
             [
                 (record["id"], record)

--- a/services/geo-execution/tests/test_http.py
+++ b/services/geo-execution/tests/test_http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import socket
 import sys
 import threading
 import unittest
@@ -224,14 +225,21 @@ class PrivateHttpTests(unittest.TestCase):
             execution.start()
         self.assertTrue(all_started.wait(timeout=3))
 
-        overflow = valid_request()
-        overflow["request_id"] = "exec-202-concurrent-overflow"
-        status, problem, response = self.request(
-            "POST",
-            "/internal/v1/execute",
-            canonical_json_bytes(overflow),
+        # Capacity is enforced immediately after accept, before a request handler
+        # or request body exists. Reading that pre-handler response directly avoids
+        # racing a client body write against the deliberate connection close.
+        overflow_connection = socket.create_connection(
+            ("127.0.0.1", self.port), timeout=3
         )
-        self.assertEqual((429, "CAPACITY_EXCEEDED"), (status, problem["code"]))
+        try:
+            response = http.client.HTTPResponse(overflow_connection)
+            response.begin()
+            problem = json.loads(response.read())
+        finally:
+            overflow_connection.close()
+        self.assertEqual(
+            (429, "CAPACITY_EXCEEDED"), (response.status, problem["code"])
+        )
         self.assertEqual("1", response.getheader("Retry-After"))
 
         resume.set()

--- a/tests/contract/test_release_metadata.py
+++ b/tests/contract/test_release_metadata.py
@@ -48,6 +48,7 @@ class ReleaseMetadataTests(unittest.TestCase):
             "packages/evidence/package.json",
             "packages/policy-client/package.json",
             "packages/provider-adapter-sdk/package.json",
+            "packages/tool-registry/package.json",
         )
         self.assertEqual(check_versions.npm_package_manifests(ROOT), expected_manifests)
 
@@ -112,6 +113,7 @@ class ReleaseMetadataTests(unittest.TestCase):
             "@gis-ai-go/contracts",
             "@gis-ai-go/evidence",
             "@gis-ai-go/policy-client",
+            "@gis-ai-go/tool-registry",
         }
         for name in workspace_components:
             with self.subTest(package=name):

--- a/tests/contract/test_tool_registry.py
+++ b/tests/contract/test_tool_registry.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_PATH = ROOT / "profiles" / "tool-registry.v1.json"
+SCHEMA_PATH = ROOT / "schemas" / "tool-registry.schema.json"
+RESEARCH_PATH = (
+    ROOT
+    / "docs"
+    / "research"
+    / "2026-08-19"
+    / "research-pack"
+    / "data"
+    / "tool-catalogue.json"
+)
+RESEARCH_SHA256 = "851f626bae4d63e8355ff9ca4021b56041ffa7e432d41f7f682c214151b5a8c3"
+CANONICAL_NAMES = [
+    "catalogue.search",
+    "catalogue.describe",
+    "selection.resolve",
+    "data.query",
+    "spatial.locate",
+    "spatial.analyse",
+    "statistics.compare",
+    "route.plan",
+    "map.render",
+    "artefact.export",
+    "evidence.inspect",
+    "workflow.execute",
+]
+TARGET_ACTIVE = [
+    "catalogue.search",
+    "catalogue.describe",
+    "selection.resolve",
+    "data.query",
+    "evidence.inspect",
+]
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class ToolRegistryContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.profile = load_json(PROFILE_PATH)
+        cls.schema = load_json(SCHEMA_PATH)
+        cls.validator = Draft202012Validator(cls.schema)
+        cls.research = load_json(RESEARCH_PATH)
+
+    def assert_invalid(self, value: Any) -> None:
+        self.assertTrue(list(self.validator.iter_errors(value)))
+
+    def test_profile_validates_as_closed_v1_contract(self) -> None:
+        Draft202012Validator.check_schema(self.schema)
+        errors = sorted(
+            self.validator.iter_errors(self.profile),
+            key=lambda error: list(error.absolute_path),
+        )
+        self.assertEqual(
+            errors,
+            [],
+            "; ".join(
+                f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+                for error in errors
+            ),
+        )
+        self.assertEqual(self.profile["canonicalOrder"], CANONICAL_NAMES)
+        self.assertEqual(
+            [tool["id"] for tool in self.profile["tools"]],
+            [f"T{index:02d}" for index in range(1, 13)],
+        )
+        self.assertEqual(
+            [tool["name"] for tool in self.profile["tools"]],
+            CANONICAL_NAMES,
+        )
+
+    def test_research_provenance_and_mirrored_fields_are_exact(self) -> None:
+        digest = hashlib.sha256(RESEARCH_PATH.read_bytes()).hexdigest()
+        self.assertEqual(digest, RESEARCH_SHA256)
+        self.assertEqual(self.profile["source"]["research"]["sha256"], digest)
+        self.assertTrue(self.profile["source"]["research"]["immutable"])
+
+        for index, (profile, research) in enumerate(
+            zip(self.profile["tools"], self.research["tools"], strict=True)
+        ):
+            with self.subTest(tool=profile["name"]):
+                self.assertEqual(profile["id"], research["id"])
+                self.assertEqual(profile["name"], research["name"])
+                self.assertEqual(profile["namespace"], research["namespace"])
+                self.assertEqual(profile["purpose"], research["purpose"])
+                self.assertEqual(profile["readOnly"], research["read_only"])
+                self.assertEqual(profile["mutating"], research["mutating"])
+                self.assertEqual(
+                    profile["support"]["providerDependencies"],
+                    research["provider_dependencies"],
+                )
+                self.assertEqual(profile["accessTiers"], research["access_tiers"])
+                self.assertEqual(
+                    profile["policyAttributes"],
+                    research["policy_relevant_attributes"],
+                )
+                self.assertEqual(profile["costPerformance"], research["cost_performance"])
+                self.assertEqual(profile["controlledErrors"], research["error_codes"])
+                self.assertEqual(
+                    profile["provenance"]["requiredFields"],
+                    research["provenance_fields"],
+                )
+                self.assertEqual(profile["fallback"]["behaviour"], research["fallback_behaviour"])
+                self.assertEqual(profile["threats"]["risks"], research["risks"])
+                self.assertEqual(
+                    profile["cursor"]["researchStatement"],
+                    research["pagination_or_artefact"],
+                )
+                pointer = f"/tools/{index}"
+                self.assertEqual(profile["source"]["pointer"], pointer)
+                self.assertEqual(
+                    profile["source"]["inputSchemaPointer"],
+                    f"{pointer}/input_schema",
+                )
+                self.assertEqual(
+                    profile["source"]["outputSchemaPointer"],
+                    f"{pointer}/output_schema",
+                )
+
+    def test_current_and_target_states_are_distinct_and_honest(self) -> None:
+        profiles = {tool["name"]: tool for tool in self.profile["tools"]}
+        implemented = [
+            name
+            for name in CANONICAL_NAMES
+            if profiles[name]["current"]["implementationState"] == "implemented"
+        ]
+        target_active = [
+            name
+            for name in CANONICAL_NAMES
+            if profiles[name]["v02Target"]["lifecycleState"] == "active"
+        ]
+        self.assertEqual(
+            implemented,
+            ["catalogue.search", "catalogue.describe", "evidence.inspect"],
+        )
+        self.assertEqual(target_active, TARGET_ACTIVE)
+        self.assertEqual(
+            profiles["selection.resolve"]["current"]["implementationState"],
+            "not-implemented",
+        )
+        self.assertEqual(
+            profiles["data.query"]["current"]["implementationState"],
+            "not-implemented",
+        )
+        self.assertTrue(profiles["workflow.execute"]["mutating"])
+        self.assertFalse(profiles["workflow.execute"]["readOnly"])
+        self.assertEqual(profiles["workflow.execute"]["releaseTarget"], "v0.3.0")
+
+        for profile in self.profile["tools"]:
+            with self.subTest(tool=profile["name"]):
+                self.assertFalse(profile["current"]["discoveryEligible"])
+                self.assertFalse(any(profile["current"]["activationGates"].values()))
+                self.assertFalse(profile["v02Target"]["runtimeAuthority"])
+        self.assertFalse(self.profile["runtimeAuthority"]["productionRegistration"])
+        self.assertFalse(self.profile["runtimeAuthority"]["registryCanActivate"])
+        self.assertFalse(self.profile["runtimeAuthority"]["environmentOverride"])
+
+    def test_runtime_schema_references_are_accepted_files_or_explicitly_missing(self) -> None:
+        for profile in self.profile["tools"]:
+            for direction, reference in profile["runtimeSchemas"].items():
+                with self.subTest(tool=profile["name"], direction=direction):
+                    if reference["state"] == "missing":
+                        self.assertIsNone(reference["ref"])
+                        continue
+                    relative = reference["ref"]
+                    self.assertTrue(relative.startswith("schemas/"))
+                    self.assertNotIn("docs/research", relative)
+                    schema_path = ROOT / relative
+                    self.assertTrue(schema_path.is_file())
+                    runtime_schema = load_json(schema_path)
+                    self.assertTrue(runtime_schema["$id"].startswith("urn:gis-ai-go:schema:"))
+
+    def test_schema_rejects_duplicates_reordering_and_unknown_fields(self) -> None:
+        duplicate = copy.deepcopy(self.profile)
+        duplicate["tools"][1]["id"] = duplicate["tools"][0]["id"]
+        self.assert_invalid(duplicate)
+
+        reordered = copy.deepcopy(self.profile)
+        reordered["tools"][0], reordered["tools"][1] = (
+            reordered["tools"][1],
+            reordered["tools"][0],
+        )
+        self.assert_invalid(reordered)
+
+        unknown_root = copy.deepcopy(self.profile)
+        unknown_root["environmentOverride"] = True
+        self.assert_invalid(unknown_root)
+
+        unknown_nested = copy.deepcopy(self.profile)
+        unknown_nested["tools"][0]["current"]["advertise"] = True
+        self.assert_invalid(unknown_nested)
+
+    def test_registry_does_not_modify_gateway_activation_or_read_environment(self) -> None:
+        activation = (ROOT / "apps" / "mcp-gateway" / "src" / "activation.ts").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("@gis-ai-go/tool-registry", activation)
+        self.assertIn("activeTools: Object.freeze([])", activation)
+        self.assertIn("activeApiOperations: Object.freeze([])", activation)
+
+        runtime_source = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in sorted((ROOT / "packages" / "tool-registry" / "src").glob("*.ts"))
+        )
+        self.assertNotIn("process.env", runtime_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

- Work item: TOOLS-205, closes the bounded profile-registry slice of #23
- Release target: v0.2.0 foundation; no runtime activation
- User-visible outcome: none yet; clients still discover zero tools by default

## Scope

- Included: the exact ordered 12-profile registry, closed Draft 2020-12 schema,
  private zero-dependency registry package, validation, threat and operations
  documentation, changelog fragment, lock and SBOM integration.
- Not included: gateway registration, activation, provider calls, execution,
  public deployment, registry publication or the implementation of planned tools.

The registry separates current runtime state from non-runtime `v02Target` intent.
All current discovery and activation gates are false. `listCurrentCallableTools()`
therefore returns an empty frozen array; it never reads target metadata or the
environment.

## Evidence

- [x] Relevant tests added or updated
- [x] `pnpm run check` passes
- [x] Source, data, rights and licence provenance reviewed
- [x] Security and privacy boundary reviewed
- [x] Accessibility impact marked not applicable: no user interface or advertised tool changes
- [x] Changelog fragment added
- [x] Deployment boundary and rollback recorded

Independent exact-byte review found no P0-P2 issue. The frozen security snapshot
was `codex-security-snapshot/v1:sha256:da218b18fa246b524c4129f3da64990cca161d69c78af5b46d5464f64ed7c477`.
Hostile substitutions for activation, lifecycle, pointers, accessors, deep values
and environment state failed closed, and the callable set remained empty.

## Verification

Registry candidate: `ee7ac50`. Current pull-request head: `94ede77`.

The second commit changes only the existing execution-service concurrency test.
The original Linux runner raced a deliberate pre-handler 429/connection close
against `http.client` still writing a body and failed with `BrokenPipeError`.
The repaired probe reads the immediate capacity response from the accepted socket,
which matches the server boundary it is testing. The focused HTTP suite passed 10
consecutive runs; the complete 105 + 20 Python-test gate also passed.

The complete locked gate passed independently in a disposable Git-backed copy:

- 7 TypeScript and 6 Python registry tests;
- 95 gateway and 27 real-browser tests;
- 125 Python tests plus the isolated execution-container acceptance;
- 25 schemas and 65 records;
- 165 CycloneDX components, with `@gis-ai-go/tool-registry@0.1.0` once;
- secret, machine-path, link, research-integrity and diagram checks; and
- two byte-identical release outputs, with `artifact.tar` SHA-256
  `04ccc381f0ba33b6a0ee8c965a26b9744e1785b9279faeff02774cafa88638e0`.

The canonical profile has 12 unique IDs and names, five explicitly non-runtime
v0.2 target-active entries, zero current discovery-eligible entries and zero
current callable entries. Immutable research remains byte-for-byte unchanged.

## Deployment and rollback

Not deployed. Production/default MCP and API activation arrays remain empty and
readiness remains blocked.

Rollback is an ordinary revert of this single commit. It removes registry metadata
and its private package without changing the supported static v0.1.0 product or
any runtime capability.
