### PR TITLE
feat(gateway): add inactive public data query

### DIFF
--- a/apps/mcp-gateway/README.md
+++ b/apps/mcp-gateway/README.md
@@ -36,6 +36,15 @@ It is an implementation workbench, not a supported or deployed service.
   problem with `plan: null`. Question text is untrusted and is never interpreted,
   reflected, persisted or sent to a provider. The application has no adapter,
   execution or network dependency and is not mounted by any transport.
+- `createDataQueryApplication` is an inactive transport-neutral application seam
+  for the exact reviewed ONS single-observation query. It requires an explicitly
+  injected `OnsDataApiAdapter`, verifies public-read v2 policy plus the adapter's
+  invocation health, estimate, rights, provenance and result independently, then
+  builds and fully verifies one v2 receipt. Discovery may remain suspended; an
+  invocation-suspended adapter cannot execute. There is no default adapter,
+  environment activation or live-provider call in ordinary tests. Caller signal
+  cancellation and caller deadline expiry are checked before and after execution
+  and remain distinct from an adapter-local provider timeout.
 - the HTTP candidate listens only on `127.0.0.1:8787` and exposes `GET /healthz`,
   `GET /readyz` and `GET /openapi.json`. Readiness always returns `503` with zero
   active tools and zero active API operations.
@@ -58,6 +67,8 @@ MCP tool or resource, public deployment, provider call or external policy servic
 The portable evidence store and inspector are inactive embedding components; no
 shipped entry point supplies their configuration or a ledger path.
 There is no environment-variable or command-line activation override.
+The application-only `data.query` constructor is likewise not referenced by any
+shipped entry point, route, MCP registration, OpenAPI operation or capability list.
 The test-only legacy launcher is separately named, requires both the existing
 conformance gate and an exact `--legacy-stdio-conformance-only` argument, and is
 not referenced by a package script or shipped entrypoint.
@@ -89,4 +100,5 @@ pnpm --filter @gis-ai-go/mcp-gateway run start:http
 See the [candidate boundary](../../docs/operations/MCP-201_GATEWAY_CANDIDATE.md),
 the [EVID-204 inspection transport boundary](../../docs/operations/EVID-204_INSPECT_TRANSPORT.md)
 the [QUAL-206 interoperability runbook](../../docs/operations/QUAL-206_INTEROPERABILITY.md)
-and the [inactive selection resolver boundary](../../docs/operations/TOOLS-205_SELECTION_RESOLVE.md).
+and the
+[inactive selection resolver boundary](../../docs/operations/TOOLS-205_SELECTION_RESOLVE.md).

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "prepare:test": "pnpm --dir ../.. run build:okf && pnpm --filter @gis-ai-go/contracts run build && pnpm --filter @gis-ai-go/evidence run build && pnpm --filter @gis-ai-go/authority-context run build && pnpm --filter @gis-ai-go/policy-client run build",
+    "prepare:test": "pnpm --dir ../.. run build:okf && pnpm --filter @gis-ai-go/contracts run build && pnpm --filter @gis-ai-go/evidence run build && pnpm --filter @gis-ai-go/authority-context run build && pnpm --filter @gis-ai-go/policy-client run build && pnpm --filter @gis-ai-go/provider-adapter-sdk run build",
     "test": "pnpm run prepare:test && pnpm run build && node --test dist/test/*.test.js",
     "start:http": "node dist/src/http-main.js ../../artifacts/okf",
     "start:stdio": "node dist/src/mcp-stdio-main.js ../../artifacts/okf"
@@ -18,6 +18,7 @@
     "@gis-ai-go/contracts": "workspace:*",
     "@gis-ai-go/evidence": "workspace:*",
     "@gis-ai-go/policy-client": "workspace:*",
+    "@gis-ai-go/provider-adapter-sdk": "workspace:*",
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0"
   },

--- a/apps/mcp-gateway/src/data-query-application.ts
+++ b/apps/mcp-gateway/src/data-query-application.ts
@@ -1,0 +1,832 @@
+import { types as utilTypes } from "node:util";
+
+import {
+  PUBLIC_READ_ONS_RESOURCE,
+  PublicEvidenceLedger,
+  buildPublicReadReceipt,
+  canonicalJson,
+  canonicalJsonClone,
+  publicReadResultEvidenceBinding,
+  verifyPublicReadAuthorityContext,
+  verifyPublicReadPolicy,
+  verifyPublicReadPolicyDecision,
+  verifyPublicReadReceipt,
+  verifyPublicReadResource,
+  type EvidenceSoftwareIdentity,
+  type PublicEvidenceStorageReference,
+  type PublicReadEvidenceReceipt,
+} from "@gis-ai-go/evidence";
+import {
+  ADAPTER_ERROR_CODES,
+  ONS_ADAPTER_ID,
+  ONS_ADAPTER_REQUEST,
+  ONS_ADAPTER_VERSION,
+  ONS_OBSERVATION_URI,
+  OnsDataApiAdapter,
+  normaliseAdapterError,
+  type AdapterErrorCode,
+  type AdapterHealth,
+  type NormalisedAdapterError,
+  type ProviderAdapterEstimate,
+  type ProviderAdapterProvenance,
+  type ProviderAdapterResult,
+  type ProviderRights,
+} from "@gis-ai-go/provider-adapter-sdk";
+import {
+  evaluatePublicReadPolicy,
+  isAllowedPublicReadOperation,
+} from "@gis-ai-go/policy-client";
+
+import {
+  assertCatalogueProblemContext,
+  type CatalogueProblemContext,
+} from "./problem.js";
+
+const SEMVER = /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u;
+const SHA40 = /^[0-9a-f]{40}$/u;
+const NUMERIC_OBSERVATION = /^(?:0|[1-9][0-9]{0,14})$/u;
+const DEADLINE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|([+-])(\d{2}):(\d{2}))$/u;
+
+export const DATA_QUERY_PROBLEM_CODES = Object.freeze([
+  "invalid_request",
+  "query_cancelled",
+  "query_deadline_exceeded",
+  "policy_denied",
+  "provider_suspended",
+  "provider_rate_limited",
+  "provider_timeout",
+  "provider_unavailable",
+  "provider_contract_failed",
+  "evidence_unavailable",
+] as const);
+
+export type DataQueryProblemCode = (typeof DATA_QUERY_PROBLEM_CODES)[number];
+
+interface DataQueryProblemDefinition {
+  readonly type: string;
+  readonly title: string;
+  readonly status: 400 | 403 | 408 | 429 | 502 | 503 | 504;
+  readonly detail: string;
+}
+
+const PROBLEM_DEFINITIONS: Readonly<Record<DataQueryProblemCode, DataQueryProblemDefinition>> =
+  Object.freeze({
+    invalid_request: {
+      type: "urn:gis-ai-go:problem:data-query-invalid-request",
+      title: "Invalid data query request",
+      status: 400,
+      detail: "The request must match the reviewed public ONS query.",
+    },
+    query_cancelled: {
+      type: "urn:gis-ai-go:problem:data-query-cancelled",
+      title: "Data query cancelled",
+      status: 408,
+      detail: "The caller cancelled the data query.",
+    },
+    query_deadline_exceeded: {
+      type: "urn:gis-ai-go:problem:data-query-deadline-exceeded",
+      title: "Data query deadline exceeded",
+      status: 408,
+      detail: "The caller deadline elapsed before the data query completed.",
+    },
+    policy_denied: {
+      type: "urn:gis-ai-go:problem:data-query-policy-denied",
+      title: "Data query denied",
+      status: 403,
+      detail: "The public-read policy did not authorise this data query.",
+    },
+    provider_suspended: {
+      type: "urn:gis-ai-go:problem:data-query-provider-suspended",
+      title: "Data provider suspended",
+      status: 503,
+      detail: "The reviewed provider adapter is suspended for invocation.",
+    },
+    provider_rate_limited: {
+      type: "urn:gis-ai-go:problem:data-query-provider-rate-limited",
+      title: "Data provider rate limited",
+      status: 429,
+      detail: "The bounded provider admission limit has been reached.",
+    },
+    provider_timeout: {
+      type: "urn:gis-ai-go:problem:data-query-provider-timeout",
+      title: "Data provider timed out",
+      status: 504,
+      detail: "The provider adapter timed out while caller controls remained active.",
+    },
+    provider_unavailable: {
+      type: "urn:gis-ai-go:problem:data-query-provider-unavailable",
+      title: "Data provider unavailable",
+      status: 503,
+      detail: "The reviewed provider is temporarily unavailable.",
+    },
+    provider_contract_failed: {
+      type: "urn:gis-ai-go:problem:data-query-provider-contract-failed",
+      title: "Data provider response rejected",
+      status: 502,
+      detail: "Provider evidence did not match the reviewed public-read contract.",
+    },
+    evidence_unavailable: {
+      type: "urn:gis-ai-go:problem:data-query-evidence-unavailable",
+      title: "Data query evidence unavailable",
+      status: 503,
+      detail: "Verified evidence could not be completed for this data query.",
+    },
+  });
+
+export interface DataQueryProblem {
+  readonly schema: "gis-ai-go.data-query-problem.v1";
+  readonly type: string;
+  readonly title: string;
+  readonly status: 400 | 403 | 408 | 429 | 502 | 503 | 504;
+  readonly code: DataQueryProblemCode;
+  readonly detail: string;
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly instance?: string;
+}
+
+/** A closed, receipt-free operational failure for the application-only seam. */
+export class DataQueryApplicationError extends Error {
+  public constructor(public readonly problem: DataQueryProblem) {
+    super(problem.title);
+    this.name = "DataQueryApplicationError";
+  }
+}
+
+export interface DataQueryParameters {
+  readonly schema: "gis-ai-go.data-query-parameters.v1";
+  readonly resource_id: typeof PUBLIC_READ_ONS_RESOURCE.resource_id;
+  readonly dataset: {
+    readonly id: "weekly-deaths-region";
+    readonly edition: "time-series";
+    readonly version: "121";
+  };
+  readonly selections: typeof PUBLIC_READ_ONS_RESOURCE.selections;
+  readonly limit: 1;
+}
+
+export const PUBLIC_ONS_DATA_QUERY_PARAMETERS: DataQueryParameters = canonicalJsonClone({
+  schema: "gis-ai-go.data-query-parameters.v1",
+  resource_id: PUBLIC_READ_ONS_RESOURCE.resource_id,
+  dataset: {
+    id: PUBLIC_READ_ONS_RESOURCE.dataset.id,
+    edition: PUBLIC_READ_ONS_RESOURCE.dataset.edition,
+    version: PUBLIC_READ_ONS_RESOURCE.dataset.version,
+  },
+  selections: PUBLIC_READ_ONS_RESOURCE.selections,
+  limit: 1,
+});
+
+export interface DataQueryResultCore {
+  readonly schema: "gis-ai-go.data-query-result.v1";
+  readonly operation: "data.query";
+  readonly request_id: string;
+  readonly trace_id: string;
+  readonly evidence_binding: ReturnType<typeof publicReadResultEvidenceBinding>;
+  readonly data: {
+    readonly status: "succeeded";
+    readonly observations: readonly [{ readonly value: string; readonly unit: null }];
+  };
+  readonly warnings: readonly [];
+}
+
+export interface DataQueryResult extends DataQueryResultCore {
+  readonly evidence_receipt: PublicReadEvidenceReceipt;
+  readonly evidence_storage?: PublicEvidenceStorageReference;
+}
+
+export interface DataQueryInvocationOptions {
+  readonly signal?: AbortSignal;
+  readonly deadline?: string;
+}
+
+export interface DataQueryApplicationOptions {
+  /** Mandatory explicit injection; omission never constructs or activates an adapter. */
+  readonly adapter: OnsDataApiAdapter;
+  readonly software: EvidenceSoftwareIdentity;
+  readonly now?: () => Date;
+  readonly evidenceLedger?: PublicEvidenceLedger;
+}
+
+export interface DataQueryApplication {
+  readonly query: (
+    request: unknown,
+    context: CatalogueProblemContext,
+    options?: DataQueryInvocationOptions,
+  ) => Promise<DataQueryResult>;
+}
+
+interface DataQueryRuntime {
+  readonly adapter: OnsDataApiAdapter;
+  readonly software: EvidenceSoftwareIdentity;
+  readonly now: () => Date;
+  readonly evidenceLedger?: PublicEvidenceLedger;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    utilTypes.isProxy(value)
+  ) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function dataProperties(
+  value: unknown,
+  allowed: readonly string[],
+  required: readonly string[],
+  label: string,
+): Readonly<Record<string, unknown>> {
+  if (!isPlainObject(value)) throw new TypeError(`${label} must be a plain object`);
+  let keys: readonly PropertyKey[];
+  let descriptors: PropertyDescriptorMap;
+  try {
+    keys = Reflect.ownKeys(value);
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch {
+    throw new TypeError(`${label} could not be inspected`);
+  }
+  if (
+    keys.some((key) => typeof key !== "string") ||
+    keys.some((key) => !allowed.includes(key as string)) ||
+    required.some((key) => !Object.hasOwn(descriptors, key))
+  ) {
+    throw new TypeError(`${label} has an unexpected shape`);
+  }
+  for (const descriptor of Object.values(descriptors)) {
+    if (!("value" in descriptor) || descriptor.enumerable !== true) {
+      throw new TypeError(`${label} must use enumerable data properties`);
+    }
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(descriptors).map(([key, descriptor]) => [key, descriptor.value]),
+    ),
+  );
+}
+
+function applicationRuntime(options: DataQueryApplicationOptions): DataQueryRuntime {
+  const values = dataProperties(
+    options,
+    ["adapter", "evidenceLedger", "now", "software"],
+    ["adapter", "software"],
+    "Data query application options",
+  );
+  if (
+    !(values.adapter instanceof OnsDataApiAdapter) ||
+    utilTypes.isProxy(values.adapter)
+  ) {
+    throw new TypeError("Data query application requires an explicitly injected ONS adapter");
+  }
+  let software: EvidenceSoftwareIdentity;
+  try {
+    software = canonicalJsonClone(values.software) as EvidenceSoftwareIdentity;
+  } catch {
+    throw new TypeError("Data query application software identity is invalid");
+  }
+  if (
+    !isPlainObject(software) ||
+    Object.keys(software).sort().join(",") !== "name,revision,version" ||
+    software.name !== "gis-ai-go-mcp-gateway" ||
+    !SEMVER.test(software.version) ||
+    !SHA40.test(software.revision)
+  ) {
+    throw new TypeError("Data query application software identity is invalid");
+  }
+  if (values.now !== undefined && typeof values.now !== "function") {
+    throw new TypeError("Data query application now option must be a function");
+  }
+  if (
+    values.evidenceLedger !== undefined &&
+    (!(values.evidenceLedger instanceof PublicEvidenceLedger) ||
+      utilTypes.isProxy(values.evidenceLedger))
+  ) {
+    throw new TypeError("Data query application evidence ledger is invalid");
+  }
+  const evidenceLedger = values.evidenceLedger as PublicEvidenceLedger | undefined;
+  evidenceLedger?.verify();
+  return Object.freeze({
+    adapter: values.adapter,
+    software,
+    now: (values.now as (() => Date) | undefined) ?? (() => new Date()),
+    ...(evidenceLedger === undefined ? {} : { evidenceLedger }),
+  });
+}
+
+function createDataQueryProblem(
+  code: DataQueryProblemCode,
+  context: CatalogueProblemContext,
+): DataQueryProblem {
+  const definition = PROBLEM_DEFINITIONS[code];
+  return canonicalJsonClone({
+    schema: "gis-ai-go.data-query-problem.v1",
+    ...definition,
+    code,
+    request_id: context.requestId,
+    trace_id: context.traceId,
+    ...(context.instance === undefined ? {} : { instance: context.instance }),
+  });
+}
+
+function fail(code: DataQueryProblemCode, context: CatalogueProblemContext): never {
+  throw new DataQueryApplicationError(createDataQueryProblem(code, context));
+}
+
+function normaliseRequest(
+  request: unknown,
+  context: CatalogueProblemContext,
+): DataQueryParameters {
+  let snapshot: unknown;
+  try {
+    snapshot = canonicalJsonClone(request);
+  } catch {
+    return fail("invalid_request", context);
+  }
+  if (canonicalJson(snapshot) !== canonicalJson(PUBLIC_ONS_DATA_QUERY_PARAMETERS)) {
+    return fail("invalid_request", context);
+  }
+  return snapshot as DataQueryParameters;
+}
+
+function validDeadline(value: string): boolean {
+  if (value.length > 64) return false;
+  const match = DEADLINE.exec(value);
+  if (match === null) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const offsetHour = match[8] === undefined ? 0 : Number(match[8]);
+  const offsetMinute = match[9] === undefined ? 0 : Number(match[9]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const monthDays = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return (
+    year >= 1 &&
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= monthDays[month - 1]! &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59 &&
+    offsetHour <= 23 &&
+    offsetMinute <= 59 &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function invocationOptions(
+  options: DataQueryInvocationOptions | undefined,
+  context: CatalogueProblemContext,
+): DataQueryInvocationOptions {
+  if (options === undefined) return Object.freeze({});
+  let values: Readonly<Record<string, unknown>>;
+  try {
+    values = dataProperties(options, ["deadline", "signal"], [], "Data query invocation options");
+  } catch {
+    return fail("invalid_request", context);
+  }
+  if (
+    values.signal !== undefined &&
+    (!(values.signal instanceof AbortSignal) || utilTypes.isProxy(values.signal))
+  ) {
+    return fail("invalid_request", context);
+  }
+  if (
+    values.deadline !== undefined &&
+    (typeof values.deadline !== "string" || !validDeadline(values.deadline))
+  ) {
+    return fail("invalid_request", context);
+  }
+  return Object.freeze({
+    ...(values.signal === undefined ? {} : { signal: values.signal as AbortSignal }),
+    ...(values.deadline === undefined ? {} : { deadline: values.deadline as string }),
+  });
+}
+
+function trustedNowMilliseconds(
+  runtime: DataQueryRuntime,
+  context: CatalogueProblemContext,
+): number {
+  let current: unknown;
+  try {
+    current = runtime.now();
+  } catch {
+    return fail("evidence_unavailable", context);
+  }
+  if (!(current instanceof Date) || utilTypes.isProxy(current)) {
+    return fail("evidence_unavailable", context);
+  }
+  let milliseconds: number;
+  try {
+    milliseconds = Date.prototype.getTime.call(current);
+  } catch {
+    return fail("evidence_unavailable", context);
+  }
+  if (!Number.isFinite(milliseconds)) return fail("evidence_unavailable", context);
+  return milliseconds;
+}
+
+function signalIsAborted(
+  signal: AbortSignal,
+  context: CatalogueProblemContext,
+): boolean {
+  try {
+    return Reflect.get(AbortSignal.prototype, "aborted", signal) === true;
+  } catch {
+    return fail("invalid_request", context);
+  }
+}
+
+function assertInvocationControls(
+  runtime: DataQueryRuntime,
+  invocation: DataQueryInvocationOptions,
+  context: CatalogueProblemContext,
+): void {
+  if (invocation.signal !== undefined && signalIsAborted(invocation.signal, context)) {
+    fail("query_cancelled", context);
+  }
+  if (
+    invocation.deadline !== undefined &&
+    trustedNowMilliseconds(runtime, context) >= Date.parse(invocation.deadline)
+  ) {
+    fail("query_deadline_exceeded", context);
+  }
+}
+
+function sameCanonical(left: unknown, right: unknown): boolean {
+  try {
+    return canonicalJson(left) === canonicalJson(right);
+  } catch {
+    return false;
+  }
+}
+
+function expectedRights(): ProviderRights {
+  const rights = PUBLIC_READ_ONS_RESOURCE.rights;
+  return canonicalJsonClone({
+    state: rights.state,
+    licence: rights.licence,
+    licenceUri: rights.licence_uri,
+    attribution: rights.attribution,
+    obligations: rights.obligations,
+    exceptions: rights.exceptions,
+    evidenceUris: rights.evidence_uris,
+    reviewedAt: rights.reviewed_at,
+  });
+}
+
+function expectedProvenance(): ProviderAdapterProvenance {
+  const resource = PUBLIC_READ_ONS_RESOURCE;
+  return canonicalJsonClone({
+    providerVersion: {
+      providerId: resource.provider.id,
+      datasetId: resource.dataset.id,
+      edition: resource.dataset.edition,
+      version: resource.dataset.version,
+      versionUri: resource.dataset.version_uri,
+      sourceDate: resource.dataset.source_date,
+      dimensionOrder: resource.dataset.dimension_order,
+    },
+    adapter: {
+      id: resource.provider.adapter_id,
+      version: resource.provider.adapter_version,
+    },
+    transformations: [
+      "ons-cmd-single-observation.v1",
+      "provider-native-identifiers-preserved.v1",
+      "untrusted-provider-links-validated-and-omitted.v1",
+      "rfc8785-canonical-json.v1",
+    ],
+    synthetic: false,
+    sourceUri: ONS_OBSERVATION_URI,
+  });
+}
+
+function expectedEstimate(): ProviderAdapterEstimate {
+  const limits = PUBLIC_READ_ONS_RESOURCE.limits;
+  return canonicalJsonClone({
+    confidence: "upper-bound",
+    maxObservations: limits.max_observations,
+    maxAttempts: limits.max_attempts,
+    maxCompressedResponseBytes: limits.max_compressed_response_bytes,
+    maxDecompressedResponseBytes: limits.max_decompressed_response_bytes,
+    maxCanonicalResponseBytes: limits.max_canonical_response_bytes,
+  });
+}
+
+function mapAdapterCode(code: AdapterErrorCode): DataQueryProblemCode {
+  switch (code) {
+    case "ADAPTER_INVOCATION_SUSPENDED":
+      return "provider_suspended";
+    case "PROVIDER_RATE_LIMITED":
+      return "provider_rate_limited";
+    case "PROVIDER_TIMEOUT":
+      return "provider_timeout";
+    case "PROVIDER_OUTAGE":
+      return "provider_unavailable";
+    case "ADAPTER_DISCOVERY_SUSPENDED":
+    case "INCOMPATIBLE_OPERATION":
+    case "INVALID_REQUEST":
+    case "MALFORMED_PROVIDER_RESPONSE":
+    case "RIGHTS_UNKNOWN":
+    case "STALE_PROVIDER_VERSION":
+      return "provider_contract_failed";
+  }
+}
+
+function failAdapter(
+  adapter: OnsDataApiAdapter,
+  error: unknown,
+  context: CatalogueProblemContext,
+): never {
+  const trusted = normaliseAdapterError(error);
+  let candidateValue: unknown;
+  try {
+    candidateValue = canonicalJsonClone(adapter.normalise_error(error));
+  } catch {
+    return fail("provider_contract_failed", context);
+  }
+  if (
+    !isPlainObject(candidateValue) ||
+    Object.keys(candidateValue).sort().join(",") !==
+      "code,message,providerStatus,retryable"
+  ) {
+    return fail("provider_contract_failed", context);
+  }
+  const candidate = candidateValue as unknown as NormalisedAdapterError;
+  if (
+    !(ADAPTER_ERROR_CODES as readonly string[]).includes(candidate.code) ||
+    !sameCanonical(candidate, trusted)
+  ) {
+    return fail("provider_contract_failed", context);
+  }
+  return fail(mapAdapterCode(trusted.code), context);
+}
+
+function assertHealth(
+  health: unknown,
+  context: CatalogueProblemContext,
+): void {
+  if (!isPlainObject(health)) fail("provider_contract_failed", context);
+  const keys = Object.keys(health).sort();
+  if (
+    keys.join(",") !== "adapterId,discovery,invocation,network" ||
+    health.adapterId !== ONS_ADAPTER_ID ||
+    (health.discovery !== "active" && health.discovery !== "suspended") ||
+    (health.invocation !== "active" && health.invocation !== "suspended") ||
+    health.network !== "not-checked"
+  ) {
+    fail("provider_contract_failed", context);
+  }
+  if (health.invocation !== "active") fail("provider_suspended", context);
+}
+
+function adapterEvidence<T>(
+  adapter: OnsDataApiAdapter,
+  read: () => unknown,
+  context: CatalogueProblemContext,
+): T {
+  let value: unknown;
+  try {
+    value = read();
+  } catch (error) {
+    return failAdapter(adapter, error, context);
+  }
+  try {
+    return canonicalJsonClone(value) as T;
+  } catch {
+    return fail("provider_contract_failed", context);
+  }
+}
+
+function preflightAdapter(
+  adapter: OnsDataApiAdapter,
+  context: CatalogueProblemContext,
+): { readonly rights: ProviderRights; readonly provenance: ProviderAdapterProvenance } {
+  const health = adapterEvidence<AdapterHealth>(adapter, () => adapter.health(), context);
+  assertHealth(health, context);
+  const estimate = adapterEvidence<ProviderAdapterEstimate>(
+    adapter,
+    () => adapter.estimate(ONS_ADAPTER_REQUEST),
+    context,
+  );
+  const rights = adapterEvidence<ProviderRights>(
+    adapter,
+    () => adapter.licence_evidence(),
+    context,
+  );
+  const provenance = adapterEvidence<ProviderAdapterProvenance>(
+    adapter,
+    () => adapter.provenance(),
+    context,
+  );
+  if (
+    !sameCanonical(estimate, expectedEstimate()) ||
+    !sameCanonical(rights, expectedRights()) ||
+    !sameCanonical(provenance, expectedProvenance())
+  ) {
+    fail("provider_contract_failed", context);
+  }
+  return Object.freeze({ rights, provenance });
+}
+
+function validateAdapterResult(
+  value: unknown,
+  checked: { readonly rights: ProviderRights; readonly provenance: ProviderAdapterProvenance },
+  context: CatalogueProblemContext,
+): ProviderAdapterResult {
+  let result: ProviderAdapterResult;
+  try {
+    result = canonicalJsonClone(value) as ProviderAdapterResult;
+  } catch {
+    return fail("provider_contract_failed", context);
+  }
+  if (
+    new TextEncoder().encode(canonicalJson(result)).byteLength >
+    PUBLIC_READ_ONS_RESOURCE.limits.max_canonical_response_bytes
+  ) {
+    return fail("provider_contract_failed", context);
+  }
+  if (
+    !isPlainObject(result) ||
+    !Array.isArray(result.observations) ||
+    result.observations.length !== 1 ||
+    !isPlainObject(result.observations[0])
+  ) {
+    return fail("provider_contract_failed", context);
+  }
+  const observation = result.observations[0];
+  const observationValue = observation?.value;
+  if (
+    observation === undefined ||
+    Object.keys(observation).sort().join(",") !== "metadata,unit,value" ||
+    typeof observationValue !== "string" ||
+    !NUMERIC_OBSERVATION.test(observationValue) ||
+    observation.unit !== null
+  ) {
+    return fail("provider_contract_failed", context);
+  }
+  const expected: ProviderAdapterResult = canonicalJsonClone({
+    schema: "gis-ai-go.provider-adapter-result.v1",
+    provider: {
+      id: PUBLIC_READ_ONS_RESOURCE.provider.id,
+      adapterId: PUBLIC_READ_ONS_RESOURCE.provider.adapter_id,
+    },
+    dataset: {
+      id: PUBLIC_READ_ONS_RESOURCE.dataset.id,
+      edition: PUBLIC_READ_ONS_RESOURCE.dataset.edition,
+      version: PUBLIC_READ_ONS_RESOURCE.dataset.version,
+      versionUri: PUBLIC_READ_ONS_RESOURCE.dataset.version_uri,
+    },
+    dimensions: PUBLIC_READ_ONS_RESOURCE.selections,
+    observations: [
+      {
+        value: observationValue,
+        unit: null,
+        metadata: [{ name: "Data Marking", value: "" }],
+      },
+    ],
+    rights: checked.rights,
+    provenance: checked.provenance,
+  });
+  if (!sameCanonical(result, expected)) return fail("provider_contract_failed", context);
+  return result;
+}
+
+function receiptTimestamp(runtime: DataQueryRuntime, context: CatalogueProblemContext): string {
+  return new Date(trustedNowMilliseconds(runtime, context)).toISOString();
+}
+
+async function query(
+  runtime: DataQueryRuntime,
+  requestValue: unknown,
+  context: CatalogueProblemContext,
+  invocationValue: DataQueryInvocationOptions | undefined,
+): Promise<DataQueryResult> {
+  assertCatalogueProblemContext(context);
+  const request = normaliseRequest(requestValue, context);
+  const invocation = invocationOptions(invocationValue, context);
+  assertInvocationControls(runtime, invocation, context);
+
+  let policyEvaluation: ReturnType<typeof evaluatePublicReadPolicy>;
+  try {
+    policyEvaluation = evaluatePublicReadPolicy({
+      requestId: context.requestId,
+      traceId: context.traceId,
+      operation: "data.query",
+      resource: PUBLIC_READ_ONS_RESOURCE,
+    });
+  } catch {
+    return fail("policy_denied", context);
+  }
+  if (
+    !isAllowedPublicReadOperation(policyEvaluation, "data.query") ||
+    !verifyPublicReadAuthorityContext(policyEvaluation.authorityContext) ||
+    !verifyPublicReadPolicy(policyEvaluation.policy) ||
+    !verifyPublicReadPolicyDecision(policyEvaluation.decision) ||
+    !verifyPublicReadResource(PUBLIC_READ_ONS_RESOURCE)
+  ) {
+    return fail("policy_denied", context);
+  }
+
+  assertInvocationControls(runtime, invocation, context);
+  const checked = preflightAdapter(runtime.adapter, context);
+  assertInvocationControls(runtime, invocation, context);
+  let adapterResult: ProviderAdapterResult;
+  try {
+    adapterResult = await runtime.adapter.execute(ONS_ADAPTER_REQUEST, invocation);
+  } catch (error) {
+    assertInvocationControls(runtime, invocation, context);
+    return failAdapter(runtime.adapter, error, context);
+  }
+  assertInvocationControls(runtime, invocation, context);
+  const result = validateAdapterResult(adapterResult, checked, context);
+  const resultCore: DataQueryResultCore = canonicalJsonClone({
+    schema: "gis-ai-go.data-query-result.v1",
+    operation: "data.query",
+    request_id: context.requestId,
+    trace_id: context.traceId,
+    evidence_binding: publicReadResultEvidenceBinding(PUBLIC_READ_ONS_RESOURCE),
+    data: {
+      status: "succeeded",
+      observations: [{ value: result.observations[0]!.value, unit: null }],
+    },
+    warnings: [],
+  });
+
+  const verificationMaterial = {
+    normalisedParameters: request,
+    resultCore,
+    publicPolicy: policyEvaluation.policy,
+    expectedAuthorityContext: policyEvaluation.authorityContext,
+    expectedPolicyDecision: policyEvaluation.decision,
+    expectedResource: PUBLIC_READ_ONS_RESOURCE,
+    expectedSoftware: runtime.software,
+  } as const;
+  let receipt: PublicReadEvidenceReceipt;
+  let evidenceStorage: PublicEvidenceStorageReference | undefined;
+  try {
+    receipt = buildPublicReadReceipt({
+      createdAt: receiptTimestamp(runtime, context),
+      requestId: context.requestId,
+      traceId: context.traceId,
+      operation: "data.query",
+      normalisedParameters: request,
+      authorityContext: policyEvaluation.authorityContext,
+      publicPolicy: policyEvaluation.policy,
+      policyDecision: policyEvaluation.decision,
+      resource: PUBLIC_READ_ONS_RESOURCE,
+      transformations: [
+        { name: "normalise-public-read-parameters", version: "v1" },
+        { name: "execute-fixed-provider-query", version: "v1" },
+        { name: "project-public-read-result-core", version: "v1" },
+      ],
+      software: runtime.software,
+      resultCore,
+    });
+    const verification = verifyPublicReadReceipt(receipt, verificationMaterial);
+    if (!verification.valid) return fail("evidence_unavailable", context);
+    evidenceStorage = runtime.evidenceLedger?.persistReceipt(
+      receipt,
+      verificationMaterial,
+    ).reference;
+  } catch (error) {
+    if (error instanceof DataQueryApplicationError) throw error;
+    return fail("evidence_unavailable", context);
+  }
+
+  return canonicalJsonClone({
+    ...resultCore,
+    evidence_receipt: receipt,
+    ...(evidenceStorage === undefined ? {} : { evidence_storage: evidenceStorage }),
+  });
+}
+
+/**
+ * Create the inactive transport-neutral data.query application.
+ *
+ * It has no default adapter and no environment activation seam. Discovery state
+ * is deliberately ignored: only an explicitly injected, invocation-active ONS
+ * adapter can execute the fixed reviewed request.
+ */
+export function createDataQueryApplication(
+  options: DataQueryApplicationOptions,
+): DataQueryApplication {
+  const runtime = applicationRuntime(options);
+  return Object.freeze({
+    query: (
+      request: unknown,
+      context: CatalogueProblemContext,
+      invocation?: DataQueryInvocationOptions,
+    ) => query(runtime, request, context, invocation),
+  });
+}

--- a/apps/mcp-gateway/src/index.ts
+++ b/apps/mcp-gateway/src/index.ts
@@ -2,6 +2,7 @@ export * from "./activation.js";
 export * from "./catalogue-application.js";
 export * from "./catalogue-snapshot.js";
 export * from "./cursor.js";
+export * from "./data-query-application.js";
 export * from "./evidence-application.js";
 export * from "./execution-envelope.js";
 export * from "./http-app.js";

--- a/apps/mcp-gateway/test/data-query-application.test.ts
+++ b/apps/mcp-gateway/test/data-query-application.test.ts
@@ -1,0 +1,810 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  PUBLIC_READ_ONS_RESOURCE,
+  PublicEvidenceLedger,
+  canonicalJson,
+  verifyPublicReadReceipt,
+} from "@gis-ai-go/evidence";
+import {
+  ONS_ADAPTER_REQUEST,
+  ONS_EGRESS_POLICY,
+  OnsDataApiAdapter,
+  ProviderAdapterFault,
+  type AdapterLifecycle,
+  type FixedHttpsResponse,
+  type FixedHttpsTransport,
+  type ProviderAdapterExecutionOptions,
+  type ProviderAdapterQuery,
+  type ProviderAdapterResult,
+} from "@gis-ai-go/provider-adapter-sdk";
+import { PUBLIC_READ_POLICY } from "@gis-ai-go/policy-client";
+
+import {
+  DataQueryApplicationError,
+  PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+  createDataQueryApplication,
+  type DataQueryApplicationOptions,
+  type DataQueryProblemCode,
+} from "../src/data-query-application.js";
+
+const SOFTWARE = Object.freeze({
+  name: "gis-ai-go-mcp-gateway",
+  version: "0.1.0",
+  revision: "e1fc1cbe69ea72c9aa310607d80f392ef56b0d58",
+} as const);
+
+const CONTEXT = Object.freeze({
+  requestId: "request-data-query-application-1",
+  traceId: "7123456789abcdef0123456789abcdef",
+  instance: "/data/query",
+} as const);
+
+const ACTIVE_INVOCATION = Object.freeze({
+  discovery: "suspended",
+  invocation: "active",
+  reason: "Explicit application-only data query test.",
+} as const);
+
+const VALID_PAYLOAD = Object.freeze({
+  dimensions: {
+    causeofdeath: {
+      option: {
+        href: "http://api.beta.ons.gov.uk/v1/code-lists/cause-of-death/codes/all-causes",
+        id: "all-causes",
+      },
+    },
+    geography: {
+      option: {
+        href:
+          "http://api.beta.ons.gov.uk/v1/code-lists/administrative-geography/codes/E92000001",
+        id: "E92000001",
+      },
+    },
+    time: {
+      option: {
+        href: "http://api.beta.ons.gov.uk/v1/code-lists/calendar-years/codes/2026",
+        id: "2026",
+      },
+    },
+    week: {
+      option: {
+        href: "http://api.beta.ons.gov.uk/v1/code-lists/week-number/codes/week-24",
+        id: "week-24",
+      },
+    },
+  },
+  limit: 10_000,
+  links: {
+    dataset_metadata: {
+      href:
+        "http://api.beta.ons.gov.uk/v1/datasets/weekly-deaths-region/" +
+        "editions/time-series/versions/121/metadata",
+    },
+    self: {
+      href:
+        "http://api.beta.ons.gov.uk/v1/datasets/weekly-deaths-region/" +
+        "editions/time-series/versions/121/observations?causeofdeath=all-causes&" +
+        "geography=E92000001&time=2026&week=week-24",
+    },
+    version: {
+      href:
+        "http://api.beta.ons.gov.uk/v1/datasets/weekly-deaths-region/" +
+        "editions/time-series/versions/121",
+      id: "121",
+    },
+  },
+  observations: [{ metadata: { "Data Marking": "" }, observation: "10471" }],
+  offset: 0,
+  total_observations: 1,
+});
+
+function mutable<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function response(payload: unknown = VALID_PAYLOAD): FixedHttpsResponse {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  return {
+    status: 200,
+    headers: Object.freeze({ "content-type": "application/json" }),
+    body,
+    telemetry: Object.freeze({
+      dnsMs: 1,
+      resolvedAddressCount: 1,
+      selectedAddressFamily: 4,
+      connectMs: 2,
+      responseMs: 3,
+      totalMs: 6,
+      compressedBytes: body.byteLength,
+      tlsProtocol: "TLSv1.3",
+      tlsCipher: "TLS_AES_256_GCM_SHA384",
+    }),
+  };
+}
+
+function transport(
+  calls: { count: number; urls: string[] },
+  payload: unknown = VALID_PAYLOAD,
+): FixedHttpsTransport {
+  return async ({ policy, url }) => {
+    calls.count += 1;
+    calls.urls.push(url);
+    assert.equal(policy, ONS_EGRESS_POLICY);
+    return response(payload);
+  };
+}
+
+function adapter(
+  calls: { count: number; urls: string[] } = { count: 0, urls: [] },
+  lifecycle: AdapterLifecycle = ACTIVE_INVOCATION,
+): OnsDataApiAdapter {
+  return new OnsDataApiAdapter({
+    lifecycle,
+    transport: transport(calls),
+    now: () => Date.parse("2030-01-01T00:00:00Z"),
+  });
+}
+
+function application(
+  injected: OnsDataApiAdapter,
+  options: Partial<Omit<DataQueryApplicationOptions, "adapter" | "software">> = {},
+) {
+  return createDataQueryApplication({
+    adapter: injected,
+    software: SOFTWARE,
+    now: () => new Date("2026-08-21T01:00:00.000Z"),
+    ...options,
+  });
+}
+
+async function expectProblem(
+  run: () => Promise<unknown>,
+  code: DataQueryProblemCode,
+): Promise<DataQueryApplicationError> {
+  let captured: DataQueryApplicationError | undefined;
+  await assert.rejects(run, (error: unknown) => {
+    assert.ok(error instanceof DataQueryApplicationError);
+    assert.equal(error.problem.code, code);
+    assert.equal(error.problem.schema, "gis-ai-go.data-query-problem.v1");
+    const serialised = canonicalJson(error.problem);
+    assert.equal(serialised.includes("receipt"), false);
+    assert.equal(serialised.includes("providerStatus"), false);
+    assert.equal(serialised.includes("stack"), false);
+    captured = error;
+    return true;
+  });
+  assert.ok(captured);
+  return captured;
+}
+
+function validAdapterResult(injected: OnsDataApiAdapter): ProviderAdapterResult {
+  return {
+    schema: "gis-ai-go.provider-adapter-result.v1",
+    provider: {
+      id: PUBLIC_READ_ONS_RESOURCE.provider.id,
+      adapterId: PUBLIC_READ_ONS_RESOURCE.provider.adapter_id,
+    },
+    dataset: {
+      id: PUBLIC_READ_ONS_RESOURCE.dataset.id,
+      edition: PUBLIC_READ_ONS_RESOURCE.dataset.edition,
+      version: PUBLIC_READ_ONS_RESOURCE.dataset.version,
+      versionUri: PUBLIC_READ_ONS_RESOURCE.dataset.version_uri,
+    },
+    dimensions: PUBLIC_READ_ONS_RESOURCE.selections,
+    observations: [
+      {
+        value: "10471",
+        unit: null,
+        metadata: [{ name: "Data Marking", value: "" }],
+      },
+    ],
+    rights: injected.licence_evidence(),
+    provenance: injected.provenance(),
+  };
+}
+
+test("requires an explicitly injected exact ONS adapter and closed options", () => {
+  assert.throws(
+    () =>
+      createDataQueryApplication({ software: SOFTWARE } as unknown as DataQueryApplicationOptions),
+    /unexpected shape/u,
+  );
+  assert.throws(
+    () =>
+      createDataQueryApplication({
+        adapter: {} as OnsDataApiAdapter,
+        software: SOFTWARE,
+      }),
+    /explicitly injected ONS adapter/u,
+  );
+  assert.throws(
+    () =>
+      createDataQueryApplication({
+        adapter: adapter(),
+        software: SOFTWARE,
+        unexpected: true,
+      } as unknown as DataQueryApplicationOptions),
+    /unexpected shape/u,
+  );
+});
+
+test("executes one fixed query with discovery suspended and verified evidence", async () => {
+  const calls = { count: 0, urls: [] as string[] };
+  const injected = adapter(calls);
+  const result = await application(injected).query(
+    mutable(PUBLIC_ONS_DATA_QUERY_PARAMETERS),
+    CONTEXT,
+  );
+  assert.equal(calls.count, 1);
+  assert.deepEqual(calls.urls, [
+    "https://api.beta.ons.gov.uk/v1/datasets/weekly-deaths-region/" +
+      "editions/time-series/versions/121/observations?time=2026&" +
+      "geography=E92000001&week=week-24&causeofdeath=all-causes",
+  ]);
+  assert.deepEqual(result.data, {
+    status: "succeeded",
+    observations: [{ value: "10471", unit: null }],
+  });
+  assert.equal(result.evidence_receipt.operation.name, "data.query");
+  assert.equal(result.evidence_receipt.resource.resource_id, PUBLIC_READ_ONS_RESOURCE.resource_id);
+  assert.equal(result.evidence_receipt.resource.dataset.dimension_order[1], "geography");
+  assert.equal(result.evidence_receipt.resource.rights.licence, "Open Government Licence v3.0");
+  assert.equal(result.evidence_storage, undefined);
+  const core = {
+    schema: result.schema,
+    operation: result.operation,
+    request_id: result.request_id,
+    trace_id: result.trace_id,
+    evidence_binding: result.evidence_binding,
+    data: result.data,
+    warnings: result.warnings,
+  };
+  assert.equal(
+    verifyPublicReadReceipt(result.evidence_receipt, {
+      normalisedParameters: PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+      resultCore: core,
+      publicPolicy: PUBLIC_READ_POLICY,
+      expectedAuthorityContext: result.evidence_receipt.authority_context,
+      expectedPolicyDecision: result.evidence_receipt.policy_decision,
+      expectedResource: PUBLIC_READ_ONS_RESOURCE,
+      expectedSoftware: SOFTWARE,
+    }).valid,
+    true,
+  );
+  assert.equal(Object.isFrozen(result), true);
+});
+
+test("reproduces the promoted successful application fixture", async () => {
+  const fixture = JSON.parse(
+    readFileSync(
+      new URL("../../../../providers/fixtures/data-query-result.example.json", import.meta.url),
+      "utf8",
+    ),
+  ) as Record<string, unknown>;
+  const result = await application(adapter()).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, {
+    requestId: "request-data-query-example-1",
+    traceId: "8123456789abcdef0123456789abcdef",
+  });
+  assert.deepEqual(result, fixture);
+});
+
+test("keeps discovery and invocation lifecycle planes independent", async (context) => {
+  const invocationCalls = { count: 0, urls: [] as string[] };
+  const invocationOnly = adapter(invocationCalls, {
+    discovery: "suspended",
+    invocation: "active",
+    reason: "Invocation-only application test.",
+  });
+  assert.equal(
+    (
+      await application(invocationOnly).query(
+        PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+        CONTEXT,
+      )
+    ).data.status,
+    "succeeded",
+  );
+  assert.equal(invocationCalls.count, 1);
+
+  const discoveryCalls = { count: 0, urls: [] as string[] };
+  const discoveryOnly = adapter(discoveryCalls, {
+    discovery: "active",
+    invocation: "suspended",
+    reason: "Discovery cannot authorise invocation.",
+  });
+  let discoveryOnlyEstimates = 0;
+  context.mock.method(discoveryOnly, "estimate", () => {
+    discoveryOnlyEstimates += 1;
+    throw new Error("estimate must not run while invocation is suspended");
+  });
+  await expectProblem(
+    () => application(discoveryOnly).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+    "provider_suspended",
+  );
+  assert.equal(discoveryCalls.count, 0);
+  assert.equal(discoveryOnlyEstimates, 0);
+
+  const suspendedCalls = { count: 0, urls: [] as string[] };
+  const suspended = adapter(suspendedCalls, {
+    discovery: "suspended",
+    invocation: "suspended",
+    reason: "Both planes suspended.",
+  });
+  await expectProblem(
+    () => application(suspended).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+    "provider_suspended",
+  );
+  assert.equal(suspendedCalls.count, 0);
+});
+
+test("orders every adapter check before the single execute call", async (context) => {
+  const injected = adapter();
+  const order: string[] = [];
+  const originalHealth = injected.health.bind(injected);
+  const originalEstimate = injected.estimate.bind(injected);
+  const originalRights = injected.licence_evidence.bind(injected);
+  const originalProvenance = injected.provenance.bind(injected);
+  const result = validAdapterResult(injected);
+  context.mock.method(injected, "health", () => {
+    order.push("health");
+    return originalHealth();
+  });
+  context.mock.method(injected, "estimate", (request: unknown) => {
+    order.push("estimate");
+    return originalEstimate(request);
+  });
+  context.mock.method(injected, "licence_evidence", () => {
+    order.push("rights");
+    return originalRights();
+  });
+  context.mock.method(injected, "provenance", () => {
+    order.push("provenance");
+    return originalProvenance();
+  });
+  context.mock.method(injected, "execute", async () => {
+    order.push("execute");
+    return result;
+  });
+  await application(injected).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT);
+  assert.deepEqual(order, ["health", "estimate", "rights", "provenance", "execute"]);
+});
+
+test("rejects every deviation from the exact five-key request before execution", async () => {
+  const calls = { count: 0, urls: [] as string[] };
+  const run = application(adapter(calls));
+  const cases: unknown[] = [
+    {},
+    { ...PUBLIC_ONS_DATA_QUERY_PARAMETERS, limit: 2 },
+    { ...PUBLIC_ONS_DATA_QUERY_PARAMETERS, url: "https://example.invalid" },
+    {
+      ...PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+      dataset: { ...PUBLIC_ONS_DATA_QUERY_PARAMETERS.dataset, version: "latest" },
+    },
+    {
+      ...PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+      selections: [...PUBLIC_ONS_DATA_QUERY_PARAMETERS.selections].reverse(),
+    },
+  ];
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  cases.push(cyclic);
+  const accessor = {};
+  Object.defineProperty(accessor, "schema", { enumerable: true, get: () => "secret" });
+  cases.push(accessor);
+  cases.push(new Proxy(mutable(PUBLIC_ONS_DATA_QUERY_PARAMETERS), {}));
+  for (const candidate of cases) {
+    await expectProblem(() => run.query(candidate, CONTEXT), "invalid_request");
+  }
+  assert.equal(calls.count, 0);
+});
+
+test("checks health, estimate, rights and provenance before execute", async (context) => {
+  for (const field of ["health", "estimate", "licence_evidence", "provenance"] as const) {
+    const injected = adapter();
+    const originalHealth = injected.health();
+    let executions = 0;
+    context.mock.method(injected, "execute", async () => {
+      executions += 1;
+      return validAdapterResult(injected);
+    });
+    if (field === "health") {
+      context.mock.method(injected, field, () => ({
+        ...originalHealth,
+        adapterId: "another-adapter",
+      }));
+    } else if (field === "estimate") {
+      context.mock.method(injected, field, () => ({
+        confidence: "upper-bound",
+        maxObservations: 2,
+        maxAttempts: 2,
+        maxCompressedResponseBytes: 262_144,
+        maxDecompressedResponseBytes: 1_048_576,
+        maxCanonicalResponseBytes: 262_144,
+      }));
+    } else if (field === "licence_evidence") {
+      const rights = mutable(injected.licence_evidence());
+      (rights as { licence: string }).licence = "Unknown";
+      context.mock.method(injected, field, () => rights);
+    } else {
+      const provenance = mutable(injected.provenance());
+      (provenance.providerVersion as { version: string }).version = "latest";
+      context.mock.method(injected, field, () => provenance);
+    }
+    await expectProblem(
+      () => application(injected).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+      "provider_contract_failed",
+    );
+    assert.equal(executions, 0, `${field} drift must fail before execute`);
+    context.mock.reset();
+  }
+
+  const malformedHealth = adapter();
+  let malformedExecutions = 0;
+  context.mock.method(malformedHealth, "health", () => null as never);
+  context.mock.method(malformedHealth, "execute", async () => {
+    malformedExecutions += 1;
+    return validAdapterResult(malformedHealth);
+  });
+  await expectProblem(
+    () => application(malformedHealth).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+    "provider_contract_failed",
+  );
+  assert.equal(malformedExecutions, 0);
+});
+
+test("independently rejects result and evidence drift", async (context) => {
+  const mutations: readonly ((result: ProviderAdapterResult) => void)[] = [
+    (result) => {
+      (result.provider as { id: string }).id = "other-provider";
+    },
+    (result) => {
+      (result.dataset as { version: string }).version = "latest";
+    },
+    (result) => {
+      (result.dimensions as { dimension: string; option: string }[]).reverse();
+    },
+    (result) => {
+      (result.rights as { licence: string }).licence = "Unknown";
+    },
+    (result) => {
+      (result.observations[0] as { value: string }).value = "10.5";
+    },
+    (result) => {
+      (result.observations[0] as { unit: string | null }).unit = "deaths";
+    },
+    (result) => {
+      (result.observations as unknown as Array<{ value: string; unit: null }>)[0] = {
+        value: "10471",
+        unit: null,
+      };
+    },
+  ];
+  for (const mutate of mutations) {
+    const injected = adapter();
+    const candidate = mutable(validAdapterResult(injected));
+    mutate(candidate);
+    let executions = 0;
+    context.mock.method(injected, "execute", async () => {
+      executions += 1;
+      return candidate;
+    });
+    await expectProblem(
+      () => application(injected).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+      "provider_contract_failed",
+    );
+    assert.equal(executions, 1);
+    context.mock.reset();
+  }
+});
+
+test("maps malformed adapter return shapes to a closed contract problem", async (context) => {
+  for (const candidate of [null, {}, [], "10471"]) {
+    const injected = adapter();
+    context.mock.method(injected, "execute", async () => candidate as never);
+    await expectProblem(
+      () => application(injected).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+      "provider_contract_failed",
+    );
+    context.mock.reset();
+  }
+});
+
+test("maps adapter failures to fixed non-reflective receipt-free problems", async (context) => {
+  const mappings: readonly [unknown, DataQueryProblemCode][] = [
+    [
+      new ProviderAdapterFault("PROVIDER_RATE_LIMITED", { providerStatus: 429 }),
+      "provider_rate_limited",
+    ],
+    [new ProviderAdapterFault("PROVIDER_TIMEOUT"), "provider_timeout"],
+    [new ProviderAdapterFault("PROVIDER_OUTAGE", { providerStatus: 503 }), "provider_unavailable"],
+    [new ProviderAdapterFault("MALFORMED_PROVIDER_RESPONSE"), "provider_contract_failed"],
+    [new ProviderAdapterFault("RIGHTS_UNKNOWN"), "provider_contract_failed"],
+    [new ProviderAdapterFault("STALE_PROVIDER_VERSION"), "provider_contract_failed"],
+    [new Error("Bearer secret-token at provider-internal-location"), "provider_unavailable"],
+  ];
+  for (const [thrown, expected] of mappings) {
+    const injected = adapter();
+    context.mock.method(injected, "execute", async () => {
+      throw thrown;
+    });
+    const error = await expectProblem(
+      () => application(injected).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT),
+      expected,
+    );
+    const problem = canonicalJson(error.problem);
+    assert.equal(problem.includes("secret-token"), false);
+    assert.equal(problem.includes("provider-internal-location"), false);
+    assert.equal(problem.includes("MALFORMED_PROVIDER_RESPONSE"), false);
+    context.mock.reset();
+  }
+});
+
+test("propagates live controls and keeps an adapter-local timeout at 504", async (context) => {
+  const injected = adapter();
+  const signal = new AbortController().signal;
+  const deadline = "2030-01-01T00:00:10Z";
+  let observedRequest: unknown;
+  let observedOptions: unknown;
+  let executions = 0;
+  context.mock.method(injected, "execute", async (
+    requestValue: unknown,
+    options?: ProviderAdapterExecutionOptions,
+  ) => {
+    executions += 1;
+    observedRequest = requestValue;
+    observedOptions = options;
+    throw new ProviderAdapterFault("PROVIDER_TIMEOUT");
+  });
+  const timeout = await expectProblem(
+    () =>
+      application(injected).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+        signal,
+        deadline,
+      }),
+    "provider_timeout",
+  );
+  assert.equal(timeout.problem.status, 504);
+  assert.equal(executions, 1);
+  assert.equal(observedRequest, ONS_ADAPTER_REQUEST);
+  assert.deepEqual(observedOptions, { signal, deadline });
+  assert.equal(signal.aborted, false);
+});
+
+test("rejects invalid and unknown controls before execution", async () => {
+  const calls = { count: 0, urls: [] as string[] };
+  const injected = adapter(calls);
+  const run = application(injected);
+  await expectProblem(
+    () =>
+      run.query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+        deadline: "not-a-deadline",
+      }),
+    "invalid_request",
+  );
+  await expectProblem(
+    () =>
+      run.query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+        unexpected: true,
+      } as unknown as { deadline: string }),
+    "invalid_request",
+  );
+  assert.equal(calls.count, 0);
+});
+
+test("attributes ended controls before policy, adapter checks or evidence", async (context) => {
+  const directory = mkdtempSync(join(tmpdir(), "gis-ai-go-data-query-controls-"));
+  try {
+    const ledger = PublicEvidenceLedger.open({ rootDirectory: directory });
+    let evidenceWrites = 0;
+    context.mock.method(ledger, "persistReceipt", () => {
+      evidenceWrites += 1;
+      throw new Error("evidence must not be written for ended controls");
+    });
+
+    const injected = adapter();
+    const adapterCalls: string[] = [];
+    const originalHealth = injected.health.bind(injected);
+    const originalEstimate = injected.estimate.bind(injected);
+    const originalRights = injected.licence_evidence.bind(injected);
+    const originalProvenance = injected.provenance.bind(injected);
+    context.mock.method(injected, "health", () => {
+      adapterCalls.push("health");
+      return originalHealth();
+    });
+    context.mock.method(injected, "estimate", (request: ProviderAdapterQuery) => {
+      adapterCalls.push("estimate");
+      return originalEstimate(request);
+    });
+    context.mock.method(injected, "licence_evidence", () => {
+      adapterCalls.push("rights");
+      return originalRights();
+    });
+    context.mock.method(injected, "provenance", () => {
+      adapterCalls.push("provenance");
+      return originalProvenance();
+    });
+    context.mock.method(injected, "execute", async () => {
+      adapterCalls.push("execute");
+      return validAdapterResult(injected);
+    });
+
+    const run = application(injected, {
+      evidenceLedger: ledger,
+      now: () => new Date("2026-08-21T01:00:00.000Z"),
+    });
+    const controller = new AbortController();
+    controller.abort("private-cancellation-reason");
+    const cancelled = await expectProblem(
+      () =>
+        run.query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+          signal: controller.signal,
+        }),
+      "query_cancelled",
+    );
+    assert.equal(cancelled.problem.status, 408);
+    assert.equal(canonicalJson(cancelled.problem).includes("private-cancellation-reason"), false);
+
+    const expiredDeadline = "2026-08-21T00:59:59.123Z";
+    const expired = await expectProblem(
+      () =>
+        run.query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+          deadline: expiredDeadline,
+        }),
+      "query_deadline_exceeded",
+    );
+    assert.equal(expired.problem.status, 408);
+    assert.equal(canonicalJson(expired.problem).includes(expiredDeadline), false);
+
+    const simultaneous = await expectProblem(
+      () =>
+        run.query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+          signal: controller.signal,
+          deadline: expiredDeadline,
+        }),
+      "query_cancelled",
+    );
+    assert.equal(simultaneous.problem.status, 408);
+    assert.deepEqual(adapterCalls, []);
+    assert.equal(evidenceWrites, 0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("reattributes controls that end during a rejected execution", async (context) => {
+  for (const kind of ["cancel", "deadline", "simultaneous"] as const) {
+    let current = Date.parse("2030-01-01T00:00:00Z");
+    const deadline = "2030-01-01T00:00:10Z";
+    const controller = new AbortController();
+    const injected = adapter();
+    let executions = 0;
+    context.mock.method(injected, "execute", async () => {
+      executions += 1;
+      if (kind !== "deadline") controller.abort("private-during-execute-reason");
+      if (kind !== "cancel") current = Date.parse(deadline);
+      throw new ProviderAdapterFault("PROVIDER_TIMEOUT");
+    });
+    const error = await expectProblem(
+      () =>
+        application(injected, { now: () => new Date(current) }).query(
+          PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+          CONTEXT,
+          {
+            ...(kind === "deadline" ? {} : { signal: controller.signal }),
+            ...(kind === "cancel" ? {} : { deadline }),
+          },
+        ),
+      kind === "deadline" ? "query_deadline_exceeded" : "query_cancelled",
+    );
+    const problem = canonicalJson(error.problem);
+    assert.equal(error.problem.status, 408);
+    assert.equal(problem.includes("private-during-execute-reason"), false);
+    assert.equal(problem.includes(deadline), false);
+    assert.equal(executions, 1);
+    context.mock.reset();
+  }
+});
+
+test("checks ended controls immediately after successful execution before evidence", async (
+  context,
+) => {
+  for (const kind of ["cancel", "deadline", "simultaneous"] as const) {
+    const directory = mkdtempSync(join(tmpdir(), "gis-ai-go-data-query-after-success-"));
+    try {
+      let current = Date.parse("2030-01-01T00:00:00Z");
+      const deadline = "2030-01-01T00:00:10Z";
+      const controller = new AbortController();
+      const ledger = PublicEvidenceLedger.open({ rootDirectory: directory });
+      let evidenceWrites = 0;
+      context.mock.method(ledger, "persistReceipt", () => {
+        evidenceWrites += 1;
+        throw new Error("evidence must not be written after controls end");
+      });
+      const injected = adapter();
+      const result = validAdapterResult(injected);
+      let executions = 0;
+      context.mock.method(injected, "execute", async () => {
+        executions += 1;
+        if (kind !== "deadline") controller.abort("private-after-success-reason");
+        if (kind !== "cancel") current = Date.parse(deadline);
+        return result;
+      });
+      const error = await expectProblem(
+        () =>
+          application(injected, {
+            evidenceLedger: ledger,
+            now: () => new Date(current),
+          }).query(PUBLIC_ONS_DATA_QUERY_PARAMETERS, CONTEXT, {
+            ...(kind === "deadline" ? {} : { signal: controller.signal }),
+            ...(kind === "cancel" ? {} : { deadline }),
+          }),
+        kind === "deadline" ? "query_deadline_exceeded" : "query_cancelled",
+      );
+      const problem = canonicalJson(error.problem);
+      assert.equal(error.problem.status, 408);
+      assert.equal(problem.includes("private-after-success-reason"), false);
+      assert.equal(problem.includes(deadline), false);
+      assert.equal(executions, 1);
+      assert.equal(evidenceWrites, 0);
+    } finally {
+      context.mock.reset();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+test("persists only fully verified v2 evidence through the optional ledger seam", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "gis-ai-go-data-query-ledger-"));
+  try {
+    const ledger = PublicEvidenceLedger.open({
+      rootDirectory: directory,
+      now: () => new Date("2026-08-21T01:00:01.000Z"),
+    });
+    const result = await application(adapter(), { evidenceLedger: ledger }).query(
+      PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+      CONTEXT,
+    );
+    assert.equal(result.evidence_storage?.status, "persisted");
+    const stored = ledger.inspect(result.evidence_receipt.receipt_id);
+    assert.equal(stored?.record.schema, "gis-ai-go.public-evidence-record.v2");
+    assert.equal(stored?.record.receipt.operation.name, "data.query");
+    assert.equal(canonicalJson(stored).includes("10471"), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("returns no receipt when evidence time or storage fails", async (context) => {
+  await expectProblem(
+    () =>
+      application(adapter(), { now: () => new Date(Number.NaN) }).query(
+        PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+        CONTEXT,
+      ),
+    "evidence_unavailable",
+  );
+
+  const directory = mkdtempSync(join(tmpdir(), "gis-ai-go-data-query-ledger-failure-"));
+  try {
+    const ledger = PublicEvidenceLedger.open({ rootDirectory: directory });
+    context.mock.method(ledger, "persistReceipt", () => {
+      throw new Error("Bearer private-ledger-secret at ledger-internal-location");
+    });
+    const error = await expectProblem(
+      () =>
+        application(adapter(), { evidenceLedger: ledger }).query(
+          PUBLIC_ONS_DATA_QUERY_PARAMETERS,
+          CONTEXT,
+        ),
+      "evidence_unavailable",
+    );
+    assert.equal(canonicalJson(error.problem).includes("private-ledger-secret"), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/changelog.d/TOOLS-205-data-query.added.md
+++ b/changelog.d/TOOLS-205-data-query.added.md
@@ -1,0 +1,7 @@
+Added an inactive transport-neutral `data.query` application for the exact reviewed
+ONS version 121 single-observation resource. It requires explicit adapter injection,
+keeps discovery and invocation lifecycle planes independent, verifies policy,
+limits, rights, provenance and results before producing fully checked v2 evidence,
+attributes caller cancellation and caller deadline expiry separately from a
+provider-local timeout, and exposes no route, MCP tool, activation override or
+deployment.

--- a/docs/operations/ADAPT-203_PROVIDER_PREFLIGHT.md
+++ b/docs/operations/ADAPT-203_PROVIDER_PREFLIGHT.md
@@ -147,11 +147,21 @@ closed privacy-safe evidence shape described above; it never prints the observat
 value or response payload. The checked-in example is
 [`data-api-adapter-live-probe.v1.json`](../../providers/ons/data-api-adapter-live-probe.v1.json).
 
-## Dependency and activation boundary
+## Application integration and activation boundary
 
-The ONS record and both lifecycle planes remain suspended. The implementation adds
-the route-specific parser, DNS/TLS transport, response and decompression limits,
-retry/rate admission and execution-control hooks, but it is not dispatched by
-EXEC-202. A later reviewed integration must join it to that exact boundary and add
-gateway-to-execution round-trip tests. No MCP tool, direct API operation, gateway
-capability list, public listener or deployment is changed by this slice.
+The ONS record and both lifecycle planes remain suspended by default. The
+implementation adds the route-specific parser, DNS/TLS transport, response and
+decompression limits, retry/rate admission and execution-control hooks, but it is
+not dispatched by EXEC-202.
+
+The later accepted public-read v2 contract defines a narrower application seam for
+this exact provider resource. Its application-only `data.query` slice explicitly
+injects `OnsDataApiAdapter` after local public-read policy evaluation and propagates
+the accepted deadline and cancellation controls directly. That reviewed direct
+injection supersedes the earlier provisional wording that integration must join the
+synthetic-only EXEC-202 operation. EXEC-202 remains the separate typed private
+Python boundary and its allowlist is not widened implicitly.
+
+Neither integration changes the default lifecycle: no MCP tool, direct API
+operation, gateway capability list, shipped adapter constructor, public listener or
+deployment is activated.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -32,3 +32,4 @@ or API is deployed.
 - [QUAL-206 host interoperability and secure-tunnel runbook](QUAL-206_INTEROPERABILITY.md)
 - [TOOLS-205 inactive public-read v2 contracts](TOOLS-205_PUBLIC_READ_V2_CONTRACTS.md)
 - [TOOLS-205 inactive selection resolver](TOOLS-205_SELECTION_RESOLVE.md)
+- [TOOLS-205 inactive data query application](TOOLS-205_DATA_QUERY_APPLICATION.md)

--- a/docs/operations/TOOLS-205_DATA_QUERY_APPLICATION.md
+++ b/docs/operations/TOOLS-205_DATA_QUERY_APPLICATION.md
@@ -1,0 +1,139 @@
+# TOOLS-205 inactive data query application
+
+Reviewed on 21 August 2026.
+
+## Outcome and boundary
+
+This slice implements the transport-neutral application function for the exact
+public ONS `data.query` selected by the accepted public-read v2 contracts. It does
+not add an HTTP route, MCP tool, MCP resource, OpenAPI operation, registry
+implementation state, activation override, shipped adapter configuration, public
+listener or deployment. Production and default capability arrays remain empty.
+
+`createDataQueryApplication()` has no default adapter and reads no environment
+variable. Its caller must explicitly inject an `OnsDataApiAdapter` instance and an
+exact gateway software identity. The adapter's invocation lifecycle plane must be
+active. Its discovery plane may remain suspended because this application neither
+lists providers nor changes capability advertising. Discovery-active with
+invocation-suspended still fails before provider transport.
+
+The only accepted request is the closed five-key
+`gis-ai-go.data-query-parameters.v1` object. It binds:
+
+- the exact accepted public-read resource identity;
+- ONS dataset `weekly-deaths-region`, edition `time-series`, version `121`;
+- native selection order `time`, `geography`, `week`, `causeofdeath` with the four
+  reviewed options; and
+- one observation.
+
+A different value, order, property or shape fails before adapter execution. The
+application accepts no URL, query string, credential, provider choice, wildcard,
+SQL, lifecycle setting or output bound from the caller.
+
+## Execution order
+
+Every successful call follows one fixed order:
+
+1. detach and compare the exact five-key parameters, context and optional execution
+   controls;
+2. check the caller signal and absolute deadline using the application's trusted
+   clock, with cancellation taking precedence, before policy evaluation, before
+   adapter preflight and immediately before execution;
+3. evaluate and verify the server-owned anonymous-open authority, checked
+   default-deny v2 policy, per-call allow decision and exact public-read resource;
+4. require an invocation-active health record, independently compare the adapter's
+   upper-bound estimate, OGL rights and provenance with the accepted resource;
+5. call the explicitly injected adapter's `execute()` exactly once with the shared
+   cancellation signal and absolute RFC 3339 deadline;
+6. recheck caller controls in the execution rejection path before mapping an adapter
+   error, and immediately after a resolved execution before validating its result;
+7. independently detach and check the returned provider, adapter, dataset, edition,
+   version URI, native dimension order, one 15-digit-or-smaller integer string,
+   `unit: null`, empty ONS Data Marking, OGL rights, provenance and 256 KiB
+   canonical-result ceiling;
+8. project the receipt-free result core, construct a public-read v2 receipt and
+   immediately verify it with the full parameter, result, policy, authority,
+   decision, resource and software material; and
+9. when an explicit verified public ledger is injected, complete and re-verify its
+   append-only write before adding `evidence_storage`.
+
+There is no provider call during policy, health, estimate, rights or provenance
+failure. An evidence-clock, receipt-verification or storage failure returns no
+success result or receipt. A cancelled signal or elapsed caller deadline also
+returns no result, receipt or durable write. Neither the abort reason nor the
+deadline value can appear in a problem.
+
+## Results and problems
+
+The success shape is `gis-ai-go.data-query-result.v1`. It contains one
+numeric-string observation with a `null` unit, the fixed evidence binding and a
+fully verified `gis-ai-go.evidence-receipt.v2`. The receipt preserves the reviewed
+profile hash, provider and adapter identity, dataset version, dimension order,
+rights, attribution and byte/attempt limits. Durable storage is optional and
+explicit; the default remains verified inline evidence only.
+
+Failures use `gis-ai-go.data-query-problem.v1` and exactly one of ten codes:
+
+- `invalid_request`;
+- `query_cancelled`;
+- `query_deadline_exceeded`;
+- `policy_denied`;
+- `provider_suspended`;
+- `provider_rate_limited`;
+- `provider_timeout`;
+- `provider_unavailable`;
+- `provider_contract_failed`; or
+- `evidence_unavailable`.
+
+`query_cancelled` and `query_deadline_exceeded` are fixed `408` problems owned by
+the caller-control plane. Cancellation wins when both controls have ended.
+`provider_timeout` remains a `504` only for an adapter or provider-local timeout
+while the external signal and deadline are still live.
+
+Problem titles, details, types and status values are fixed. They cannot represent
+an adapter error message, provider status, payload, path, stack, credential,
+parameter/result material or evidence receipt. Adapter failures are normalised and
+checked before this closed non-reflective mapping.
+
+## Public API and contracts
+
+The gateway package exports:
+
+- `PUBLIC_ONS_DATA_QUERY_PARAMETERS`;
+- `createDataQueryApplication()`;
+- `DataQueryApplication`, `DataQueryApplicationOptions` and
+  `DataQueryInvocationOptions`;
+- `DataQueryParameters`, `DataQueryResultCore` and `DataQueryResult`; and
+- `DATA_QUERY_PROBLEM_CODES`, `DataQueryProblem` and
+  `DataQueryApplicationError`.
+
+The promoted schemas and examples are:
+
+- [`data-query-parameters.schema.json`](../../schemas/data-query-parameters.schema.json)
+  and
+  the promoted `data-query-parameters.example.json` fixture;
+- [`data-query-result.schema.json`](../../schemas/data-query-result.schema.json) and
+  [`data-query-result.example.json`](../../providers/fixtures/data-query-result.example.json);
+  and
+- [`data-query-problem.schema.json`](../../schemas/data-query-problem.schema.json)
+  and
+  [`data-query-problem.example.json`](../../providers/fixtures/data-query-problem.example.json),
+  [`data-query-cancelled-problem.example.json`][cancelled-problem]
+  and
+  [`data-query-deadline-exceeded-problem.example.json`][deadline-problem].
+
+[cancelled-problem]: ../../providers/fixtures/data-query-cancelled-problem.example.json
+[deadline-problem]: ../../providers/fixtures/data-query-deadline-exceeded-problem.example.json
+
+The successful fixture retains the already documented public aggregate scalar
+`10471` solely to reproduce the complete application result and receipt. It is not
+a stored provider response, fresh live observation or activation claim.
+
+## Remaining gates
+
+This application-only slice still cannot be called through a shipped product. A
+later integration must add and review direct API and MCP schema/result/problem
+parity, registry implementation state, complete non-App rendering, lifecycle
+agreement, independent-host evidence, operational cache/fallback behaviour and
+deployment rollback before any activation. No new live ONS call is needed for this
+inactive application test slice.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@gis-ai-go/policy-client':
         specifier: workspace:*
         version: link:../../packages/policy-client
+      '@gis-ai-go/provider-adapter-sdk':
+        specifier: workspace:*
+        version: link:../../packages/provider-adapter-sdk
       '@modelcontextprotocol/node':
         specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.3)

--- a/providers/fixtures/README.md
+++ b/providers/fixtures/README.md
@@ -27,6 +27,14 @@ fixture cover the deterministic inactive resolver. The plan is an exact
 non-executable projection; it contains no observation and is not evidence of a
 provider call. Problem fixtures deliberately contain no receipt.
 
+The `data-query-parameters`, `data-query-result` and `data-query-problem` examples
+exercise the later inactive application-only seam. The successful fixture retains
+the already documented public aggregate scalar `10471` to reproduce its complete
+result-core and receipt digests; it is not a fresh live query or stored provider
+response. The provider, caller-cancelled and caller-deadline problem fixtures are
+deliberately receipt-free and cannot retain an abort reason, deadline, adapter
+message, provider status, payload, credential, path or stack.
+
 The `@gis-ai-go/provider-adapter-sdk` package supplies a frozen statistics fixture
 with fixture-native dataset, version, dimension and option identifiers. Both its
 discovery and invocation planes are suspended unless a test activates them

--- a/providers/fixtures/data-query-cancelled-problem.example.json
+++ b/providers/fixtures/data-query-cancelled-problem.example.json
@@ -1,0 +1,11 @@
+{
+  "schema": "gis-ai-go.data-query-problem.v1",
+  "type": "urn:gis-ai-go:problem:data-query-cancelled",
+  "title": "Data query cancelled",
+  "status": 408,
+  "code": "query_cancelled",
+  "detail": "The caller cancelled the data query.",
+  "request_id": "request-data-query-example-1",
+  "trace_id": "8123456789abcdef0123456789abcdef",
+  "instance": "/data/query"
+}

--- a/providers/fixtures/data-query-deadline-exceeded-problem.example.json
+++ b/providers/fixtures/data-query-deadline-exceeded-problem.example.json
@@ -1,0 +1,11 @@
+{
+  "schema": "gis-ai-go.data-query-problem.v1",
+  "type": "urn:gis-ai-go:problem:data-query-deadline-exceeded",
+  "title": "Data query deadline exceeded",
+  "status": 408,
+  "code": "query_deadline_exceeded",
+  "detail": "The caller deadline elapsed before the data query completed.",
+  "request_id": "request-data-query-example-1",
+  "trace_id": "8123456789abcdef0123456789abcdef",
+  "instance": "/data/query"
+}

--- a/providers/fixtures/data-query-parameters.example.json
+++ b/providers/fixtures/data-query-parameters.example.json
@@ -1,0 +1,16 @@
+{
+  "schema": "gis-ai-go.data-query-parameters.v1",
+  "resource_id": "gis-ai-go:public-read-resource:sha256:c7130712a40d75e71bcf0259792404389bea2e549adf6733f34d491f83e99f68",
+  "dataset": {
+    "id": "weekly-deaths-region",
+    "edition": "time-series",
+    "version": "121"
+  },
+  "selections": [
+    { "dimension": "time", "option": "2026" },
+    { "dimension": "geography", "option": "E92000001" },
+    { "dimension": "week", "option": "week-24" },
+    { "dimension": "causeofdeath", "option": "all-causes" }
+  ],
+  "limit": 1
+}

--- a/providers/fixtures/data-query-problem.example.json
+++ b/providers/fixtures/data-query-problem.example.json
@@ -1,0 +1,11 @@
+{
+  "schema": "gis-ai-go.data-query-problem.v1",
+  "type": "urn:gis-ai-go:problem:data-query-provider-unavailable",
+  "title": "Data provider unavailable",
+  "status": 503,
+  "code": "provider_unavailable",
+  "detail": "The reviewed provider is temporarily unavailable.",
+  "request_id": "request-data-query-example-1",
+  "trace_id": "8123456789abcdef0123456789abcdef",
+  "instance": "/data/query"
+}

--- a/providers/fixtures/data-query-result.example.json
+++ b/providers/fixtures/data-query-result.example.json
@@ -1,0 +1,194 @@
+{
+  "schema": "gis-ai-go.data-query-result.v1",
+  "operation": "data.query",
+  "request_id": "request-data-query-example-1",
+  "trace_id": "8123456789abcdef0123456789abcdef",
+  "evidence_binding": {
+    "adapter_id": "gis-ai-go.ons-data-api",
+    "dataset_id": "weekly-deaths-region",
+    "edition": "time-series",
+    "profile_sha256": "535e6eb65fc9af4507e30700d425393a658a085a3a240689f4b37124dc8f8622",
+    "provider_id": "ons-data-api",
+    "resource_id": "gis-ai-go:public-read-resource:sha256:c7130712a40d75e71bcf0259792404389bea2e549adf6733f34d491f83e99f68",
+    "returned_item_count": 1,
+    "rights_sha256": "305b49e6d1f55de0109de12b2cbf0b7ec5da1d573e111f5884736c832b2e4b17",
+    "version": "121"
+  },
+  "data": {
+    "status": "succeeded",
+    "observations": [{ "value": "10471", "unit": null }]
+  },
+  "warnings": [],
+  "evidence_receipt": {
+    "authority_context": {
+      "access": {
+        "authentication": "none",
+        "contains_personal_data": false,
+        "contains_protected_data": false,
+        "publication_classification": "public",
+        "read_only": true,
+        "tier": "open"
+      },
+      "canonicalisation": "rfc8785-jcs",
+      "construction": {
+        "product": "gis-ai-go-gateway",
+        "profile": "anonymous-open",
+        "source": "server"
+      },
+      "context_id": "gis-ai-go:public-authority-context:sha256:5d97a93aaa9c8fcbf9f02d2812275cf59b4c0e0e923de89ac975035c741bc1f1",
+      "evidence": {
+        "attestation": "not-attested",
+        "persistence": "not-persisted",
+        "receipt": "inline-required"
+      },
+      "permitted_operations": ["data.query", "selection.resolve"],
+      "schema": "gis-ai-go.public-authority-context.v2"
+    },
+    "created_at": "2026-08-21T01:00:00.000Z",
+    "evidence_handling": {
+      "attestation": "not-attested",
+      "delivery": "inline-only",
+      "persistence": "not-persisted"
+    },
+    "operation": {
+      "contract_version": "v1",
+      "name": "data.query",
+      "normalised_parameters": {
+        "domain": "gis-ai-go.data-query-parameters.v1",
+        "sha256": "1d4451784db65f8a47978f643b94fe4f6d8f6be95cf9b4327d861249796edc20"
+      }
+    },
+    "policy_decision": {
+      "authority_context_id": "gis-ai-go:public-authority-context:sha256:5d97a93aaa9c8fcbf9f02d2812275cf59b4c0e0e923de89ac975035c741bc1f1",
+      "canonicalisation": "rfc8785-jcs",
+      "decision_id": "gis-ai-go:public-policy-decision:sha256:6fc2ce6e35387808e0608602a808b1566f28eed64794bdcc157043d865b45de0",
+      "effect": "allow-with-obligations",
+      "obligations": [
+        "bounded-single-observation",
+        "inline-evidence-receipt",
+        "not-attested",
+        "not-persisted",
+        "preserve-attribution",
+        "preserve-provider-identifiers",
+        "preserve-provider-rights",
+        "preserve-provider-version"
+      ],
+      "operation": "data.query",
+      "policy_default_effect": "deny",
+      "policy_id": "gis-ai-go:public-policy:sha256:b1a37b2ebf6900e2b5d62dfa20bcdaa1232e1c4c9f9630f90ac9d3dde738624a",
+      "policy_version": "2.0.0",
+      "reason_code": "public-read-operation-allowed",
+      "request_id": "request-data-query-example-1",
+      "resource_id": "gis-ai-go:public-read-resource:sha256:c7130712a40d75e71bcf0259792404389bea2e549adf6733f34d491f83e99f68",
+      "schema": "gis-ai-go.public-policy-decision.v2",
+      "trace_id": "8123456789abcdef0123456789abcdef"
+    },
+    "receipt_id": "gis-ai-go:evidence-receipt:sha256:40300996835f5e8af1d8342c0f374b03584ec021500c11bc866f1cc0ff18c592",
+    "request_id": "request-data-query-example-1",
+    "resource": {
+      "dataset": {
+        "dimension_order": ["time", "geography", "week", "causeofdeath"],
+        "edition": "time-series",
+        "id": "weekly-deaths-region",
+        "source_date": "2026-07-01",
+        "version": "121",
+        "version_uri": "https://api.beta.ons.gov.uk/v1/datasets/weekly-deaths-region/editions/time-series/versions/121"
+      },
+      "limits": {
+        "max_attempts": 2,
+        "max_canonical_response_bytes": 262144,
+        "max_compressed_response_bytes": 262144,
+        "max_decompressed_response_bytes": 1048576,
+        "max_observations": 1
+      },
+      "output": {
+        "axis_order": null,
+        "crs": null,
+        "media_type": "application/json",
+        "spatial": false
+      },
+      "profile": {
+        "id": "PV-ONS-DATA",
+        "sha256": "535e6eb65fc9af4507e30700d425393a658a085a3a240689f4b37124dc8f8622",
+        "source_path": "docs/research/2026-08-19/research-pack/data/providers.json",
+        "source_pointer": "/providers/1"
+      },
+      "provider": {
+        "adapter_id": "gis-ai-go.ons-data-api",
+        "adapter_version": "1",
+        "id": "ons-data-api"
+      },
+      "publication": {
+        "access_tier": "open",
+        "authentication": "none",
+        "classification": "public",
+        "contains_personal_data": false,
+        "contains_protected_data": false,
+        "read_only": true
+      },
+      "resource_id": "gis-ai-go:public-read-resource:sha256:c7130712a40d75e71bcf0259792404389bea2e549adf6733f34d491f83e99f68",
+      "rights": {
+        "attribution": "Source: Office for National Statistics licensed under the Open Government Licence v.3.0",
+        "evidence_uris": [
+          "https://www.ons.gov.uk/datasets/weekly-deaths-region/editions/time-series/versions/121",
+          "https://www.ons.gov.uk/help/terms-conditions",
+          "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+        ],
+        "exceptions": [
+          "The ONS logo is excluded and is not retrieved or redistributed.",
+          "Any record-level third-party exception overrides this general evidence and must fail closed.",
+          "The selected aggregate dataset page stated no additional exception when reviewed."
+        ],
+        "licence": "Open Government Licence v3.0",
+        "licence_uri": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        "obligations": [
+          "Acknowledge the source and licence when reproducing the selected ONS content.",
+          "Preserve the selected dataset, edition, version and release date.",
+          "Do not imply that ONS endorses GIS AI GO or its interpretation."
+        ],
+        "reviewed_at": "2026-08-20T17:40:35Z",
+        "state": "open-with-conditions"
+      },
+      "schema": "gis-ai-go.public-read-resource.v1",
+      "selections": [
+        { "dimension": "time", "option": "2026" },
+        { "dimension": "geography", "option": "E92000001" },
+        { "dimension": "week", "option": "week-24" },
+        { "dimension": "causeofdeath", "option": "all-causes" }
+      ]
+    },
+    "result": {
+      "domain": "gis-ai-go.data-query-result-core.v1",
+      "media_type": "application/json",
+      "returned_item_count": 1,
+      "sha256": "af064bfd95484ea5658d4da83dc0ca5a29c418a0962a1b39874a9a56805d83bb"
+    },
+    "schema": "gis-ai-go.evidence-receipt.v2",
+    "software": {
+      "name": "gis-ai-go-mcp-gateway",
+      "revision": "e1fc1cbe69ea72c9aa310607d80f392ef56b0d58",
+      "version": "0.1.0"
+    },
+    "trace_id": "8123456789abcdef0123456789abcdef",
+    "transformations": [
+      { "name": "normalise-public-read-parameters", "version": "v1" },
+      { "name": "execute-fixed-provider-query", "version": "v1" },
+      { "name": "project-public-read-result-core", "version": "v1" }
+    ],
+    "verification": {
+      "canonicalisation": "rfc8785-jcs",
+      "checks": [
+        "authority-context",
+        "normalised-parameters-digest",
+        "profile-binding",
+        "provider-binding",
+        "provider-rights",
+        "public-policy-decision",
+        "result-core-digest",
+        "schema"
+      ],
+      "digest_algorithm": "sha256",
+      "status": "passed"
+    }
+  }
+}

--- a/providers/ons/README.md
+++ b/providers/ons/README.md
@@ -29,6 +29,9 @@ The deterministic adapter test separately retains the public aggregate scalar
 `10471` needed to reproduce the result digest; the value is not present in the
 live-probe record or its standard output.
 
-Both lifecycle planes remain suspended. Runtime integration must reuse the accepted
-EXEC-202 typed request, result, error, deadline, cancellation and trace boundary;
-this folder and adapter do not invent or activate a substitute gateway envelope.
+Both lifecycle planes remain suspended by default. The accepted public-read v2
+application now integrates this exact resource through mandatory direct
+`OnsDataApiAdapter` injection after policy evaluation, while reusing the accepted
+deadline, cancellation and trace semantics. This supersedes the earlier provisional
+requirement to widen the synthetic-only EXEC-202 allowlist. It does not invent a
+transport envelope, configure a shipped adapter or activate a gateway capability.

--- a/schemas/data-query-parameters.schema.json
+++ b/schemas/data-query-parameters.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:data-query-parameters:v1",
+  "title": "GIS AI GO exact public ONS data query parameters",
+  "description": "The only parameter object accepted by the inactive application-only data.query seam. It contains no caller URL, credential, wildcard or lifecycle control.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "dataset": {},
+    "limit": {},
+    "resource_id": {},
+    "schema": {},
+    "selections": {}
+  },
+  "const": {
+    "schema": "gis-ai-go.data-query-parameters.v1",
+    "resource_id": "gis-ai-go:public-read-resource:sha256:c7130712a40d75e71bcf0259792404389bea2e549adf6733f34d491f83e99f68",
+    "dataset": {
+      "id": "weekly-deaths-region",
+      "edition": "time-series",
+      "version": "121"
+    },
+    "selections": [
+      { "dimension": "time", "option": "2026" },
+      { "dimension": "geography", "option": "E92000001" },
+      { "dimension": "week", "option": "week-24" },
+      { "dimension": "causeofdeath", "option": "all-causes" }
+    ],
+    "limit": 1
+  }
+}

--- a/schemas/data-query-problem.schema.json
+++ b/schemas/data-query-problem.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:data-query-problem:v1",
+  "title": "GIS AI GO data query problem",
+  "description": "A closed receipt-free problem. Adapter messages, provider status, response content, paths, credentials and evidence receipts cannot be represented.",
+  "oneOf": [
+    { "$ref": "#/$defs/invalidRequest" },
+    { "$ref": "#/$defs/queryCancelled" },
+    { "$ref": "#/$defs/queryDeadlineExceeded" },
+    { "$ref": "#/$defs/policyDenied" },
+    { "$ref": "#/$defs/providerSuspended" },
+    { "$ref": "#/$defs/providerRateLimited" },
+    { "$ref": "#/$defs/providerTimeout" },
+    { "$ref": "#/$defs/providerUnavailable" },
+    { "$ref": "#/$defs/providerContractFailed" },
+    { "$ref": "#/$defs/evidenceUnavailable" }
+  ],
+  "$defs": {
+    "commonProperties": {
+      "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+      "request_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+      },
+      "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+      "instance": {
+        "type": "string",
+        "format": "uri-reference",
+        "minLength": 1,
+        "maxLength": 2048
+      }
+    },
+    "invalidRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-invalid-request" },
+        "title": { "const": "Invalid data query request" },
+        "status": { "const": 400 },
+        "code": { "const": "invalid_request" },
+        "detail": { "const": "The request must match the reviewed public ONS query." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "queryCancelled": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-cancelled" },
+        "title": { "const": "Data query cancelled" },
+        "status": { "const": 408 },
+        "code": { "const": "query_cancelled" },
+        "detail": { "const": "The caller cancelled the data query." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "queryDeadlineExceeded": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-deadline-exceeded" },
+        "title": { "const": "Data query deadline exceeded" },
+        "status": { "const": 408 },
+        "code": { "const": "query_deadline_exceeded" },
+        "detail": { "const": "The caller deadline elapsed before the data query completed." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "policyDenied": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-policy-denied" },
+        "title": { "const": "Data query denied" },
+        "status": { "const": 403 },
+        "code": { "const": "policy_denied" },
+        "detail": { "const": "The public-read policy did not authorise this data query." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "providerSuspended": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-provider-suspended" },
+        "title": { "const": "Data provider suspended" },
+        "status": { "const": 503 },
+        "code": { "const": "provider_suspended" },
+        "detail": { "const": "The reviewed provider adapter is suspended for invocation." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "providerRateLimited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-provider-rate-limited" },
+        "title": { "const": "Data provider rate limited" },
+        "status": { "const": 429 },
+        "code": { "const": "provider_rate_limited" },
+        "detail": { "const": "The bounded provider admission limit has been reached." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "providerTimeout": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-provider-timeout" },
+        "title": { "const": "Data provider timed out" },
+        "status": { "const": 504 },
+        "code": { "const": "provider_timeout" },
+        "detail": { "const": "The provider adapter timed out while caller controls remained active." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "providerUnavailable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-provider-unavailable" },
+        "title": { "const": "Data provider unavailable" },
+        "status": { "const": 503 },
+        "code": { "const": "provider_unavailable" },
+        "detail": { "const": "The reviewed provider is temporarily unavailable." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "providerContractFailed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-provider-contract-failed" },
+        "title": { "const": "Data provider response rejected" },
+        "status": { "const": 502 },
+        "code": { "const": "provider_contract_failed" },
+        "detail": { "const": "Provider evidence did not match the reviewed public-read contract." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    },
+    "evidenceUnavailable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "type", "title", "status", "code", "detail", "request_id", "trace_id"],
+      "properties": {
+        "schema": { "const": "gis-ai-go.data-query-problem.v1" },
+        "type": { "const": "urn:gis-ai-go:problem:data-query-evidence-unavailable" },
+        "title": { "const": "Data query evidence unavailable" },
+        "status": { "const": 503 },
+        "code": { "const": "evidence_unavailable" },
+        "detail": { "const": "Verified evidence could not be completed for this data query." },
+        "request_id": { "$ref": "#/$defs/commonProperties/request_id" },
+        "trace_id": { "$ref": "#/$defs/commonProperties/trace_id" },
+        "instance": { "$ref": "#/$defs/commonProperties/instance" }
+      }
+    }
+  }
+}

--- a/schemas/data-query-result.schema.json
+++ b/schemas/data-query-result.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:data-query-result:v1",
+  "title": "GIS AI GO successful public ONS data query result",
+  "description": "One complete successful application result with independently checked provider evidence and a fully verified public-read v2 receipt.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "operation",
+    "request_id",
+    "trace_id",
+    "evidence_binding",
+    "data",
+    "warnings",
+    "evidence_receipt"
+  ],
+  "properties": {
+    "schema": { "const": "gis-ai-go.data-query-result.v1" },
+    "operation": { "const": "data.query" },
+    "request_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+    "evidence_binding": {
+      "const": {
+        "resource_id": "gis-ai-go:public-read-resource:sha256:c7130712a40d75e71bcf0259792404389bea2e549adf6733f34d491f83e99f68",
+        "profile_sha256": "535e6eb65fc9af4507e30700d425393a658a085a3a240689f4b37124dc8f8622",
+        "provider_id": "ons-data-api",
+        "adapter_id": "gis-ai-go.ons-data-api",
+        "dataset_id": "weekly-deaths-region",
+        "edition": "time-series",
+        "version": "121",
+        "rights_sha256": "305b49e6d1f55de0109de12b2cbf0b7ec5da1d573e111f5884736c832b2e4b17",
+        "returned_item_count": 1
+      }
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "observations"],
+      "properties": {
+        "status": { "const": "succeeded" },
+        "observations": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["value", "unit"],
+            "properties": {
+              "value": {
+                "type": "string",
+                "pattern": "^(?:0|[1-9][0-9]{0,14})$"
+              },
+              "unit": { "type": "null" }
+            }
+          }
+        }
+      }
+    },
+    "warnings": { "const": [] },
+    "evidence_receipt": {
+      "allOf": [
+        { "$ref": "urn:gis-ai-go:schema:evidence-receipt:v2" },
+        {
+          "properties": {
+            "operation": {
+              "properties": { "name": { "const": "data.query" } }
+            },
+            "result": {
+              "properties": {
+                "domain": { "const": "gis-ai-go.data-query-result-core.v1" },
+                "returned_item_count": { "const": 1 }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "evidence_storage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "ledger_id",
+        "record_id",
+        "event_id",
+        "persisted_at",
+        "retain_until"
+      ],
+      "properties": {
+        "status": { "const": "persisted" },
+        "ledger_id": {
+          "type": "string",
+          "pattern": "^gis-ai-go:public-evidence-ledger:sha256:[0-9a-f]{64}$"
+        },
+        "record_id": {
+          "type": "string",
+          "pattern": "^gis-ai-go:public-evidence-record:sha256:[0-9a-f]{64}$"
+        },
+        "event_id": {
+          "type": "string",
+          "pattern": "^gis-ai-go:evidence-ledger-event:sha256:[0-9a-f]{64}$"
+        },
+        "persisted_at": { "type": "string", "format": "date-time" },
+        "retain_until": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -539,6 +539,46 @@ def main() -> None:
             ],
         ),
         (
+            "data-query-parameters.schema.json",
+            [
+                (
+                    "data-query-parameters.example.json",
+                    load_json(fixture_dir / "data-query-parameters.example.json"),
+                )
+            ],
+        ),
+        (
+            "data-query-result.schema.json",
+            [
+                (
+                    "data-query-result.example.json",
+                    load_json(fixture_dir / "data-query-result.example.json"),
+                )
+            ],
+        ),
+        (
+            "data-query-problem.schema.json",
+            [
+                (
+                    "data-query-problem.example.json",
+                    load_json(fixture_dir / "data-query-problem.example.json"),
+                ),
+                (
+                    "data-query-cancelled-problem.example.json",
+                    load_json(
+                        fixture_dir / "data-query-cancelled-problem.example.json"
+                    ),
+                ),
+                (
+                    "data-query-deadline-exceeded-problem.example.json",
+                    load_json(
+                        fixture_dir
+                        / "data-query-deadline-exceeded-problem.example.json"
+                    ),
+                ),
+            ],
+        ),
+        (
             "execution-request.schema.json",
             [
                 (

--- a/tests/contract/test_data_query_contracts.py
+++ b/tests/contract/test_data_query_contracts.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas"
+FIXTURE_DIR = ROOT / "providers" / "fixtures"
+
+
+def load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def registry() -> Registry:
+    resources = []
+    for path in sorted(SCHEMA_DIR.glob("*.schema.json")):
+        schema = load(path)
+        resources.append((schema["$id"], Resource.from_contents(schema)))
+    return Registry().with_resources(resources)
+
+
+def validator(name: str) -> Draft202012Validator:
+    schema = load(SCHEMA_DIR / name)
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(
+        schema,
+        registry=registry(),
+        format_checker=FormatChecker(),
+    )
+
+
+def assert_closed(test_case: unittest.TestCase, node: object, path: str = "$") -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            test_case.assertIs(
+                node.get("additionalProperties"),
+                False,
+                f"{path} must reject unknown properties",
+            )
+        for key, value in node.items():
+            assert_closed(test_case, value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            assert_closed(test_case, value, f"{path}[{index}]")
+
+
+class DataQueryContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parameters = load(FIXTURE_DIR / "data-query-parameters.example.json")
+        self.result = load(FIXTURE_DIR / "data-query-result.example.json")
+        self.problem = load(FIXTURE_DIR / "data-query-problem.example.json")
+        self.cancelled_problem = load(
+            FIXTURE_DIR / "data-query-cancelled-problem.example.json"
+        )
+        self.deadline_problem = load(
+            FIXTURE_DIR / "data-query-deadline-exceeded-problem.example.json"
+        )
+
+    def test_schema_ids_are_stable_and_every_object_is_closed(self) -> None:
+        expected = {
+            "data-query-parameters.schema.json": (
+                "urn:gis-ai-go:schema:data-query-parameters:v1"
+            ),
+            "data-query-result.schema.json": (
+                "urn:gis-ai-go:schema:data-query-result:v1"
+            ),
+            "data-query-problem.schema.json": (
+                "urn:gis-ai-go:schema:data-query-problem:v1"
+            ),
+        }
+        for name, schema_id in expected.items():
+            with self.subTest(schema=name):
+                schema = load(SCHEMA_DIR / name)
+                Draft202012Validator.check_schema(schema)
+                self.assertEqual(schema_id, schema["$id"])
+                assert_closed(self, schema)
+        self.assertEqual(
+            10,
+            len(load(SCHEMA_DIR / "data-query-problem.schema.json")["oneOf"]),
+        )
+
+    def test_exact_parameters_and_success_fixture_validate(self) -> None:
+        parameters = validator("data-query-parameters.schema.json")
+        result = validator("data-query-result.schema.json")
+        self.assertTrue(parameters.is_valid(self.parameters))
+        self.assertTrue(result.is_valid(self.result))
+        self.assertEqual(5, len(self.parameters))
+        self.assertEqual(1, self.parameters["limit"])
+        self.assertEqual(
+            ["time", "geography", "week", "causeofdeath"],
+            [entry["dimension"] for entry in self.parameters["selections"]],
+        )
+        self.assertEqual("10471", self.result["data"]["observations"][0]["value"])
+        self.assertIsNone(self.result["data"]["observations"][0]["unit"])
+        selection_plan_path = SCHEMA_DIR / "selection-plan.schema.json"
+        if selection_plan_path.exists():
+            self.assertEqual(
+                self.parameters,
+                load(selection_plan_path)["const"]["data_query"],
+                "the independently validated query must equal selection plan output",
+            )
+
+    def test_parameter_and_result_drift_fail_closed(self) -> None:
+        parameters = validator("data-query-parameters.schema.json")
+        result = validator("data-query-result.schema.json")
+        mutations: list[tuple[str, dict[str, Any], Draft202012Validator]] = []
+        for label, path, value in [
+            ("latest version", ["dataset", "version"], "latest"),
+            ("second item", ["limit"], 2),
+            ("caller URL", ["url"], "https://example.invalid"),
+        ]:
+            candidate = copy.deepcopy(self.parameters)
+            target = candidate
+            for member in path[:-1]:
+                target = target[member]
+            target[path[-1]] = value
+            mutations.append((label, candidate, parameters))
+
+        reordered = copy.deepcopy(self.parameters)
+        reordered["selections"].reverse()
+        mutations.append(("selection order", reordered, parameters))
+
+        for label, path, value in [
+            ("decimal observation", ["data", "observations", 0, "value"], "10.5"),
+            ("invented unit", ["data", "observations", 0, "unit"], "deaths"),
+            ("wrong provider", ["evidence_binding", "provider_id"], "other"),
+            ("wrong operation", ["operation"], "selection.resolve"),
+        ]:
+            candidate = copy.deepcopy(self.result)
+            target: Any = candidate
+            for member in path[:-1]:
+                target = target[member]
+            target[path[-1]] = value
+            mutations.append((label, candidate, result))
+
+        for label, candidate, checked_by in mutations:
+            with self.subTest(mutation=label):
+                self.assertFalse(checked_by.is_valid(candidate))
+
+    def test_problems_are_closed_receipt_free_and_non_reflective(self) -> None:
+        problem = validator("data-query-problem.schema.json")
+        for fixture in [
+            self.problem,
+            self.cancelled_problem,
+            self.deadline_problem,
+        ]:
+            with self.subTest(code=fixture["code"]):
+                self.assertTrue(problem.is_valid(fixture))
+        forbidden = {
+            "abort_reason",
+            "adapter_code",
+            "credential",
+            "deadline",
+            "evidence_receipt",
+            "provider_status",
+            "raw_error",
+            "reason",
+            "stack",
+            "token",
+        }
+        for fixture in [
+            self.problem,
+            self.cancelled_problem,
+            self.deadline_problem,
+        ]:
+            self.assertTrue(forbidden.isdisjoint(fixture))
+            for key in forbidden:
+                candidate = copy.deepcopy(fixture)
+                candidate[key] = "secret"
+                with self.subTest(code=fixture["code"], extra=key):
+                    self.assertFalse(problem.is_valid(candidate))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the inactive, transport-neutral `data.query` application for the exact reviewed
  ONS single-observation request
- require an explicitly injected invocation-active `OnsDataApiAdapter`; discovery may
  remain suspended and discovery alone never authorises invocation
- verify public-read v2 authority, policy, resource, health, estimate, rights,
  provenance and the single returned observation before building a fully verified
  evidence receipt
- distinguish caller cancellation and caller absolute-deadline expiry from an
  adapter-local provider timeout, with cancellation precedence and no evidence after
  either caller control ends
- add closed schemas, promoted fixtures, contract validation, operational guidance
  and a changelog fragment
- retain byte-equal compatibility with the merged inactive selection resolver

## Activation and provider boundary

This is an application-only inactive seam. It does not register or activate a tool,
mount an HTTP, MCP, STDIO or OpenAPI surface, change the tool registry, or alter the
private EXEC service. There is no default adapter or environment activation path.

No live ONS request was made while implementing or assuring this change. Ordinary
tests use an explicitly injected fixed transport. The one opt-in live-provider test
remains deliberately skipped.

## Cancellation and deadline boundary

- `query_cancelled` is a fixed, receipt-free `408` for a sender/client signal.
- `query_deadline_exceeded` is a fixed, receipt-free `408` for the caller's absolute
  deadline, compared with the application's trusted clock.
- `provider_timeout` remains `504` only when the adapter or provider times out while
  both external controls remain live.
- cancellation takes precedence if both external controls have ended.
- controls are checked before policy, preflight and execution, in the rejected
  execution path, and immediately after a successful adapter return before result
  validation, receipt construction or ledger persistence.
- abort reasons and deadline values cannot be represented by the closed problems.

## Independent review and security

- the original 20-path implementation review was **SHIP**, with no P0, P1 or P2
  findings before integration
- the cancellation-attribution P2 held this PR before merge; its exact staged
  amendment was independently revalidated as **SHIP**, with no P0, P1 or P2 findings
- independent review scan `afe7816a-a6c5-4082-8f9b-875c3bd81e7d`: complete coverage,
  0 findings; token usage unavailable
- Codex Security amendment scan `431bf2ce-8590-491f-ba9c-52c36c9ac2cf`: complete
  coverage, 0 findings; token usage unavailable
- both amendment reviews are bound to snapshot
  `357315044c32607ecbe11cc8029ed0843e77312149e1d08bb7e1bb4057b1e9fc`
- original Codex Security scan `cef12403-0f32-46ee-a7c8-b0660880583a`: 0 findings
- after rebasing onto protected main `99426ded11f69ca25cf694649deac7ce818e2a29`,
  the integration retains adjacent selection then data documentation, both gateway
  exports, and all selection plus data contract-validator mappings
- the pinned provider preflight, research evidence, activation surfaces, registry and
  EXEC service are unchanged by the cancellation amendment

## Assurance

- `pnpm run check`: passed at exact commit
  `8d134c5e580ced95df6a2ed9fb1de5b0f2c2f57b` with 473 tests passed and one deliberate
  opt-in live ONS test skipped
- gateway suite: 130 passed; focused data-query application suite: 17 passed
- focused data-query contract tests: 4 passed
- cancellation hostile checks: 10 passed; fixture/runtime parity checks: 3 passed
- contract validation: 44 schemas, 93 records and 10 forbidden selection mutations
- the exact five-key query projection has canonical SHA-256
  `3c8290b217cef24e80a2a90d26101e9b9e1090ba8f508feaaa78a57a67c5a60c`
  across all six checked-in fixture, schema and selection-profile projections; the
  application and evidence-plan runtime exports match it too
- frozen offline pnpm and uv installs: passed with 153 pnpm packages reused and zero
  downloads
- browser acceptance: 27 passed, including accessibility and security journeys
- execution container: passed non-root, read-only, network-none and private
  health/readiness/OpenAPI acceptance
- two clean locked release builds were byte-identical:
  `7be5d8674185c114df417d6bc8414fb4414f8925eceaf99f1196eedd3347c209`
- secret and machine-path scan: 661 text files, no findings

## Publication boundary

This PR did not activate, deploy or release `data.query`. Its guarded squash merge
was authorised only after exact-head PR assurance, all CodeQL jobs and the
repository's open-alert check were terminal green. No deployment, tag, tunnel or
provider action formed part of the merge.
