### PR TITLE
fix(ci): use the verified independent builder identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
       - name: Start the independent pinned gateway image builder
         run: |
           docker buildx create \
-            --name gis-ai-go-gateway-independent \
+            --name gis-ai-go-gateway \
             --driver docker-container \
             --driver-opt image=moby/buildkit:buildx-stable-1@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 \
             --use
@@ -328,7 +328,7 @@ jobs:
 
       - name: Remove the independent image builder
         if: always()
-        run: docker buildx rm gis-ai-go-gateway-independent
+        run: docker buildx rm gis-ai-go-gateway
 
       - name: Upload immutable independent gateway derivation
         id: gateway_independent_upload

--- a/changelog.d/QUAL-206-independent-builder.fixed.md
+++ b/changelog.d/QUAL-206-independent-builder.fixed.md
@@ -1,0 +1,3 @@
+Fix the protected-main independent OCI derivation to instantiate the exact
+contract-fixed BuildKit builder identity on its isolated runner, preserving the
+separate checkout and artefact trust boundary without weakening builder validation.

--- a/docs/operations/DEPLOY-207_GATEWAY_CONTAINER.md
+++ b/docs/operations/DEPLOY-207_GATEWAY_CONTAINER.md
@@ -432,7 +432,10 @@ occurrences, in addition to its depth and node bounds.
 Protected-main runs add two unprivileged trust domains before provenance. An
 independent image job checks out the exact clean commit, regenerates the OKF
 projection and produces a separate canonical OCI derivation without receiving any
-producer artefact. A separate verification job downloads the producer and independent
+producer artefact. Its fresh, isolated runner uses the same contract-fixed BuildKit
+builder name and pinned image as the producer runner; independence comes from the
+runner, checkout and artefact boundary, not from an alternative unchecked builder
+identity. A separate verification job downloads the producer and independent
 artefacts by their immutable current-run artefact IDs, regenerates the OKF projection,
 acquires and digest-checks the pinned scanners, and rehydrates the exact Grype database
 archive from Anchore using its retained URL, length and SHA-256. It then re-verifies

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -209,7 +209,13 @@ class PagesWorkflowTests(unittest.TestCase):
         self.assertIn("scripts/verify_gateway_oci.py", independent)
         self.assertIn('--expected-source-commit "$GITHUB_SHA"', independent)
         self.assertIn("--require-clean", independent)
-        self.assertIn("gis-ai-go-gateway-independent", independent)
+        independent_lines = [line.strip() for line in independent.splitlines()]
+        self.assertEqual(independent_lines.count("--name gis-ai-go-gateway \\"), 1)
+        self.assertEqual(
+            independent_lines.count("run: docker buildx rm gis-ai-go-gateway"),
+            1,
+        )
+        self.assertNotIn("gis-ai-go-gateway-independent", independent)
         self.assertIn(
             "moby/buildkit:buildx-stable-1@sha256:"
             "28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",


### PR DESCRIPTION
## Summary

- use the contract-fixed `gis-ai-go-gateway` BuildKit builder identity in the protected-main independent OCI derivation job
- remove that same daemon-local builder during unconditional clean-up
- bind the exact create and remove commands in the workflow contract test
- document that independence comes from the fresh runner, clean checkout and artefact boundary, rather than an alternative unchecked builder name

## Root cause and evidence

Protected-main run [32758249054](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32758249054), for exact commit `deceb1cd5aeff74997b7aca5c862d2cae734b8c5`, failed only in job [97531967707](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32758249054/job/97531967707).

The workflow successfully created `gis-ai-go-gateway-independent`, then `scripts/package_gateway_oci.py` failed closed because `verify_pinned_builder()` requires the fixed identity `gis-ai-go-gateway`. No independent OCI build or upload occurred, so attestation verification and gateway provenance were skipped.

The primary gateway image assurance passed end to end in the same run, including reproducible OCI packaging, a 488-component SBOM, vulnerability replay, Compose/runtime checks, persistence and exact-image restore. This repair does not alter the primary image or weaken builder verification.

GitHub-hosted `ubuntu-24.04` jobs run on separate fresh virtual machines and Docker daemons. Reusing the fixed daemon-local handle therefore preserves the independent runner, checkout, generated projection and artefact trust boundaries. A future move to a shared or self-hosted Docker daemon would require explicit builder ownership and clean-up isolation.

## Verification

- `pnpm run check`
  - 210 gateway tests
  - 16 interoperability tests
  - 42 Explorer unit tests
  - 300 Python tests
  - 22 execution-service tests
  - 27 browser tests
  - deterministic two-build release archive
  - 70 schemas and 101 records
  - 425 local links and 183 research hashes
  - clean secret and machine-path scan
  - 9 rendered diagrams and 169-component repository SBOM
- 20 workflow contract tests, including exact builder create and clean-up assertions
- 3 fixed-builder identity and rejection tests
- `git diff --check`
- independent final diff review: no findings

The independent derivation is intentionally a protected-main-only job, so PR assurance cannot by itself prove this lane. After merge, the exact protected-main run must pass independent derivation, gateway attestation verification and gateway provenance before the repair is considered complete.

No deployment, activation, registry publication, risk acceptance, tag or release is performed by this PR.
