### PR TITLE
docs: record protected-main QUAL-206 acceptance

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,11 +41,12 @@ through [pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14),
 whose accepted implementation commit is
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
 at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
-recorded below. Protected `main` is now at
-`f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a` and contains inactive catalogue,
-evidence, selection and fixed-data-query applications, direct and MCP transport
-seams, receipt-only lost-response reconciliation and the repository-only blocked
-gateway image plus the accepted repository-only QUAL-206 preflight. Production
+recorded below. The accepted implementation baseline for this hand-off is
+protected-main commit `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`; it contains
+inactive catalogue, evidence, selection and fixed-data-query applications, direct
+and MCP transport seams, receipt-only lost-response reconciliation and the
+repository-only blocked gateway image plus the accepted repository-only QUAL-206
+preflight. Production
 operation arrays remain empty, readiness remains `503`, and there is no public MCP
 service, live provider capability, external policy or identity service, deployment
 or `v0.2.0` release.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Current context
 
-Last updated: 22 August 2026
+Last updated: 23 August 2026
 
 ## Authority and reading order
 
@@ -42,12 +42,13 @@ whose accepted implementation commit is
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
 at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
 recorded below. Protected `main` is now at
-`e65071dc1f1bb0baab852bbf8218f9b5f953ad02` and contains inactive catalogue,
+`f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a` and contains inactive catalogue,
 evidence, selection and fixed-data-query applications, direct and MCP transport
 seams, receipt-only lost-response reconciliation and the repository-only blocked
-gateway image candidate. Production operation arrays remain empty, readiness
-remains `503`, and there is no public MCP service, live provider capability,
-external policy or identity service, deployment or `v0.2.0` release.
+gateway image plus the accepted repository-only QUAL-206 preflight. Production
+operation arrays remain empty, readiness remains `503`, and there is no public MCP
+service, live provider capability, external policy or identity service, deployment
+or `v0.2.0` release.
 
 The owner has authorised autonomous implementation in the open under
 [`ADR-0004`](docs/decisions/ADR-0004-public-autonomous-delivery.md). The repository
@@ -169,16 +170,23 @@ evidence manifest. Protected-main
 passed for Actions, JavaScript/TypeScript and Python. This is a verified
 repository-only container candidate, not a registry publication or deployment.
 
-The current QUAL-206 repository-preflight candidate adds deterministic local receipts
-for E01, E02, E09, E13, E15, E17 and E20, an integrated 30-risk Stage-2 threat record,
-an explicit unresolved disposition for the three retained High image vulnerabilities,
-and one exact injection-only approved ONS cache fallback for T04. The fallback is
-available only after an internally classified network failure or HTTP 500 to 599
-response; it does not add a default loader, environment override, production
-registration or live call. All local receipts remain non-live, unscored and
-incomplete for release. Public hosting, independent-host acceptance, workload
-identity, governed ingress and storage, a real
-deployed rollback and owner disposition of the retained vulnerabilities remain gates.
+QUAL-206 repository preflight merged through
+[pull request 49](https://github.com/chris-page-gov/gis-ai-go/pull/49) as
+`f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`. Protected-main
+[run 32567301935](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301935)
+passed repository, gateway-image, aggregate and provenance assurance, and
+[run 32567301734](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301734)
+passed CodeQL for Actions, JavaScript/TypeScript and Python. The accepted tree adds
+deterministic local receipts for E01, E02, E09, E13, E15, E17 and E20, an integrated
+30-risk Stage-2 threat record, an explicit unresolved disposition for the three
+retained High image vulnerabilities, and one exact injection-only approved ONS cache
+fallback for T04. The fallback is available only after an internally classified
+network failure or HTTP 500 to 599 response; it adds no default loader, environment
+override, production registration or live call. All local receipts remain non-live,
+unscored and incomplete for release. Public hosting, independent-host acceptance,
+workload identity, governed ingress and storage, a real deployed rollback and
+patched image bytes or explicit owner disposition of the retained vulnerabilities
+remain gates.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Delivery progress
 
-Last updated: 22 August 2026
+Last updated: 23 August 2026
 
 ## Current outcome
 
@@ -11,13 +11,12 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Active workstream
 
-`QUAL-206 — Complete the repository-only v0.2.0 release preflight`
+`EVID-204 — Close the remaining repository trace and readiness gaps`
 
-- execute and retain the applicable deterministic local evaluation receipts;
-- integrate the Stage-2 release threat record and explicitly disposition retained
-  container findings;
-- implement or precisely block the required `data.query` fallback without weakening
-  source, policy, rights, freshness or evidence semantics; and
+- record the accepted QUAL-206 repository preflight and current issue state;
+- carry validated W3C Trace Context through the fixed provider-adapter invocation;
+- re-verify configured evidence storage through an inactive readiness-integrity seam
+  while production readiness remains `503` and capability arrays remain empty; and
 - stop before any public runtime, live provider call, host credential, registry
   publication, activation, tag or release that requires separate authority.
 
@@ -124,6 +123,11 @@ The supported target active set is exactly `catalogue.search`,
 - those protected-main slices remain explicitly injected and suspended: production
   operation arrays are empty, readiness is `503`, and there is no public MCP service,
   live provider capability, deployment or `v0.2.0` release;
+- the completed repository/private boundaries for
+  [MCP-201](https://github.com/chris-page-gov/gis-ai-go/issues/19) and
+  [EXEC-202](https://github.com/chris-page-gov/gis-ai-go/issues/20) were reconciled
+  and closed on 23 August 2026. Their successor activation, live-host and deployment
+  gates remain open under TOOLS-205, QUAL-206 and DEPLOY-207;
 - DEPLOY-207 repository assurance merged through
   [pull request 48](https://github.com/chris-page-gov/gis-ai-go/pull/48) as protected-main
   commit `e65071dc1f1bb0baab852bbf8218f9b5f953ad02`. Protected-main
@@ -139,11 +143,18 @@ The supported target active set is exactly `catalogue.search`,
   the declared loopback binding, internal network and host-closed probes remain exact.
   Generated text and bounded phase output share the privacy gate; incomplete evidence
   remains private and is never uploaded. This is not a published image or deployment;
-- the repository-only QUAL-206 preflight candidate now retains deterministic local
+- QUAL-206 repository preflight merged through
+  [pull request 49](https://github.com/chris-page-gov/gis-ai-go/pull/49) as protected-main
+  commit `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`. Protected-main
+  [run 32567301935](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301935)
+  passed repository, exact gateway-image, aggregate and provenance assurance, while
+  [run 32567301734](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301734)
+  passed CodeQL for Actions, JavaScript/TypeScript and Python;
+- the accepted repository-only preflight retains deterministic local
   receipts for E01, E02, E09, E13, E15, E17 and E20 across 13 source-bound suites and
   58 exact selected tests. Every receipt remains non-live, unscored and explicitly
   incomplete as release evidence;
-- the candidate integrates all 30 Stage-2 threat-record risks, with a hold outcome for
+- the accepted tree integrates all 30 Stage-2 threat-record risks, with a hold outcome for
   activation and release, and records the three retained unfixed High image
   vulnerabilities as unresolved rather than accepting them;
 - T04 has one exact, content-addressed ONS cache fallback that must be injected
@@ -154,17 +165,22 @@ The supported target active set is exactly `catalogue.search`,
   fixed;
   all other failures remain closed, production registration remains empty and
   readiness remains `503`; and
-- the complete local repository gate passes on the combined candidate, including all
+- the complete local repository gate and protected pull-request checks pass on the
+  accepted tree, including all
   TypeScript and Python tests, 27 real-browser tests, deterministic release builds,
   contract, link and secret validation, the execution container, diagrams and the
   repository SBOM.
 
 ## Next
 
-1. Submit the exact repository-only QUAL-206 candidate through protected pull-request
-   assurance and CodeQL, merge only the unchanged reviewed head, and verify the
-   protected-main result.
-2. Only after a separately authorised public runtime exists, deploy an unregistered
+1. Complete the remaining EVID-204 trace-context and readiness-integrity contracts,
+   tests and acceptance evidence without activating a production operation.
+2. Evaluate a pinned official base that omits or fixes the three retained High
+   findings; accept it only if complete repository and image assurance, reproducible
+   OCI builds, SBOM, current scanning and compatibility review pass.
+3. Keep DEPLOY-207 at `status: decision needed` until an authorised public runtime,
+   hostname/TLS, identity, egress, storage and operator boundary exists.
+4. Only after that separate authority exists, deploy an unregistered
    candidate and complete live QUAL-206 evidence before any activation, registry
    publication, tag or `v0.2.0` release.
 
@@ -200,7 +216,7 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Latest evidence
 
-- QUAL-206 repository-preflight candidate: the
+- QUAL-206 repository-preflight acceptance: the
   [content-addressed local receipt set](evaluation/qual-206-local-evaluation-receipts.v1.json)
   binds 7 applicable cases, 13 suites and 58 exact tests to their current source and
   fixtures. The approved T04 cache, rebuild and provider-result identities
@@ -213,8 +229,11 @@ The supported target active set is exactly `catalogue.search`,
   proxies, method substitution and HTTP parser framing; and treats premature response
   closure, including a truncated redirect, as malformed while retaining pre-response
   connection resets as network failures. Only unchanged exact bytes with a terminal
-  no-P2 review and protected pull-request checks may progress. This is local, non-live
-  and unscored evidence, not host interoperability or release acceptance;
+  no-P2 review and protected pull-request checks progressed through
+  [pull request 49](https://github.com/chris-page-gov/gis-ai-go/pull/49) as
+  `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`. Protected-main CI and CodeQL passed.
+  This is accepted local, non-live and unscored evidence, not host interoperability or
+  release acceptance;
 - DEPLOY-207 protected-main evidence: the final aggregator rebuilds the OKF projection,
   materialises only Git-tracked allowlisted source plus checksummed OKF outputs,
   proves canonical repeat-build OCI identity, generates an unfiltered full Syft
@@ -226,9 +245,12 @@ The supported target active set is exactly `catalogue.search`,
   reproducible OCI. Compose declares only host loopback, while acceptance records
   either the realised loopback or a no-port internal fallback. This makes no
   host-ingress, public deployment, provider, activation or production-rollback claim.
-  [Run 32553285859](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32553285859)
-  passed on protected-main commit `e65071dc1f1bb0baab852bbf8218f9b5f953ad02`;
-  strict attestations bind the OCI archive, SBOM and evidence manifest to that source;
+  [Run 32567301935](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301935)
+  passed on protected-main commit `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`;
+  strict [OCI archive](https://github.com/chris-page-gov/gis-ai-go/attestations/42310989),
+  [SBOM](https://github.com/chris-page-gov/gis-ai-go/attestations/42310990) and
+  [evidence manifest](https://github.com/chris-page-gov/gis-ai-go/attestations/42310993)
+  attestations bind the exact subjects to that source;
 - every accepted public-read operation and transport remains inactive by default;
 - EVID-204 reconciliation acceptance: protected-main assurance and provenance pass
   in [run 32456796186](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32456796186),

--- a/changelog.d/QUAL-206.acceptance.changed.md
+++ b/changelog.d/QUAL-206.acceptance.changed.md
@@ -1,3 +1,5 @@
 - Recorded protected-main acceptance of the repository-only QUAL-206 preflight while
   keeping live host evidence, public deployment, three retained High image findings,
-  activation, registration and the `v0.2.0` release explicitly blocked.
+  activation, registration and the `v0.2.0` release explicitly blocked; stabilised
+  the 8 MiB privacy-scanner complexity guard without raising its ten-second ceiling
+  or removing any private-path case.

--- a/changelog.d/QUAL-206.acceptance.changed.md
+++ b/changelog.d/QUAL-206.acceptance.changed.md
@@ -1,0 +1,3 @@
+- Recorded protected-main acceptance of the repository-only QUAL-206 preflight while
+  keeping live host evidence, public deployment, three retained High image findings,
+  activation, registration and the `v0.2.0` release explicitly blocked.

--- a/docs/operations/DEPLOY-207_GATEWAY_CONTAINER.md
+++ b/docs/operations/DEPLOY-207_GATEWAY_CONTAINER.md
@@ -1,11 +1,33 @@
 # DEPLOY-207 blocked gateway container
 
-Status: repository-only candidate; inactive and undeployed.
+Status: accepted repository-only candidate on protected `main`; inactive and
+undeployed.
 
 This runbook covers the image, local Compose and assurance slice that can proceed
 without selecting a public runtime. It does not activate GIS AI GO, contact ONS,
 publish an image, create an HTTPS endpoint, register an MCP service or change the
 supported `v0.1.0` release.
+
+## Protected-main acceptance
+
+The repository-only container foundation merged through
+[pull request 48](https://github.com/chris-page-gov/gis-ai-go/pull/48). The later
+QUAL-206 preflight changed admitted provider and assurance source, then merged
+through [pull request 49](https://github.com/chris-page-gov/gis-ai-go/pull/49) as
+protected-main commit `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`.
+[Run 32567301935](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301935)
+rebuilt and verified the exact current image, two-build identity, full SBOM, retained
+vulnerability evidence, Compose boundary, storage restart, suspension and exact-image
+restore. The canonical OCI archive has SHA-256
+`1c6976c1242782d13b14fd826c64fec28b81513b1258f6359a6cce3f9dfb397a` and image
+manifest digest
+`sha256:c191f23ef6ceb16c324992075592a91a2171cc9b8b7f668fd153de5d0b549690`.
+Strict attestations bind the
+[OCI archive](https://github.com/chris-page-gov/gis-ai-go/attestations/42310989),
+[full image SBOM](https://github.com/chris-page-gov/gis-ai-go/attestations/42310990)
+and [closed evidence manifest](https://github.com/chris-page-gov/gis-ai-go/attestations/42310993)
+to that exact source. This acceptance publishes no image or service and changes no
+activation state.
 
 ## Exact boundary
 

--- a/docs/operations/DEPLOY-207_GATEWAY_CONTAINER.md
+++ b/docs/operations/DEPLOY-207_GATEWAY_CONTAINER.md
@@ -16,9 +16,9 @@ QUAL-206 preflight changed admitted provider and assurance source, then merged
 through [pull request 49](https://github.com/chris-page-gov/gis-ai-go/pull/49) as
 protected-main commit `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`.
 [Run 32567301935](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301935)
-rebuilt and verified the exact current image, two-build identity, full SBOM, retained
-vulnerability evidence, Compose boundary, storage restart, suspension and exact-image
-restore. The canonical OCI archive has SHA-256
+rebuilt and verified the exact image for that source, two-build identity, full SBOM,
+retained vulnerability evidence, Compose boundary, storage restart, suspension and
+exact-image restore. The canonical OCI archive has SHA-256
 `1c6976c1242782d13b14fd826c64fec28b81513b1258f6359a6cce3f9dfb397a` and image
 manifest digest
 `sha256:c191f23ef6ceb16c324992075592a91a2171cc9b8b7f668fd153de5d0b549690`.

--- a/docs/operations/EXEC-202_EXECUTION_SERVICE.md
+++ b/docs/operations/EXEC-202_EXECUTION_SERVICE.md
@@ -1,6 +1,9 @@
 # EXEC-202 private execution service
 
-Status: local merge candidate; not deployed, activated or registered.
+Status: accepted private implementation on protected `main` through
+[pull request 34](https://github.com/chris-page-gov/gis-ai-go/pull/34) as
+`6837af6eaa01ffb45e7da08d6a9131cedd1b1a0b`; not deployed, activated or
+registered.
 
 ## Delivered boundary
 

--- a/docs/operations/QUAL-206_IMAGE_VULNERABILITY_DISPOSITION.md
+++ b/docs/operations/QUAL-206_IMAGE_VULNERABILITY_DISPOSITION.md
@@ -3,26 +3,28 @@
 Status: unresolved repository preflight; not owner risk acceptance and not release
 readiness.
 
-Reviewed on: 22 August 2026.
+Reviewed on: 22 August 2026. Protected-main acceptance refreshed on 23 August 2026.
 
 ## Evidence identity
 
 Protected `main` commit
-[`e65071dc1f1bb0baab852bbf8218f9b5f953ad02`](https://github.com/chris-page-gov/gis-ai-go/commit/e65071dc1f1bb0baab852bbf8218f9b5f953ad02)
-passed [CI run 32553285859](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32553285859).
-That run regenerated the repository-only blocked candidate and retained the GitHub
+[`f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`](https://github.com/chris-page-gov/gis-ai-go/commit/f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a)
+passed [CI run 32567301935](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32567301935).
+That run regenerated the repository-only blocked candidate and retained GitHub
 Actions artefact
-`gateway-image-e65071dc1f1bb0baab852bbf8218f9b5f953ad02`.
+`gateway-image-f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`, artefact ID
+`9474493529`, with bundle digest
+`sha256:050bdbc55c6ca00a42c2da2fe51e8e3125468f60b339730ee68358d96480bcef`.
 
 The canonical OCI archive has SHA-256
-`6fa2b1dd95ea652fd53ffe9be552783537f18c5a0c3b6328045a551a27a0df31`;
+`1c6976c1242782d13b14fd826c64fec28b81513b1258f6359a6cce3f9dfb397a`;
 its image manifest digest is
-`sha256:353caf83949821354896746d2781f5efd8d8d1acad920545fa3c5e61ccaaa9f7`.
+`sha256:c191f23ef6ceb16c324992075592a91a2171cc9b8b7f668fd153de5d0b549690`.
 Protected-main provenance separately attests the
-[OCI archive](https://github.com/chris-page-gov/gis-ai-go/attestations/42286849),
-[full image SBOM](https://github.com/chris-page-gov/gis-ai-go/attestations/42286853)
+[OCI archive](https://github.com/chris-page-gov/gis-ai-go/attestations/42310989),
+[full image SBOM](https://github.com/chris-page-gov/gis-ai-go/attestations/42310990)
 and
-[closed evidence manifest](https://github.com/chris-page-gov/gis-ai-go/attestations/42286856).
+[closed evidence manifest](https://github.com/chris-page-gov/gis-ai-go/attestations/42310993).
 The evidence manifest binds the retained vulnerability database, complete Trivy
 report, closed scan projection and successful network-disabled replay.
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -11,8 +11,10 @@ implementations. Accepted inactive slices add explicitly constructed direct and 
 `evidence.inspect`, `selection.resolve` and `data.query` faces over the applications
 and durable ledger, plus a digest-only reconciliation index and receipt-only inspect
 v2 recovery. Its deterministic, non-live and unscored `QUAL-206-HOST-015` case passes
-locally. Default capability lists remain empty, activation and publication remain
-blocked, and no public MCP service or API is deployed.
+locally. The repository-only QUAL-206 preflight is accepted on protected `main`, but
+its evaluation receipts remain non-live, unscored and incomplete for release.
+Default capability lists remain empty, activation and publication remain blocked,
+and no public MCP service or API is deployed.
 
 - [Stage 0 boundary](STAGE_0_BOUNDARY.md)
 - [Dependency baseline](DEPENDENCIES.md)

--- a/docs/operations/TOOLS-205_DATA_QUERY_APPLICATION.md
+++ b/docs/operations/TOOLS-205_DATA_QUERY_APPLICATION.md
@@ -1,5 +1,9 @@
 # TOOLS-205 inactive data query application
 
+Status: accepted on protected `main` through
+[pull request 44](https://github.com/chris-page-gov/gis-ai-go/pull/44) as
+`b5f8edc78b011f3d4ccb4c6be60bbd49cdc4fc47`; not activated or deployed.
+
 Reviewed on 22 August 2026.
 
 This record preserves the application-only boundary at the time it was accepted and

--- a/docs/operations/TOOLS-205_PUBLIC_READ_TRANSPORT.md
+++ b/docs/operations/TOOLS-205_PUBLIC_READ_TRANSPORT.md
@@ -1,5 +1,9 @@
 # TOOLS-205 inactive public-read transport candidate
 
+Status: accepted on protected `main` through
+[pull request 45](https://github.com/chris-page-gov/gis-ai-go/pull/45) as
+`51147e0c7af438c28bb8dc4c66c8eb7fb27d3ded`; not activated or deployed.
+
 Reviewed on 21 August 2026.
 
 ## Outcome and publication boundary

--- a/docs/operations/TOOLS-205_SELECTION_RESOLVE.md
+++ b/docs/operations/TOOLS-205_SELECTION_RESOLVE.md
@@ -1,5 +1,9 @@
 # TOOLS-205 inactive selection resolver
 
+Status: accepted on protected `main` through
+[pull request 43](https://github.com/chris-page-gov/gis-ai-go/pull/43) as
+`99426ded11f69ca25cf694649deac7ce818e2a29`; not activated or deployed.
+
 The subsequent explicitly mounted local-conformance transport candidate is recorded
 in [`TOOLS-205_PUBLIC_READ_TRANSPORT.md`](TOOLS-205_PUBLIC_READ_TRANSPORT.md). It
 does not change this application's historical activation or publication boundary.

--- a/docs/operations/TOOLS-205_TOOL_REGISTRY.md
+++ b/docs/operations/TOOLS-205_TOOL_REGISTRY.md
@@ -1,6 +1,9 @@
 # TOOLS-205 non-activating tool registry candidate
 
-- status: local candidate; not activated, advertised or deployed
+- status: accepted on protected `main` through
+  [pull request 36](https://github.com/chris-page-gov/gis-ai-go/pull/36) as
+  `76103c1b10d57abb1e3dce4b6fe793faecf81dc8`; not activated, advertised or
+  deployed
 - work item: `TOOLS-205`
 - decision: [ADR-0009](../decisions/ADR-0009-read-only-mcp-tool-lifecycle.md)
 - base: protected `main` commit `364c8680ad11399e0547a843be2a04da7a737301`

--- a/docs/threat-model/QUAL-206_STAGE_2_RELEASE.md
+++ b/docs/threat-model/QUAL-206_STAGE_2_RELEASE.md
@@ -1,12 +1,19 @@
 # QUAL-206 Stage 2 release threat record
 
-Status: repository preflight only; activation and release are not accepted.
+Status: repository preflight accepted on protected `main`; activation and release
+are not accepted.
 
-Review date: 22 August 2026.
+Threat review date: 22 August 2026. Protected-main acceptance recorded on
+23 August 2026.
 
-Protected-main starting point: commit
+Protected-main review starting point: commit
 [`e65071dc1f1bb0baab852bbf8218f9b5f953ad02`](https://github.com/chris-page-gov/gis-ai-go/commit/e65071dc1f1bb0baab852bbf8218f9b5f953ad02),
 merged through [pull request 48](https://github.com/chris-page-gov/gis-ai-go/pull/48).
+The completed record and exact reviewed implementation merged through
+[pull request 49](https://github.com/chris-page-gov/gis-ai-go/pull/49) as protected-main
+commit
+[`f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`](https://github.com/chris-page-gov/gis-ai-go/commit/f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a),
+with passing protected-main CI, provenance and CodeQL.
 
 ## Decision boundary
 

--- a/scripts/gateway_image.py
+++ b/scripts/gateway_image.py
@@ -1200,7 +1200,18 @@ def _has_unexempted_path_match(
 def _contains_private_path(
     value: str, *, trusted_cpe_tokens: frozenset[str] = frozenset()
 ) -> bool:
-    if "/" not in value and "\\" not in value and "=" not in value:
+    has_forward_slash = "/" in value
+    has_backslash = "\\" in value
+    has_assignment = "=" in value
+    if not has_forward_slash and not has_backslash and not has_assignment:
+        return False
+    if (
+        not has_forward_slash
+        and not has_assignment
+        and ":" not in value
+        and "\\\\" not in value
+    ):
+        # A backslash-only match requires either a drive prefix or a UNC/device root.
         return False
     if not trusted_cpe_tokens and CPE_PATH_PREFIX_TEXT.search(value) is None:
         return PRIVATE_PATH_TEXT.search(value) is not None

--- a/tests/contract/test_gateway_image_contract.py
+++ b/tests/contract/test_gateway_image_contract.py
@@ -3402,87 +3402,89 @@ class GatewayImageContractTests(unittest.TestCase):
                 )
 
     def test_shared_privacy_boundary_is_linear_for_long_assignment_prefixes(self) -> None:
+        # Measure algorithm CPU cost rather than unrelated hosted-runner scheduling delay.
+        clock = time.process_time
         fixtures = (
             ("a_" * (8 * 1024 * 1024 // 2))[: 8 * 1024 * 1024],
             ("prefix_" * (8 * 1024 * 1024 // 7 + 1))[: 8 * 1024 * 1024],
             ("eyJ" * (8 * 1024 * 1024 // 3 + 1))[: 8 * 1024 * 1024],
         )
         for value in fixtures:
-            started = time.monotonic()
+            started = clock()
             with self.subTest(prefix=value[:8]):
                 self.assertIsNone(prohibited_text_reason(value))
-                self.assertLess(time.monotonic() - started, 10.0)
+                self.assertLess(clock() - started, 10.0)
         backslashes = "\\" * (8 * 1024 * 1024)
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(backslashes), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         colon_slashes = (":/" * (8 * 1024 * 1024 // 2))[: 8 * 1024 * 1024]
-        started = time.monotonic()
+        started = clock()
         self.assertIsNone(prohibited_text_reason(colon_slashes))
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         line_folds = ("a\n" * (4 * 1024 * 1024))[: 8 * 1024 * 1024]
-        started = time.monotonic()
+        started = clock()
         self.assertIsNone(prohibited_text_reason(line_folds))
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         self.assertEqual(prohibited_text_reason("/\n/:!@"), "sensitive")
         self.assertEqual(prohibited_text_reason("/\n/!!/@@"), "private-path")
 
         spaces = " " * (8 * 1024 * 1024)
-        started = time.monotonic()
+        started = clock()
         self.assertIsNone(prohibited_text_reason(spaces))
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         continuations = ("a\\\n" * (8 * 1024 * 1024 // 3 + 1))[
             : 8 * 1024 * 1024
         ]
-        started = time.monotonic()
+        started = clock()
         self.assertIsNone(prohibited_text_reason(continuations))
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         escaped_quotes = "{" + '\\"' * ((8 * 1024 * 1024 - 1) // 2)
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(escaped_quotes), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         unclosed_comments = "{" + "name/*" * ((8 * 1024 * 1024 - 1) // 6)
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(unclosed_comments), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         for comment in ("/*", "//"):
             comment_only = (comment * (MAX_PRIVACY_MALFORMED_CHARS // 2 + 1))[
                 : MAX_PRIVACY_MALFORMED_CHARS + 1
             ]
-            started = time.monotonic()
+            started = clock()
             with self.subTest(comment=comment):
                 self.assertEqual(prohibited_text_reason(comment_only), "sensitive")
-                self.assertLess(time.monotonic() - started, 10.0)
+                self.assertLess(clock() - started, 10.0)
 
         dense_malformed_tokens = "{" + ("a " * (4 * 1024 * 1024 - 1)) + "}"
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(dense_malformed_tokens), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         sequential_frames = "{" + "{}" * 4_097 + "}"
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(sequential_frames), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         cpe_unit = "cpe:2.3:a:x:x:1:*:*:*:*:*:*:* "
         dense_cpe = (cpe_unit * (MAX_PRIVACY_TEXT_BYTES // len(cpe_unit) + 1))[
             :MAX_PRIVACY_TEXT_BYTES
         ]
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(dense_cpe), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         over_raw_bound = "a" * (16 * 1024 * 1024) + "\n"
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(over_raw_bound), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         aggregate_json = json.dumps(
             {
@@ -3491,33 +3493,33 @@ class GatewayImageContractTests(unittest.TestCase):
             },
             separators=(",", ":"),
         )
-        started = time.monotonic()
+        started = clock()
         self.assertGreater(len(aggregate_json), 8 * 1024 * 1024)
         self.assertEqual(prohibited_text_reason(aggregate_json), "sensitive")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         over_utf8_bound = "£" * (4 * 1024 * 1024 + 1)
         over_utf8_bytes = over_utf8_bound.encode("utf-8")
-        started = time.monotonic()
+        started = clock()
         self.assertLess(len(over_utf8_bound), 8 * 1024 * 1024)
         self.assertGreater(len(over_utf8_bytes), 8 * 1024 * 1024)
         self.assertEqual(prohibited_text_reason(over_utf8_bound), "sensitive")
         with self.assertRaisesRegex(ValueError, "prohibited sensitive"):
             assert_no_private_text(over_utf8_bytes, "fixture")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         encoded_run = "%41" * (MAX_PRIVACY_TEXT_BYTES // 3)
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(
             prohibited_json_reason({"safe": encoded_run}),
             "sensitive",
         )
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
         long_traversal = "/" + "a/" * (8 * 1024 * 1024 // 2 - 8) + "../private"
-        started = time.monotonic()
+        started = clock()
         self.assertEqual(prohibited_text_reason(long_traversal), "private-path")
-        self.assertLess(time.monotonic() - started, 10.0)
+        self.assertLess(clock() - started, 10.0)
 
     def test_acceptance_binding_rejects_coordinated_runtime_mutations(self) -> None:
         source = {


### PR DESCRIPTION
## Outcome

- record protected-main acceptance of the repository-only QUAL-206 preflight at
  `f0e3ccc1dceeba6b3f7d0ecd56c5dd083dee405a`;
- bind the current CI, CodeQL, gateway-image, SBOM and attestation identities;
- reconcile the accepted private/inactive EXEC-202 and TOOLS-205 implementation
  records;
- move the hand-off to the two remaining EVID-204 repository gaps, patched-image
  evaluation and the separately governed DEPLOY-207 decision; and
- keep the 8 MiB privacy-scanner complexity guard portable without raising its
  ten-second ceiling or removing any recognised private-path case.

The full branch diff at head
`44563a6e74b331e7a5209e4311b9c11f0969f169` has SHA-256
`ff44b458893d04297c7191af9e8663471a25e43f3342dd295fa5d37166bf83db`.
An independent review of the substantive acceptance/status patch found no P1 or
factual blocker; its one changelog-formatting P2 was corrected before commit.

## CI correction

Two GitHub-hosted runs exceeded the 10-second wall-clock ceiling for the same 8 MiB
line-continuation fixture by 0.135 and 0.055 seconds. Changing that algorithmic test
to process CPU time then exposed a genuine Linux-runner cost of 10.189 seconds, so
the ceiling was not raised and the fixture was not reduced.

Profiling showed that two general private-path regular-expression scans dominated
the safe continuation case even though it cannot contain a recognised path. The
scanner now skips those scans only when a backslash-bearing value contains no
forward slash, assignment, drive colon or doubled UNC/device backslash. Every
recognised backslash-only private-path form requires at least one of those necessary
characters. Existing regressions cover drive, UNC, device, runner-variable, CPE and
encoded paths.

The focused hot phase fell from about 1.39 seconds to 0.003 seconds locally. The
test now measures algorithm CPU cost, retains its 10-second ceiling and retains every
adversarial fixture. Detection semantics and release policy are unchanged.

## Verification

- `pnpm run check`
- `uv run --locked --cache-dir .uv-cache python -m unittest tests.contract.test_gateway_image_contract.GatewayImageContractTests.test_shared_privacy_boundary_is_linear_for_long_assignment_prefixes`
- `uv run --locked --cache-dir .uv-cache python -m unittest tests.contract.test_gateway_image_contract` (48 tests)
- `git diff --check`

The complete locked gate includes typechecks; TypeScript, interoperability, Explorer,
217 repository Python and 20 execution-service tests; 27 real-browser checks; two
byte-identical release builds; contract, version, link and secret validation;
diagram rendering; and the repository SBOM.

## Publication boundary

This reconciles documentation and tracker state and optimises one release-assurance
scanner prefilter plus its complexity measurement. It changes no production gateway
or execution runtime, schema, workflow, capability array, readiness status, provider
call, deployment, activation, registry entry, tag or release. Production capability
arrays remain empty, readiness remains `503`, and the three retained High image
findings remain unresolved release gates.

Relates to #22, #23, #24 and #25.
