### PR TITLE
test(qual): bind Claude legacy readiness

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,13 +41,13 @@ through [pull request 14](https://github.com/chris-page-gov/gis-ai-go/pull/14),
 whose accepted implementation commit is
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
 at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
-recorded below. The latest protected-main runtime hand-off is
+recorded below. The latest protected-main repository hand-off is
+`30b575beb27ff805745a2864c1acf44392774046`; its unchanged runtime baseline is
 `7fa8b720d3cbaa3e0a1ebfadf0fb355a7330a04c`. It contains the repository-only
 QUAL-206 preflight, completed trace and readiness integrity, one compile-time
-`candidate-unregistered` exact-five assembly, the bounded 23 August research intake
-and a dedicated inline-only receipt for each successful current `evidence.inspect`
-call. The repository-local protocol matrix in this tree is bound to that runtime
-baseline.
+`candidate-unregistered` exact-five assembly, the bounded 23 August research intake,
+a dedicated inline-only receipt for each successful current `evidence.inspect` call
+and the source-bound repository-local protocol matrix.
 The shipped production and default operation arrays remain empty and their
 readiness remains `503`. There is no public MCP service, activated live provider
 capability, external policy or identity service, deployment or `v0.2.0` release.
@@ -257,14 +257,29 @@ the inspected stored receipt. The new receipt is not persisted or attested and
 creates no ledger record or event; historical v1 and v2 contracts remain unchanged.
 This does not activate, register, deploy or release the candidate.
 
-The repository-local QUAL-206 protocol matrix in this tree binds four
+The repository-local QUAL-206 protocol matrix merged through
+[pull request 55](https://github.com/chris-page-gov/gis-ai-go/pull/55) as
+protected-main commit `30b575beb27ff805745a2864c1acf44392774046`.
+Protected-main
+[run 32667087755](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32667087755)
+passed repository, exact gateway-image, aggregate and provenance assurance, and
+[run 32667087601](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32667087601)
+passed CodeQL for Actions, JavaScript/TypeScript and Python. The matrix binds four
 official-client and raw-transcript HTTP and STDIO source-coverage rows to exact Git
-blobs from that protected-main runtime. Its in-process STDIO regression covers seven
+blobs from the protected-main runtime. Its in-process STDIO regression covers seven
 suspension scenarios, nine resulting suspensions, reduced tool and resource
 discovery, rejected suspended calls and zero provider calls. The JSON records no
 test-runner outcome; current execution is established separately by repository
 assurance. It remains repository-only, non-live and unscored; it is not desktop
 STDIO, remote HTTP, live-provider, activation, deployment or release evidence.
+
+A separate source-bound Claude Code `2.1.204` observation now records protected-main
+legacy STDIO transport readiness from a clean, detached checkout of that exact
+commit. The constructor-only two-tool launcher completed initialisation and
+`tools/list`; capability remains unscored. The earlier modern-only `not_ready`
+record and uncommitted exploratory record remain unchanged. No model authentication,
+model task, tool call, resource read, exact-five production assembly, live provider,
+remote HTTP host, registration, activation, deployment or release was exercised.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,7 +15,9 @@ The supported target active set is exactly `catalogue.search`,
 
 - retain the repository-local STDIO and client/version matrix bound to the
   protected-main v3 inspection-receipt runtime as preflight only;
-- complete independent desktop-STDIO and remote-HTTP host evidence separately; and
+- retain the source-bound Claude Code `2.1.204` legacy STDIO transport-readiness
+  result separately from capability scoring, then complete the remaining
+  independent desktop-STDIO and remote-HTTP host evidence; and
 - stop before any public runtime, live provider call, host credential, registry
   publication, activation, tag or release that requires separate authority.
 
@@ -203,12 +205,27 @@ The supported target active set is exactly `catalogue.search`,
   inspection result carries a distinct verifiable inline receipt without persisting
   or attesting it or creating a ledger record or event. Historical v1 and v2
   contracts remain unchanged, and production registration remains false; and
-- the repository-local QUAL-206 protocol matrix in this tree binds four pinned
+- the repository-local QUAL-206 protocol matrix merged through
+  [pull request 55](https://github.com/chris-page-gov/gis-ai-go/pull/55) as
+  protected-main commit `30b575beb27ff805745a2864c1acf44392774046` with
+  passing protected-main assurance and provenance in
+  [run 32667087755](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32667087755)
+  and passing CodeQL in
+  [run 32667087601](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32667087601).
+  It binds four pinned
   official-client and raw-transcript HTTP and STDIO source-coverage rows to exact
   Git blobs from the protected-main v3 runtime. Seven in-process suspension
   scenarios produce nine suspensions, reduced discovery, rejected calls and zero
   provider calls. The JSON records no test-runner outcome; it remains non-live and
   unscored and does not complete independent-host evidence; and
+- Claude Code `2.1.204` subsequently completed legacy STDIO initialisation and
+  `tools/list` through the constructor-only two-tool conformance launcher from a
+  clean, detached checkout of exact protected-main commit
+  `30b575beb27ff805745a2864c1acf44392774046`. This is source-bound transport
+  readiness with capability unscored. It does not alter the earlier modern-only
+  `not_ready` or exploratory records and exercised no model authentication, model task,
+  tool call, resource read, exact-five production assembly, live provider, remote
+  HTTP host, registration, activation, deployment or release; and
 - acceptance requires both the complete local repository gate, which passes on this
   matrix tree, and the protected pull-request and protected-main checks. The local
   gate includes all TypeScript and Python tests, 27 real-browser tests,
@@ -217,9 +234,9 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Next
 
-1. Complete independent desktop-STDIO and remote-HTTP host evidence. The local
-   protocol matrix remains repository-only preflight and does not complete issue
-   #24's live-host criteria.
+1. Complete bounded Claude capability evidence and the remaining independent
+   desktop-STDIO and remote-HTTP host evidence. The local protocol matrix and
+   Claude transport-only result do not complete issue #24's live-host criteria.
 2. Monitor official supported glibc base releases. Re-probe Bookworm and Trixie
    only when immutable upstream bytes or package fix status changes; accept a
    replacement only if complete repository and image assurance, reproducible OCI
@@ -241,9 +258,10 @@ The supported target active set is exactly `catalogue.search`,
   service identity and network-policy evidence.
 - Activating or publishing a catalogue service remains hard-blocked. Raw protocol
   transcripts, deterministic local host fixtures and the pinned SDK clients do not
-  establish independent live major-host interoperability. Security, accessibility,
-  governed ingress/storage admission, retention/disposal and host-specific lifecycle
-  evidence remain activation gates.
+  establish independent live major-host interoperability. The source-bound Claude
+  transport check establishes initialisation and listing only, not capability.
+  Security, accessibility, governed ingress/storage admission, retention/disposal
+  and host-specific lifecycle evidence remain activation gates.
 - Direct routes and MCP transports now exist on protected `main`, but the
   exact-five assembly is `candidate-unregistered`, production registration is
   false, the production/default capability arrays are empty, shipped readiness is
@@ -269,6 +287,17 @@ The supported target active set is exactly `catalogue.search`,
 
 ## Latest evidence
 
+- Claude Code `2.1.204` protected-main legacy STDIO readiness: the
+  [source-bound summary](tests/interoperability/evidence/claude-code-legacy-stdio-readiness-2026-08-23.json)
+  records a clean, detached checkout of exact protected-main commit
+  `30b575beb27ff805745a2864c1acf44392774046`, current-wrapper telemetry and a
+  successful `mcp list` transport check. Initialisation and `tools/list` passed
+  through the constructor-only two-tool conformance launcher. Capability remains
+  unscored; no model authentication, model task, tool call, resource read, exact-five
+  production assembly, live provider, remote HTTP host, registration, activation,
+  deployment or release was exercised. The historical modern-only `not_ready` and
+  uncommitted exploratory records remain unchanged;
+
 - current protected-main runtime hand-off: EVID-204 inspection receipts
   [pull request 54](https://github.com/chris-page-gov/gis-ai-go/pull/54) merged as
   `7fa8b720d3cbaa3e0a1ebfadf0fb355a7330a04c`; protected-main assurance and
@@ -285,7 +314,14 @@ The supported target active set is exactly `catalogue.search`,
   `gis-ai-go:qual-206-local-evaluation-set:sha256:160298c85fb3db5394c5c27d4905e1e5cf086bad60aae3b7512f2890dcbeb43d`
   and file SHA-256
   `f93e0988a966e0387cde1bdb89261fe40308e733f1ac7725e8735818094e1dea`;
-- QUAL-206 local protocol-matrix candidate: the matrix in this tree binds the
+- QUAL-206 local protocol-matrix acceptance: protected
+  [pull request 55](https://github.com/chris-page-gov/gis-ai-go/pull/55) merged as
+  `30b575beb27ff805745a2864c1acf44392774046`; protected-main assurance and
+  provenance passed in
+  [run 32667087755](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32667087755)
+  and CodeQL passed in
+  [run 32667087601](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32667087601).
+  The matrix binds the
   official MCP client 2.0.0 and MCP 2026-07-28 source coverage across four
   semantically fixed HTTP and STDIO rows to exact Git blobs from protected-main
   runtime `7fa8b720d3cbaa3e0a1ebfadf0fb355a7330a04c`. Seven in-process suspension

--- a/changelog.d/QUAL-206-claude-legacy-readiness.changed.md
+++ b/changelog.d/QUAL-206-claude-legacy-readiness.changed.md
@@ -1,0 +1,5 @@
+- Record source-bound Claude Code `2.1.204` legacy STDIO transport readiness from
+  exact protected-main bytes. Initialisation and tool listing pass through the
+  constructor-only two-tool conformance seam; capability remains unscored and no
+  exact-five assembly, live provider, remote host, activation, deployment or
+  release is claimed.

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -2,16 +2,22 @@
 
 - status: local conformance and four ChatGPT secure-tunnel probes passed, including
   the current final telemetry wrapper;
-  four independent-host readiness attempts are documented but not ready;
+  four 20 August independent-host readiness attempts remain documented as not
+  ready; a separate 23 August Claude Code legacy STDIO observation from exact
+  protected-main bytes passed initialisation and tool listing, with capability
+  unscored;
   deterministic `HOST-015` application recovery passes locally but remains non-live
   and unscored; capability scoring and activation remain pending
 - reviewed source base: `66507f9a6e6c0da23a8af4682268f9362d93bc06`
+- Claude transport-readiness source: protected `main` commit
+  `30b575beb27ff805745a2864c1acf44392774046`
 - legacy fallback integration base: protected `main` commit
   `5a7e441bfc754af2bf95ec49a5ec113951c7c0bf`
 - legacy fallback status: accepted through
   [pull request 40](https://github.com/chris-page-gov/gis-ai-go/pull/40) at
   protected `main` commit `e1fc1cbe69ea72c9aa310607d80f392ef56b0d58`;
-  it has not been deployed or retested through a live host
+  it has not been deployed; its constructor-only launcher has since been exercised
+  by isolated Claude Code transport from later protected-main bytes
 - supported public product: immutable
   [`v0.1.0`](https://github.com/chris-page-gov/gis-ai-go/releases/tag/v0.1.0)
 - production MCP activation: empty
@@ -200,7 +206,8 @@ MCP registry for a conformance run.
 | ChatGPT | Secure tunnel, discovery, search, receipt and text fallback | Four probes passed; latest run binds the final wrapper and current receipt |
 | Codex CLI 0.146.1 | Isolated non-interactive STDIO search and inline evidence | `not_ready`: legacy `2025-06-18` initialisation rejected `-32022`; capability unscored |
 | Antigravity IDE 1.107.0 | Temporary profile, STDIO discovery, search, resource and fallback | `not_ready`: isolated profile signed out and server directory unavailable; zero MCP traffic |
-| Claude Code 2.1.204 | Strict temporary MCP configuration and non-persistent session | `not_ready`: legacy `initialize` rejected `-32022`; capability unscored |
+| Claude Code 2.1.204, modern-only seam, 20 August | Strict temporary MCP configuration and non-persistent session | `not_ready`: legacy `initialize` rejected `-32022`; capability unscored |
+| Claude Code 2.1.204, protected-main legacy seam, 23 August | Isolated `mcp list` transport check against the protected-main source named below | `ready`: legacy initialisation and `tools/list` passed; capability unscored |
 | VS Code 1.134.0 | Temporary workspace and MCP registry; prove correct window attachment | `not_ready`: no GitHub token and no proved chat attachment; zero MCP traffic |
 | Official SDK client | HTTP and STDIO discovery, calls, resources and shutdown | Accepted on protected `main` |
 
@@ -582,6 +589,33 @@ That exploratory summary deliberately retains base commit `b798a40`, a null
 candidate commit and its original runtime hashes because those are the bytes that
 were observed. The rebase did not rerun a host, use a credential, touch the
 ChatGPT tunnel or upgrade that exploratory observation into accepted evidence.
+
+### Protected-main Claude Code transport readiness
+
+A later isolated `claude mcp list` observation repeated the transport check from a
+clean, detached checkout of exact protected-main commit
+`30b575beb27ff805745a2864c1acf44392774046`, tree
+`bb84c13d618984304d5db300be775275b8037ea8`. The current telemetry wrapper and
+the protected-main source blobs are bound in the separate
+[`Claude Code legacy STDIO readiness summary`](../../tests/interoperability/evidence/claude-code-legacy-stdio-readiness-2026-08-23.json).
+The temporary profile removed both supported OpenAI key variables from the parent
+and MCP child environments, supplied no model authentication and left no scoped
+process running after the check.
+
+Claude Code `2.1.204` returned `Connected`. Its `2025-06-18` legacy STDIO session
+completed initialisation, the initialised notification and `tools/list`, then exited
+cleanly with no malformed, truncated or pending request. This makes the tested
+transport `ready`; it does not score host capability. The launcher was the
+constructor-only two-tool conformance seam, not the exact-five unregistered
+production assembly. No model task, tool call, resource read, live provider,
+remote HTTP host, registration, activation, deployment or release was exercised.
+
+This new record does not change either historical result. The 20 August
+modern-only attempt remains `not_ready` because it received `-32022`, and the
+uncommitted fallback observation remains exploratory. Complete a separately
+authorised, bounded model task before scoring Claude capability, and complete the
+remaining independent desktop and remote HTTP evidence before claiming the full
+independent-host gate.
 
 This fallback is local-only. Do not attach it to the existing ChatGPT tunnel,
 change that tunnel's profile, publish its address, activate a production tool or

--- a/schemas/qual-206-legacy-stdio-readiness.schema.json
+++ b/schemas/qual-206-legacy-stdio-readiness.schema.json
@@ -1,0 +1,647 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:qual-206-legacy-stdio-readiness:v1",
+  "title": "QUAL-206 protected-main legacy STDIO readiness evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_contract",
+    "status",
+    "observed_at",
+    "source",
+    "host",
+    "telemetry",
+    "isolation",
+    "limitations",
+    "boundary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.qual-206-legacy-stdio-readiness.v1"
+    },
+    "schema_contract": {
+      "$ref": "#/$defs/schemaContract"
+    },
+    "status": {
+      "const": "readiness-pass-capability-unscored"
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit",
+        "tree",
+        "protected_main",
+        "version",
+        "detached_checkout",
+        "worktree_changes_uncommitted",
+        "production_registration",
+        "production_activation",
+        "public_endpoint_created",
+        "runtime_files",
+        "build"
+      ],
+      "properties": {
+        "repository": {
+          "const": "chris-page-gov/gis-ai-go"
+        },
+        "commit": {
+          "const": "30b575beb27ff805745a2864c1acf44392774046"
+        },
+        "tree": {
+          "const": "bb84c13d618984304d5db300be775275b8037ea8"
+        },
+        "protected_main": {
+          "const": true
+        },
+        "version": {
+          "const": "0.1.0"
+        },
+        "detached_checkout": {
+          "const": true
+        },
+        "worktree_changes_uncommitted": {
+          "const": false
+        },
+        "production_registration": {
+          "const": false
+        },
+        "production_activation": {
+          "const": false
+        },
+        "public_endpoint_created": {
+          "const": false
+        },
+        "runtime_files": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "prefixItems": [
+            {
+              "$ref": "#/$defs/runtimeMcpServer"
+            },
+            {
+              "$ref": "#/$defs/runtimeMcpStdio"
+            },
+            {
+              "$ref": "#/$defs/runtimeLegacyLauncher"
+            },
+            {
+              "$ref": "#/$defs/runtimeTelemetryProxy"
+            }
+          ],
+          "items": false
+        },
+        "build": {
+          "$ref": "#/$defs/buildObservation"
+        }
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "platform",
+        "architecture",
+        "binary_sha256",
+        "command",
+        "transport",
+        "model_authentication_supplied",
+        "model_task_requested",
+        "transport_readiness",
+        "capability",
+        "classification",
+        "host_result",
+        "requested_protocol_version",
+        "requested_protocol_version_evidence",
+        "initialize_success",
+        "tools_list_success",
+        "tool_call_observed",
+        "resource_read_observed"
+      ],
+      "properties": {
+        "name": {
+          "const": "Claude Code"
+        },
+        "version": {
+          "const": "2.1.204"
+        },
+        "platform": {
+          "const": "darwin"
+        },
+        "architecture": {
+          "const": "arm64"
+        },
+        "binary_sha256": {
+          "const": "1677b67595b6251156d62600dc85d4070ec385b72dd0b07e73742a56030952c3"
+        },
+        "command": {
+          "const": "mcp list"
+        },
+        "transport": {
+          "const": "legacy-stdio"
+        },
+        "model_authentication_supplied": {
+          "const": false
+        },
+        "model_task_requested": {
+          "const": false
+        },
+        "transport_readiness": {
+          "const": "ready"
+        },
+        "capability": {
+          "const": "unscored"
+        },
+        "classification": {
+          "const": "legacy-handshake-and-tool-list-pass"
+        },
+        "host_result": {
+          "const": "Connected"
+        },
+        "requested_protocol_version": {
+          "const": "2025-06-18"
+        },
+        "requested_protocol_version_evidence": {
+          "const": "exact-initialise-frame-digest-matches-reviewed-2025-06-18-observation"
+        },
+        "initialize_success": {
+          "const": true
+        },
+        "tools_list_success": {
+          "const": true
+        },
+        "tool_call_observed": {
+          "const": false
+        },
+        "resource_read_observed": {
+          "const": false
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "current_wrapper_exercised",
+        "session_id_sha256",
+        "command_sha256",
+        "node_version",
+        "source_commit",
+        "retained_private_bytes",
+        "retained_private_sha256",
+        "retained_private_mode",
+        "event_count",
+        "event_counts",
+        "initialize_request",
+        "initialize_response",
+        "initialized_notification",
+        "tools_list_request",
+        "tools_list_response",
+        "invalid_frame_count",
+        "non_json_frame_count",
+        "truncated_frame_count",
+        "server_stderr_event_count",
+        "exit_code",
+        "pending_request_count",
+        "raw_content_published"
+      ],
+      "properties": {
+        "schema": {
+          "const": "gis-ai-go.qual-206-host-telemetry.v1"
+        },
+        "current_wrapper_exercised": {
+          "const": true
+        },
+        "session_id_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "command_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "node_version": {
+          "const": "v26.7.0"
+        },
+        "source_commit": {
+          "const": "30b575beb27ff805745a2864c1acf44392774046"
+        },
+        "retained_private_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "retained_private_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "retained_private_mode": {
+          "const": "0600"
+        },
+        "event_count": {
+          "const": 7
+        },
+        "event_counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_start",
+            "request",
+            "response",
+            "session_end"
+          ],
+          "properties": {
+            "session_start": {
+              "const": 1
+            },
+            "request": {
+              "const": 3
+            },
+            "response": {
+              "const": 2
+            },
+            "session_end": {
+              "const": 1
+            }
+          }
+        },
+        "initialize_request": {
+          "$ref": "#/$defs/requestFrameOther"
+        },
+        "initialize_response": {
+          "$ref": "#/$defs/successResponse"
+        },
+        "initialized_notification": {
+          "$ref": "#/$defs/requestFrameOther"
+        },
+        "tools_list_request": {
+          "$ref": "#/$defs/requestFrameToolsList"
+        },
+        "tools_list_response": {
+          "$ref": "#/$defs/successResponse"
+        },
+        "invalid_frame_count": {
+          "const": 0
+        },
+        "non_json_frame_count": {
+          "const": 0
+        },
+        "truncated_frame_count": {
+          "const": 0
+        },
+        "server_stderr_event_count": {
+          "const": 0
+        },
+        "exit_code": {
+          "const": 0
+        },
+        "pending_request_count": {
+          "const": 0
+        },
+        "raw_content_published": {
+          "const": false
+        }
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temporary_profile",
+        "directory_mode",
+        "claude_config_mode",
+        "proxy_log_mode",
+        "normal_profile_mutation_observed",
+        "parent_openai_key_variables_removed",
+        "mcp_child_environment_allowlisted",
+        "mcp_child_openai_key_variables_removed",
+        "files_scanned_for_token_patterns",
+        "token_pattern_matches",
+        "remaining_isolated_processes_after_cleanup",
+        "raw_host_logs_published"
+      ],
+      "properties": {
+        "temporary_profile": {
+          "const": true
+        },
+        "directory_mode": {
+          "const": "0700"
+        },
+        "claude_config_mode": {
+          "const": "0600"
+        },
+        "proxy_log_mode": {
+          "const": "0600"
+        },
+        "normal_profile_mutation_observed": {
+          "const": false
+        },
+        "parent_openai_key_variables_removed": {
+          "const": true
+        },
+        "mcp_child_environment_allowlisted": {
+          "const": true
+        },
+        "mcp_child_openai_key_variables_removed": {
+          "const": true
+        },
+        "files_scanned_for_token_patterns": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "token_pattern_matches": {
+          "const": 0
+        },
+        "remaining_isolated_processes_after_cleanup": {
+          "const": 0
+        },
+        "raw_host_logs_published": {
+          "const": false
+        }
+      }
+    },
+    "limitations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability_result_claimed",
+        "independent_host_gate_completed",
+        "exact_five_assembly_exercised",
+        "live_provider_called",
+        "remote_http_observed",
+        "chatgpt_tunnel_touched",
+        "activation_or_release_claimed"
+      ],
+      "properties": {
+        "capability_result_claimed": {
+          "const": false
+        },
+        "independent_host_gate_completed": {
+          "const": false
+        },
+        "exact_five_assembly_exercised": {
+          "const": false
+        },
+        "live_provider_called": {
+          "const": false
+        },
+        "remote_http_observed": {
+          "const": false
+        },
+        "chatgpt_tunnel_touched": {
+          "const": false
+        },
+        "activation_or_release_claimed": {
+          "const": false
+        }
+      }
+    },
+    "boundary": {
+      "const": "Accepted protected-main Claude Code transport-readiness evidence only. The constructor-only local conformance launcher passed legacy STDIO initialisation and tools/list; no tool, resource, exact-five production assembly, model, provider, remote HTTP host, registration, activation, deployment or release was exercised. Capability remains unscored."
+    }
+  },
+  "$defs": {
+    "schemaContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "schemas/qual-206-legacy-stdio-readiness.schema.json"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "runtimeMcpServer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "apps/mcp-gateway/src/mcp-server.ts"
+        },
+        "sha256": {
+          "const": "e2c5cec027f3049d0a501b885a0ab6336d7e6059690df54ac7b257945807b454"
+        }
+      }
+    },
+    "runtimeMcpStdio": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "apps/mcp-gateway/src/mcp-stdio.ts"
+        },
+        "sha256": {
+          "const": "5e8d87020d1efe34b2b83940f60d2df5926f466c12473fffc156463c9a6cef30"
+        }
+      }
+    },
+    "runtimeLegacyLauncher": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "scripts/qual_206_legacy_conformance_server.mjs"
+        },
+        "sha256": {
+          "const": "bf87bec24357d5fd6d419bd8b4374642ab46a2f3dfa6d9baebde46f7498edb9c"
+        }
+      }
+    },
+    "runtimeTelemetryProxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "scripts/qual_206_telemetry_proxy.mjs"
+        },
+        "sha256": {
+          "const": "3800e4458932ee1324ad03d64007f23f76f49682a6eabdc191ecf6eaccb501d5"
+        }
+      }
+    },
+    "buildObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "dependencies_installed_with_frozen_lockfile",
+        "preflight_passed",
+        "lockfile",
+        "compiled_entrypoints"
+      ],
+      "properties": {
+        "command": {
+          "const": "pnpm run test:interoperability"
+        },
+        "dependencies_installed_with_frozen_lockfile": {
+          "const": true
+        },
+        "preflight_passed": {
+          "const": true
+        },
+        "lockfile": {
+          "$ref": "#/$defs/lockfile"
+        },
+        "compiled_entrypoints": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "prefixItems": [
+            {
+              "$ref": "#/$defs/compiledMcpServer"
+            },
+            {
+              "$ref": "#/$defs/compiledMcpStdio"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "lockfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "pnpm-lock.yaml"
+        },
+        "sha256": {
+          "const": "640208aa66d26241514025b33dbde50bc14be7bbd33641eec9977e87699bb4ec"
+        }
+      }
+    },
+    "compiledMcpServer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_path", "sha256"],
+      "properties": {
+        "source_path": {
+          "const": "apps/mcp-gateway/dist/src/mcp-server.js"
+        },
+        "sha256": {
+          "const": "71fdde3b45363d366b62e7c4219c2cc77efbfbfe9d9e5d110f656e76ee9d2ab1"
+        }
+      }
+    },
+    "compiledMcpStdio": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_path", "sha256"],
+      "properties": {
+        "source_path": {
+          "const": "apps/mcp-gateway/dist/src/mcp-stdio.js"
+        },
+        "sha256": {
+          "const": "17a04b0b1f0a5549157c8e07119ac1d7a895b86d9a73312aaaa2561fd1e092e3"
+        }
+      }
+    },
+    "requestFrameOther": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method_label",
+        "frame_bytes",
+        "frame_sha256",
+        "parameters_bytes",
+        "parameters_sha256"
+      ],
+      "properties": {
+        "method_label": {
+          "const": "other"
+        },
+        "frame_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "frame_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "parameters_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        },
+        "parameters_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "requestFrameToolsList": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method_label",
+        "frame_bytes",
+        "frame_sha256",
+        "parameters_bytes",
+        "parameters_sha256"
+      ],
+      "properties": {
+        "method_label": {
+          "const": "tools/list"
+        },
+        "frame_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "frame_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "parameters_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        },
+        "parameters_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "successResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome", "duration_ms", "frame_bytes", "frame_sha256"],
+      "properties": {
+        "outcome": {
+          "const": "success"
+        },
+        "duration_ms": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 60000
+        },
+        "frame_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "frame_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -833,6 +833,22 @@ def main() -> None:
             ],
         ),
         (
+            "qual-206-legacy-stdio-readiness.schema.json",
+            [
+                (
+                    "tests/interoperability/evidence/"
+                    "claude-code-legacy-stdio-readiness-2026-08-23.json",
+                    load_json(
+                        ROOT
+                        / "tests"
+                        / "interoperability"
+                        / "evidence"
+                        / "claude-code-legacy-stdio-readiness-2026-08-23.json"
+                    ),
+                )
+            ],
+        ),
+        (
             "decision.schema.json",
             [
                 (record["id"], record)

--- a/tests/contract/test_qual_206_legacy_stdio_readiness.py
+++ b/tests/contract/test_qual_206_legacy_stdio_readiness.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "qual-206-legacy-stdio-readiness.schema.json"
+EVIDENCE_PATH = (
+    ROOT
+    / "tests"
+    / "interoperability"
+    / "evidence"
+    / "claude-code-legacy-stdio-readiness-2026-08-23.json"
+)
+SOURCE_COMMIT = "30b575beb27ff805745a2864c1acf44392774046"
+SOURCE_TREE = "bb84c13d618984304d5db300be775275b8037ea8"
+SCHEMA_SHA256 = "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a"
+EVIDENCE_SHA256 = "a3d40e2013095baf977bad336366c0fb429a05b6a5a267c3e069595e4cdb1a6b"
+LOCKFILE_SHA256 = "640208aa66d26241514025b33dbde50bc14be7bbd33641eec9977e87699bb4ec"
+EXPECTED_RUNTIME_FILES = [
+    (
+        "apps/mcp-gateway/src/mcp-server.ts",
+        "e2c5cec027f3049d0a501b885a0ab6336d7e6059690df54ac7b257945807b454",
+    ),
+    (
+        "apps/mcp-gateway/src/mcp-stdio.ts",
+        "5e8d87020d1efe34b2b83940f60d2df5926f466c12473fffc156463c9a6cef30",
+    ),
+    (
+        "scripts/qual_206_legacy_conformance_server.mjs",
+        "bf87bec24357d5fd6d419bd8b4374642ab46a2f3dfa6d9baebde46f7498edb9c",
+    ),
+    (
+        "scripts/qual_206_telemetry_proxy.mjs",
+        "3800e4458932ee1324ad03d64007f23f76f49682a6eabdc191ecf6eaccb501d5",
+    ),
+]
+EXPECTED_COMPILED_ENTRYPOINTS = [
+    (
+        "apps/mcp-gateway/dist/src/mcp-server.js",
+        "71fdde3b45363d366b62e7c4219c2cc77efbfbfe9d9e5d110f656e76ee9d2ab1",
+    ),
+    (
+        "apps/mcp-gateway/dist/src/mcp-stdio.js",
+        "17a04b0b1f0a5549157c8e07119ac1d7a895b86d9a73312aaaa2561fd1e092e3",
+    ),
+]
+BOUNDARY = (
+    "Accepted protected-main Claude Code transport-readiness evidence only. The "
+    "constructor-only local conformance launcher passed legacy STDIO initialisation "
+    "and tools/list; no tool, resource, exact-five production assembly, model, "
+    "provider, remote HTTP host, registration, activation, deployment or release "
+    "was exercised. Capability remains unscored."
+)
+PUBLIC_EVIDENCE_FORBIDDEN = re.compile(
+    r"(?:"
+    r"/Users/|/home/|/Volumes/|/private/tmp/|file://|"
+    r"[A-Za-z]:\\\\Users\\\\|"
+    r"\bsk-[A-Za-z0-9_-]{8,}|\bgh[opusr]_[A-Za-z0-9]{8,}|"
+    r"\bxox[baprs]-[A-Za-z0-9-]{8,}|\bAKIA[0-9A-Z]{16}|"
+    r"\bBearer\s+[A-Za-z0-9._~-]+|"
+    r"OPENAI_API_KEY|CODEX_API_KEY|ANTHROPIC_API_KEY|"
+    r"https?://(?:chatgpt\.com/c/|claude\.ai/chat/)|"
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b"
+    r")",
+    re.IGNORECASE,
+)
+FORBIDDEN_FIELD_NAMES = {
+    "credential",
+    "device_id",
+    "environment",
+    "headers",
+    "host_profile_path",
+    "log",
+    "prompt",
+    "raw_command",
+    "result",
+    "telemetry_path",
+}
+
+
+def reject_non_standard_number(value: str) -> None:
+    raise ValueError(f"Non-standard JSON number: {value}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=reject_non_standard_number,
+    )
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def git_output(*arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise AssertionError(f"git {' '.join(arguments)} failed: {message}")
+    return result.stdout
+
+
+def git_blob(commit: str, path: str) -> bytes:
+    return git_output("show", f"{commit}:{path}")
+
+
+def assert_contract_objects_are_closed(
+    test_case: unittest.TestCase,
+    node: object,
+    path: str = "$",
+) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            test_case.assertIs(
+                node.get("additionalProperties"),
+                False,
+                f"{path} must reject unknown properties",
+            )
+        for key, value in node.items():
+            assert_contract_objects_are_closed(test_case, value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            assert_contract_objects_are_closed(test_case, value, f"{path}[{index}]")
+
+
+def nested_field_names(node: object) -> set[str]:
+    names: set[str] = set()
+    if isinstance(node, dict):
+        names.update(node)
+        for value in node.values():
+            names.update(nested_field_names(value))
+    elif isinstance(node, list):
+        for value in node:
+            names.update(nested_field_names(value))
+    return names
+
+
+class Qual206LegacyStdioReadinessTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = load_json(SCHEMA_PATH)
+        cls.document = load_json(EVIDENCE_PATH)
+        cls.validator = Draft202012Validator(
+            cls.schema,
+            format_checker=FormatChecker(),
+        )
+
+    def assert_invalid(self, value: object) -> None:
+        self.assertTrue(list(self.validator.iter_errors(value)))
+
+    def test_closed_schema_accepts_exact_canonical_evidence(self) -> None:
+        Draft202012Validator.check_schema(self.schema)
+        assert_contract_objects_are_closed(self, self.schema)
+        errors = sorted(
+            self.validator.iter_errors(self.document),
+            key=lambda error: list(error.absolute_path),
+        )
+        self.assertEqual(
+            [],
+            [
+                f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: "
+                f"{error.message}"
+                for error in errors
+            ],
+        )
+        expected_bytes = (
+            json.dumps(self.document, ensure_ascii=False, indent=2) + "\n"
+        ).encode()
+        self.assertEqual(EVIDENCE_PATH.read_bytes(), expected_bytes)
+        self.assertEqual(sha256_bytes(SCHEMA_PATH.read_bytes()), SCHEMA_SHA256)
+        self.assertEqual(sha256_bytes(EVIDENCE_PATH.read_bytes()), EVIDENCE_SHA256)
+        self.assertEqual(
+            self.document["schema_contract"],
+            {
+                "path": "schemas/qual-206-legacy-stdio-readiness.schema.json",
+                "sha256": SCHEMA_SHA256,
+            },
+        )
+
+    def test_record_binds_the_exact_protected_main_source_materials(self) -> None:
+        source = self.document["source"]
+        self.assertEqual(source["commit"], SOURCE_COMMIT)
+        self.assertEqual(source["tree"], SOURCE_TREE)
+        actual_tree = git_output("rev-parse", f"{SOURCE_COMMIT}^{{tree}}").decode().strip()
+        self.assertEqual(actual_tree, SOURCE_TREE)
+        self.assertEqual(
+            [(item["path"], item["sha256"]) for item in source["runtime_files"]],
+            EXPECTED_RUNTIME_FILES,
+        )
+        for path, expected_digest in EXPECTED_RUNTIME_FILES:
+            with self.subTest(path=path):
+                self.assertEqual(sha256_bytes(git_blob(SOURCE_COMMIT, path)), expected_digest)
+        build = source["build"]
+        self.assertEqual(
+            build["lockfile"],
+            {"path": "pnpm-lock.yaml", "sha256": LOCKFILE_SHA256},
+        )
+        self.assertEqual(
+            sha256_bytes(git_blob(SOURCE_COMMIT, "pnpm-lock.yaml")),
+            LOCKFILE_SHA256,
+        )
+        self.assertEqual(build["command"], "pnpm run test:interoperability")
+        self.assertTrue(build["dependencies_installed_with_frozen_lockfile"])
+        self.assertTrue(build["preflight_passed"])
+        self.assertEqual(
+            [
+                (item["source_path"], item["sha256"])
+                for item in build["compiled_entrypoints"]
+            ],
+            EXPECTED_COMPILED_ENTRYPOINTS,
+        )
+        # These are immutable observed entrypoint bytes, not a claim about a later
+        # branch build. The exact historical tree and frozen lockfile are verified
+        # above so ordinary future runtime work cannot relabel this observation.
+
+    def test_transport_readiness_is_not_inflated_into_capability(self) -> None:
+        source = self.document["source"]
+        host = self.document["host"]
+        telemetry = self.document["telemetry"]
+        isolation = self.document["isolation"]
+        limitations = self.document["limitations"]
+
+        self.assertEqual(telemetry["source_commit"], source["commit"])
+        self.assertEqual(telemetry["event_count"], sum(telemetry["event_counts"].values()))
+        self.assertEqual(host["transport_readiness"], "ready")
+        self.assertEqual(host["capability"], "unscored")
+        self.assertEqual((host["platform"], host["architecture"]), ("darwin", "arm64"))
+        self.assertTrue(host["initialize_success"])
+        self.assertTrue(host["tools_list_success"])
+        self.assertFalse(host["model_authentication_supplied"])
+        self.assertFalse(host["model_task_requested"])
+        self.assertFalse(host["tool_call_observed"])
+        self.assertFalse(host["resource_read_observed"])
+        self.assertEqual(telemetry["initialize_response"]["outcome"], "success")
+        self.assertEqual(telemetry["tools_list_response"]["outcome"], "success")
+        for response_name in ("initialize_response", "tools_list_response"):
+            duration = telemetry[response_name]["duration_ms"]
+            self.assertTrue(math.isfinite(duration))
+            self.assertGreaterEqual(duration, 0)
+        for count_name in (
+            "invalid_frame_count",
+            "non_json_frame_count",
+            "truncated_frame_count",
+            "server_stderr_event_count",
+            "pending_request_count",
+        ):
+            self.assertEqual(telemetry[count_name], 0)
+        self.assertEqual(telemetry["exit_code"], 0)
+        self.assertFalse(telemetry["raw_content_published"])
+        self.assertEqual(isolation["token_pattern_matches"], 0)
+        self.assertEqual(isolation["remaining_isolated_processes_after_cleanup"], 0)
+        self.assertFalse(isolation["normal_profile_mutation_observed"])
+        self.assertFalse(isolation["raw_host_logs_published"])
+        self.assertTrue(isolation["parent_openai_key_variables_removed"])
+        self.assertTrue(isolation["mcp_child_environment_allowlisted"])
+        self.assertTrue(isolation["mcp_child_openai_key_variables_removed"])
+        self.assertEqual(set(limitations.values()), {False})
+        self.assertEqual(self.document["boundary"], BOUNDARY)
+
+    def test_public_record_contains_no_path_secret_or_raw_payload_fields(self) -> None:
+        public_text = EVIDENCE_PATH.read_text(encoding="utf-8")
+        self.assertIsNone(PUBLIC_EVIDENCE_FORBIDDEN.search(public_text))
+        self.assertTrue(
+            FORBIDDEN_FIELD_NAMES.isdisjoint(nested_field_names(self.document))
+        )
+
+    def test_hostile_or_inflated_mutations_are_rejected(self) -> None:
+        mutations: list[tuple[str, Any]] = []
+
+        absolute_path = copy.deepcopy(self.document)
+        absolute_path["source"]["runtime_files"][0]["path"] = (
+            "/" + "Users" + "/example/runtime.ts"
+        )
+        mutations.append(("absolute path", absolute_path))
+
+        parent_path = copy.deepcopy(self.document)
+        parent_path["source"]["runtime_files"][0]["path"] = "../runtime.ts"
+        mutations.append(("parent-relative path", parent_path))
+
+        raw_command = copy.deepcopy(self.document)
+        raw_command["host"]["raw_command"] = "unexpected"
+        mutations.append(("raw command", raw_command))
+
+        prompt = copy.deepcopy(self.document)
+        prompt["telemetry"]["prompt"] = "unexpected"
+        mutations.append(("prompt", prompt))
+
+        raw_result = copy.deepcopy(self.document)
+        raw_result["telemetry"]["result"] = {"unexpected": True}
+        mutations.append(("result", raw_result))
+
+        environment = copy.deepcopy(self.document)
+        environment["isolation"]["environment"] = {"unexpected": True}
+        mutations.append(("environment", environment))
+
+        log = copy.deepcopy(self.document)
+        log["telemetry"]["log"] = "unexpected"
+        mutations.append(("log", log))
+
+        wrong_commit = copy.deepcopy(self.document)
+        wrong_commit["source"]["commit"] = "0" * 40
+        mutations.append(("wrong source commit", wrong_commit))
+
+        activation = copy.deepcopy(self.document)
+        activation["source"]["production_activation"] = True
+        mutations.append(("production activation", activation))
+
+        capability = copy.deepcopy(self.document)
+        capability["host"]["capability"] = "passed"
+        mutations.append(("capability inflation", capability))
+
+        tool_call = copy.deepcopy(self.document)
+        tool_call["host"]["tool_call_observed"] = True
+        mutations.append(("tool call", tool_call))
+
+        resource_read = copy.deepcopy(self.document)
+        resource_read["host"]["resource_read_observed"] = True
+        mutations.append(("resource read", resource_read))
+
+        pending = copy.deepcopy(self.document)
+        pending["telemetry"]["pending_request_count"] = 1
+        mutations.append(("pending request", pending))
+
+        token_match = copy.deepcopy(self.document)
+        token_match["isolation"]["token_pattern_matches"] = 1
+        mutations.append(("credential pattern", token_match))
+
+        completed_gate = copy.deepcopy(self.document)
+        completed_gate["limitations"]["independent_host_gate_completed"] = True
+        mutations.append(("completed host gate", completed_gate))
+
+        exact_five = copy.deepcopy(self.document)
+        exact_five["limitations"]["exact_five_assembly_exercised"] = True
+        mutations.append(("exact-five claim", exact_five))
+
+        raw_content = copy.deepcopy(self.document)
+        raw_content["telemetry"]["raw_content_published"] = True
+        mutations.append(("raw content", raw_content))
+
+        swapped_runtime = copy.deepcopy(self.document)
+        swapped_runtime["source"]["runtime_files"][0:2] = reversed(
+            swapped_runtime["source"]["runtime_files"][0:2]
+        )
+        mutations.append(("runtime order", swapped_runtime))
+
+        unknown = copy.deepcopy(self.document)
+        unknown["unexpected"] = True
+        mutations.append(("unknown root field", unknown))
+
+        for label, mutation in mutations:
+            with self.subTest(label=label):
+                self.assert_invalid(mutation)
+
+    def test_non_standard_json_numbers_are_rejected_at_load_boundary(self) -> None:
+        with self.assertRaises(ValueError):
+            json.loads('{"duration_ms": NaN}', parse_constant=reject_non_standard_number)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/interoperability/README.md
+++ b/tests/interoperability/README.md
@@ -63,7 +63,17 @@ being added to an older evidence record.
 The current [legacy fallback exploratory summary](evidence/legacy-fallback-exploratory-2026-08-20.json)
 records a credential-stripped Claude health connection and a Codex
 configuration-only check against exact uncommitted runtime hashes. It is explicitly
-not accepted host evidence and requires repetition from a reviewed commit.
+not accepted host evidence and is not relabelled by later observations.
+
+The separate
+[protected-main Claude Code readiness summary](evidence/claude-code-legacy-stdio-readiness-2026-08-23.json)
+records that repetition from a clean, detached checkout of exact protected-main
+commit `30b575beb27ff805745a2864c1acf44392774046`. Claude Code `2.1.204`
+completed legacy STDIO initialisation and `tools/list` through the
+constructor-only two-tool conformance launcher. This establishes transport
+readiness only. No model authentication, model task, tool call, resource read, live
+provider, remote HTTP host, exact-five production assembly, registration,
+activation, deployment or release was exercised, so capability remains unscored.
 
 See the [QUAL-206 interoperability runbook](../../docs/operations/QUAL-206_INTEROPERABILITY.md)
 for repeatable ChatGPT secure-tunnel and independent-host procedures.

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -24,6 +24,18 @@ non-interactive host attempt separately from the earlier three-host readiness su
 It binds the exact corpus case and current wrapper bytes, but remains `not_ready` and
 unscored because protocol negotiation stopped before a task-level tool call.
 
+The
+[`Claude Code protected-main legacy STDIO readiness summary`](claude-code-legacy-stdio-readiness-2026-08-23.json)
+is a later, separately source-bound record. It captures a clean, detached checkout
+of protected-main commit `30b575beb27ff805745a2864c1acf44392774046` and the
+current telemetry wrapper. Claude Code `2.1.204` completed legacy STDIO
+initialisation and `tools/list` through the constructor-only two-tool conformance
+launcher. The result is transport `ready` and capability `unscored`: no
+model authentication, model task, tool call, resource read, live provider, remote HTTP
+host, exact-five production assembly, registration, activation, deployment or
+release was exercised. It does not alter the earlier modern-only `not_ready` record
+or upgrade the uncommitted exploratory fallback record.
+
 The historical records continue to bind the unchanged ten-case
 [`qual_206_cases.json`](../qual_206_cases.json) bytes. The separate
 [`qual_206_cases_expansion.json`](../qual_206_cases_expansion.json) is design-time,

--- a/tests/interoperability/evidence/claude-code-legacy-stdio-readiness-2026-08-23.json
+++ b/tests/interoperability/evidence/claude-code-legacy-stdio-readiness-2026-08-23.json
@@ -1,0 +1,161 @@
+{
+  "schema": "gis-ai-go.qual-206-legacy-stdio-readiness.v1",
+  "schema_contract": {
+    "path": "schemas/qual-206-legacy-stdio-readiness.schema.json",
+    "sha256": "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a"
+  },
+  "status": "readiness-pass-capability-unscored",
+  "observed_at": "2026-08-23T21:41:20.640Z",
+  "source": {
+    "repository": "chris-page-gov/gis-ai-go",
+    "commit": "30b575beb27ff805745a2864c1acf44392774046",
+    "tree": "bb84c13d618984304d5db300be775275b8037ea8",
+    "protected_main": true,
+    "version": "0.1.0",
+    "detached_checkout": true,
+    "worktree_changes_uncommitted": false,
+    "production_registration": false,
+    "production_activation": false,
+    "public_endpoint_created": false,
+    "runtime_files": [
+      {
+        "path": "apps/mcp-gateway/src/mcp-server.ts",
+        "sha256": "e2c5cec027f3049d0a501b885a0ab6336d7e6059690df54ac7b257945807b454"
+      },
+      {
+        "path": "apps/mcp-gateway/src/mcp-stdio.ts",
+        "sha256": "5e8d87020d1efe34b2b83940f60d2df5926f466c12473fffc156463c9a6cef30"
+      },
+      {
+        "path": "scripts/qual_206_legacy_conformance_server.mjs",
+        "sha256": "bf87bec24357d5fd6d419bd8b4374642ab46a2f3dfa6d9baebde46f7498edb9c"
+      },
+      {
+        "path": "scripts/qual_206_telemetry_proxy.mjs",
+        "sha256": "3800e4458932ee1324ad03d64007f23f76f49682a6eabdc191ecf6eaccb501d5"
+      }
+    ],
+    "build": {
+      "command": "pnpm run test:interoperability",
+      "dependencies_installed_with_frozen_lockfile": true,
+      "preflight_passed": true,
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "sha256": "640208aa66d26241514025b33dbde50bc14be7bbd33641eec9977e87699bb4ec"
+      },
+      "compiled_entrypoints": [
+        {
+          "source_path": "apps/mcp-gateway/dist/src/mcp-server.js",
+          "sha256": "71fdde3b45363d366b62e7c4219c2cc77efbfbfe9d9e5d110f656e76ee9d2ab1"
+        },
+        {
+          "source_path": "apps/mcp-gateway/dist/src/mcp-stdio.js",
+          "sha256": "17a04b0b1f0a5549157c8e07119ac1d7a895b86d9a73312aaaa2561fd1e092e3"
+        }
+      ]
+    }
+  },
+  "host": {
+    "name": "Claude Code",
+    "version": "2.1.204",
+    "platform": "darwin",
+    "architecture": "arm64",
+    "binary_sha256": "1677b67595b6251156d62600dc85d4070ec385b72dd0b07e73742a56030952c3",
+    "command": "mcp list",
+    "transport": "legacy-stdio",
+    "model_authentication_supplied": false,
+    "model_task_requested": false,
+    "transport_readiness": "ready",
+    "capability": "unscored",
+    "classification": "legacy-handshake-and-tool-list-pass",
+    "host_result": "Connected",
+    "requested_protocol_version": "2025-06-18",
+    "requested_protocol_version_evidence": "exact-initialise-frame-digest-matches-reviewed-2025-06-18-observation",
+    "initialize_success": true,
+    "tools_list_success": true,
+    "tool_call_observed": false,
+    "resource_read_observed": false
+  },
+  "telemetry": {
+    "schema": "gis-ai-go.qual-206-host-telemetry.v1",
+    "current_wrapper_exercised": true,
+    "session_id_sha256": "f81e07a0743e9135e02a12a923545dea5d353d17afbbcfa36470ecaef113664b",
+    "command_sha256": "3eefb15165317484303baede203a40831bd108a9c6453be1b367f9b4597f123a",
+    "node_version": "v26.7.0",
+    "source_commit": "30b575beb27ff805745a2864c1acf44392774046",
+    "retained_private_bytes": 2882,
+    "retained_private_sha256": "84a3d22e9024a800a1b095ccf108f5fd76613ab0e55e5791e4ca43e175f66c9b",
+    "retained_private_mode": "0600",
+    "event_count": 7,
+    "event_counts": {
+      "session_start": 1,
+      "request": 3,
+      "response": 2,
+      "session_end": 1
+    },
+    "initialize_request": {
+      "method_label": "other",
+      "frame_bytes": 323,
+      "frame_sha256": "e4be5810197faf2a09f6ffcf87a35a270bd35df9c5a6d1115d7253bfb1358299",
+      "parameters_bytes": 267,
+      "parameters_sha256": "df19797912d3d069ec097cb62af844c49e8ffabb28231cf508952deb2c47f2eb"
+    },
+    "initialize_response": {
+      "outcome": "success",
+      "duration_ms": 200.313208,
+      "frame_bytes": 391,
+      "frame_sha256": "a4f84e28cb3cacdbc16c13c870aa0797e2ca7c09bf43ad72947bcfbdb7b9a279"
+    },
+    "initialized_notification": {
+      "method_label": "other",
+      "frame_bytes": 54,
+      "frame_sha256": "1991440c743375cc3f711ec3788c732cfff71984933a8bf73701ff563427860d",
+      "parameters_bytes": 4,
+      "parameters_sha256": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+    },
+    "tools_list_request": {
+      "method_label": "tools/list",
+      "frame_bytes": 46,
+      "frame_sha256": "75f0c7627a35c7e96a0a88482622a0d1ec7e81c0eb5414a88ba7aab9450cf73b",
+      "parameters_bytes": 4,
+      "parameters_sha256": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+    },
+    "tools_list_response": {
+      "outcome": "success",
+      "duration_ms": 1.620875,
+      "frame_bytes": 47304,
+      "frame_sha256": "30b56ca69a8767fe393ceaf3c86d29ca91d3026f73255c56bff7616fd7ea7cb5"
+    },
+    "invalid_frame_count": 0,
+    "non_json_frame_count": 0,
+    "truncated_frame_count": 0,
+    "server_stderr_event_count": 0,
+    "exit_code": 0,
+    "pending_request_count": 0,
+    "raw_content_published": false
+  },
+  "isolation": {
+    "temporary_profile": true,
+    "directory_mode": "0700",
+    "claude_config_mode": "0600",
+    "proxy_log_mode": "0600",
+    "normal_profile_mutation_observed": false,
+    "parent_openai_key_variables_removed": true,
+    "mcp_child_environment_allowlisted": true,
+    "mcp_child_openai_key_variables_removed": true,
+    "files_scanned_for_token_patterns": 4,
+    "token_pattern_matches": 0,
+    "remaining_isolated_processes_after_cleanup": 0,
+    "raw_host_logs_published": false
+  },
+  "limitations": {
+    "capability_result_claimed": false,
+    "independent_host_gate_completed": false,
+    "exact_five_assembly_exercised": false,
+    "live_provider_called": false,
+    "remote_http_observed": false,
+    "chatgpt_tunnel_touched": false,
+    "activation_or_release_claimed": false
+  },
+  "boundary": "Accepted protected-main Claude Code transport-readiness evidence only. The constructor-only local conformance launcher passed legacy STDIO initialisation and tools/list; no tool, resource, exact-five production assembly, model, provider, remote HTTP host, registration, activation, deployment or release was exercised. Capability remains unscored."
+}


### PR DESCRIPTION
## Summary

- record a clean, source-bound Claude Code 2.1.204 legacy STDIO transport-readiness observation against protected-main commit `30b575beb27ff805745a2864c1acf44392774046`;
- validate the path-free public record with a closed schema, canonical byte and Git-object checks, hostile-mutation tests and exact schema/evidence digests; and
- update the QUAL-206 hand-off without changing the earlier modern-only `not_ready` result or the unaccepted exploratory record.

## Evidence boundary

Claude completed initialisation and `tools/list` through the constructor-only two-tool conformance launcher. Capability remains unscored. No model authentication, model task, tool call, resource read, exact-five production assembly, live provider, remote HTTP host, registration, activation, deployment or release was exercised. Raw host logs and disposable profile material are not published.

## Validation

- `pnpm run check` passed at exact commit `2876bc81aeb2ea5d193863610cd86488068c68ea`;
- 66 schemas and 101 mapped records validated;
- 236 repository Python tests and 22 execution-service tests passed;
- 16 interoperability checks and 7 deterministic local QUAL-206 receipts passed;
- 27 real-browser tests passed;
- two clean release builds were byte-identical;
- the 767-file secret and machine-path scan passed; and
- independent final review found no P0-P2 issue.

Refs #24.
