### PR TITLE
test(qual): bind current Claude protocol variance

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Current context
 
-Last updated: 23 August 2026
+Last updated: 24 August 2026
 
 ## Authority and reading order
 
@@ -42,7 +42,7 @@ whose accepted implementation commit is
 `a0e826384cf50d9d81b87489dbf3580e8e3602f7`. The Explorer is deployed and verified
 at <https://chris-page-gov.github.io/gis-ai-go/> from the later release commit
 recorded below. The latest protected-main repository hand-off is
-`30b575beb27ff805745a2864c1acf44392774046`; its unchanged runtime baseline is
+`dda0eb9f776e64bcd45069e77b4acbcd4d495e01`; its unchanged runtime baseline is
 `7fa8b720d3cbaa3e0a1ebfadf0fb355a7330a04c`. It contains the repository-only
 QUAL-206 preflight, completed trace and readiness integrity, one compile-time
 `candidate-unregistered` exact-five assembly, the bounded 23 August research intake,
@@ -284,6 +284,31 @@ commit. The constructor-only two-tool launcher completed initialisation and
 record and uncommitted exploratory record remain unchanged. No model authentication,
 model task, tool call, resource read, exact-five production assembly, live provider,
 remote HTTP host, registration, activation, deployment or release was exercised.
+
+The combined `v0.2.0` repository candidate merged through
+[pull request 57](https://github.com/chris-page-gov/gis-ai-go/pull/57), and its
+main-only independent-builder repair merged through
+[pull request 58](https://github.com/chris-page-gov/gis-ai-go/pull/58) as exact
+protected-main commit `dda0eb9f776e64bcd45069e77b4acbcd4d495e01`.
+[Run 32760872035](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32760872035)
+passed repository assurance, the producer and independent OCI derivations,
+byte-identical cross-verification, aggregate assurance and both provenance jobs;
+[run 32760871684](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32760871684)
+passed CodeQL for Actions, JavaScript/TypeScript and Python. Both derivations
+produced manifest
+`sha256:d08eea1ef3bd74bdba203d8d824cdc9dfac3553e51370ee6006f42c6db27b324`
+and archive SHA-256
+`62893bcf428dfe8736e75d53ed702df2141c5c82e0e81798fb43342ba9e323a2`.
+This accepts the remediated UBI repository image and its evidence; it does not
+activate, publish, deploy or release the service.
+
+An additive Claude Code `2.1.241` observation preserves the `2.1.204` evidence and
+records the current client's actual protocol boundary. The client offered MCP
+`2025-11-25`; the strict `2026-07-28` STDIO surface correctly returned `-32022`,
+while the constructor-only fallback completed initialisation and `tools/list`.
+Capability remains unscored. No model, operation, resource, provider or remote HTTP
+host was exercised, and this explained variance does not widen the production
+protocol boundary or complete the independent-host gate.
 
 ## Non-negotiable boundaries
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,11 +15,14 @@ The supported target active set is exactly `catalogue.search`,
 
 - retain the repository-local STDIO and client/version matrix bound to the
   protected-main v3 inspection-receipt runtime as preflight only;
-- retain the source-bound Claude Code `2.1.204` legacy STDIO transport-readiness
-  result separately from capability scoring, then complete the remaining
-  independent desktop-STDIO and remote-HTTP host evidence; and
-- stop before any public runtime, live provider call, host credential, registry
-  publication, activation, tag or release that requires separate authority.
+- preserve the source-bound Claude Code `2.1.204` result and the additive `2.1.241`
+  protocol observation separately from capability scoring; `2.1.241` offers MCP
+  `2025-11-25`, so it cannot close the strict `2026-07-28` desktop-host gate;
+- complete the remaining strict-modern independent desktop-STDIO and remote-HTTP
+  host evidence; and
+- continue provider-neutral preparation, but stop before public provisioning or
+  spend until a provider account, numeric monthly ceiling and operational hosting
+  envelope are supplied.
 
 Supporting `EVID-204` release assurance remains inactive and does not replace that
 main flow. A provider-independent candidate now checkpoints one stopped linked
@@ -28,17 +31,16 @@ separately retained tail checkpoint, and restores only into empty private roots
 before completing both verifiers. It selects no storage provider and supplies no
 deployment, operator-fencing, schedule, RPO/RTO, disposal or release evidence.
 
-The accepted DEPLOY-207 base-remediation route is also integrated without displacing
+The accepted DEPLOY-207 base-remediation route is integrated without displacing
 the independent-host workstream. The fixed `linux/amd64` UBI 10 composition and
-closed receipt and SBOM contracts are implemented. The clean combined tree passed
-the complete repository and exact local image-assurance gates, including reproducible
-OCI bytes, a 488-component SBOM, Trivy and calibrated Node advisory coverage,
-retained offline replay, and runtime, persistence, suspension and exact-image restore
-acceptance. The original security findings are remediated and the two bounded closure
-scans are complete with no findings. The tree still requires the protected
-pull-request and protected-main checks. It remains a repository-only blocked
-candidate; no publication, live provider call, deployment, activation, tag or
-release is claimed.
+closed receipt and SBOM contracts are implemented. Exact protected-main commit
+`dda0eb9f776e64bcd45069e77b4acbcd4d495e01` passed repository assurance, producer
+and independent OCI derivation, byte-identical verification, a 488-component SBOM,
+Trivy and calibrated Node advisory coverage, retained offline replay, runtime,
+persistence, suspension, exact-image restore, provenance and CodeQL. The original
+Debian findings are absent from the accepted UBI bytes. It remains a repository-only
+blocked candidate; no publication, live provider call, deployment, activation, tag
+or release is claimed.
 
 ## Completed
 
@@ -253,13 +255,13 @@ release is claimed.
 
 ## Next
 
-1. Complete bounded Claude capability evidence and the remaining independent
-   desktop-STDIO and remote-HTTP host evidence. The local protocol matrix and
-   Claude transport-only result do not complete issue #24's live-host criteria.
-2. Push the clean combined integration commit through a protected pull request, then
-   require the same commit to pass protected-main repository, exact image,
-   provenance and CodeQL checks before it can supersede the historical Debian
-   candidate.
+1. Use a different independent desktop host whose first frame proves a valid
+   `2026-07-28` opening, then complete the bounded capability pack and remaining
+   remote-HTTP host evidence. Claude Code `2.1.241` is an explained legacy-only
+   transport result, not the modern host acceptance.
+2. Retain the exact protected-main UBI, independent-derivation and provenance
+   evidence from runs `32760872035` and `32760871684`; rebuild and repeat it after
+   every later source-changing activation or release commit.
 3. Keep DEPLOY-207 at `status: decision needed` until an authorised public runtime,
    hostname/TLS, identity, egress, storage and operator boundary exists.
 4. Only after that separate authority exists, deploy an unregistered
@@ -282,8 +284,10 @@ release is claimed.
   service identity and network-policy evidence.
 - Activating or publishing a catalogue service remains hard-blocked. Raw protocol
   transcripts, deterministic local host fixtures and the pinned SDK clients do not
-  establish independent live major-host interoperability. The source-bound Claude
-  transport check establishes initialisation and listing only, not capability.
+  establish independent live major-host interoperability. Claude Code `2.1.241`
+  offers MCP `2025-11-25`: it fails the strict `2026-07-28` surface and establishes
+  initialisation and listing only through the constructor-only fallback, not
+  capability.
   Security, accessibility, governed ingress/storage admission, retention/disposal
   and host-specific lifecycle evidence remain activation gates.
 - Direct routes and MCP transports now exist on protected `main`, but the
@@ -293,16 +297,12 @@ release is claimed.
   repository-local matrix is non-live and cannot close issue #23 or issue #24;
   independent hosts, a live provider, authorised deployment and release evidence
   remain outstanding.
-- The historical protected-main Debian image retains three unresolved High findings.
-  The authorised combined UBI 10 and Node integration passed the complete repository
-  and exact image-assurance gates from clean commit
-  `f8d3210064a2fc88f85722d373f935b355c8d289`. That repository-only evidence
-  establishes the historical Debian package instances are absent from those exact
-  local bytes and gives the standalone Node runtime independent advisory coverage. It
-  cannot close the protected-main findings until the combined commit and the protected
-  pull-request and protected-main checks pass. No protected-source attestation exists
-  for the replacement yet, and every source change requires a new exact image build
-  and evidence set.
+- The historical Debian image findings are superseded for the accepted repository
+  candidate by exact protected-main UBI commit `dda0eb9`, whose producer and
+  independent archives were byte-identical and whose image, SBOM and evidence
+  subjects are attested. This is not a claim about a later source-changing
+  activation or release commit: every such commit requires a new exact image build,
+  scan, independent derivation, evidence replay and attestation set.
 - The accepted ONS adapter and reconciliation storage are local, explicitly injected
   components. The fixed 4,096-claim pre-publication index ceiling and accepted ledger
   event ceiling are local safety bounds, not deployment quotas. There is no
@@ -314,6 +314,24 @@ release is claimed.
   the open product.
 
 ## Latest evidence
+
+- Protected-main combined candidate acceptance on 24 August 2026: integration
+  [pull request 57](https://github.com/chris-page-gov/gis-ai-go/pull/57) and repair
+  [pull request 58](https://github.com/chris-page-gov/gis-ai-go/pull/58) produced
+  exact main commit `dda0eb9f776e64bcd45069e77b4acbcd4d495e01`.
+  [Run 32760872035](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32760872035)
+  passed repository assurance, gateway image assurance, independent derivation,
+  byte-identical verification and both provenance jobs;
+  [run 32760871684](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32760871684)
+  passed all three CodeQL analyses. Both derivations produced OCI manifest
+  `sha256:d08eea1ef3bd74bdba203d8d824cdc9dfac3553e51370ee6006f42c6db27b324`
+  and archive SHA-256
+  `62893bcf428dfe8736e75d53ed702df2141c5c82e0e81798fb43342ba9e323a2`.
+  GitHub attestations bind the
+  [OCI archive](https://github.com/chris-page-gov/gis-ai-go/attestations/42660140),
+  [SBOM](https://github.com/chris-page-gov/gis-ai-go/attestations/42660142) and
+  [evidence manifest](https://github.com/chris-page-gov/gis-ai-go/attestations/42660145).
+  The candidate is still unregistered and undeployed;
 
 - Combined integration local assurance on 24 August 2026: exact clean commit
   `f8d3210064a2fc88f85722d373f935b355c8d289` passed the complete repository and
@@ -357,6 +375,16 @@ release is claimed.
   that exact component and retained database, not a claim of no vulnerabilities. The
   candidate remains repository-only and blocked; no publication, provider call,
   deployment, registration, activation, tag or release is claimed;
+
+- Claude Code `2.1.241` current-protocol observation: the
+  [additive source-bound summary](tests/interoperability/evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json)
+  records two credential-free `mcp list` attempts from exact protected-main commit
+  `dda0eb9f776e64bcd45069e77b4acbcd4d495e01`. The current client offered MCP
+  `2025-11-25`; the strict `2026-07-28` surface returned `-32022`, while the
+  constructor-only fallback completed initialisation and `tools/list`. Capability
+  and the independent-host gate remain unscored and incomplete. The private raw
+  telemetry remains local, and the earlier `2.1.204` schema and evidence hashes are
+  preserved separately;
 
 - Claude Code `2.1.204` protected-main legacy STDIO readiness: the
   [source-bound summary](tests/interoperability/evidence/claude-code-legacy-stdio-readiness-2026-08-23.json)

--- a/changelog.d/QUAL-206-claude-2-1-241-stdio-observation.changed.md
+++ b/changelog.d/QUAL-206-claude-2-1-241-stdio-observation.changed.md
@@ -1,0 +1,5 @@
+Record an additive, source-bound Claude Code `2.1.241` STDIO observation: the
+current client offers MCP `2025-11-25` and is not ready for the strict
+`2026-07-28` surface, while the constructor-only fallback completes initialisation
+and `tools/list`. Historical evidence remains unchanged and capability, activation,
+deployment and release stay unclaimed.

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -225,6 +225,7 @@ MCP registry for a conformance run.
 | Antigravity IDE 1.107.0 | Temporary profile, STDIO discovery, search, resource and fallback | `not_ready`: isolated profile signed out and server directory unavailable; zero MCP traffic |
 | Claude Code 2.1.204, modern-only seam, 20 August | Strict temporary MCP configuration and non-persistent session | `not_ready`: legacy `initialize` rejected `-32022`; capability unscored |
 | Claude Code 2.1.204, protected-main legacy seam, 23 August | Isolated `mcp list` transport check against the protected-main source named below | `ready`: legacy initialisation and `tools/list` passed; capability unscored |
+| Claude Code 2.1.241, strict modern and fallback seams, 24 August | Two credential-free `mcp list` checks against exact protected main `dda0eb9` | strict `2026-07-28` `not_ready`: client offered `2025-11-25` and received `-32022`; constructor-only fallback `ready`: initialisation and `tools/list` passed; capability unscored |
 | VS Code 1.134.0 | Temporary workspace and MCP registry; prove correct window attachment | `not_ready`: no GitHub token and no proved chat attachment; zero MCP traffic |
 | Official SDK client | HTTP and STDIO discovery, calls, resources and shutdown | Accepted on protected `main` |
 
@@ -236,8 +237,8 @@ server results. Run the capability pack only after discovery and listing succeed
 
 Start from the reviewed checkout and create one disposable root. Do not reuse a
 normal host profile or put an AI-provider credential in the MCP definition. Remove
-both OpenAI key variable names from every non-OpenAI host parent and its MCP proxy
-process:
+the five recognised OpenAI and Anthropic credential variable names from every
+non-OpenAI host parent and every MCP proxy process:
 
 ```bash
 export QUAL206_REPO="$(pwd -P)"
@@ -260,6 +261,12 @@ argument list, substituting the host name in the telemetry path and client label
 OPENAI_API_KEY
 -u
 CODEX_API_KEY
+-u
+ANTHROPIC_API_KEY
+-u
+ANTHROPIC_AUTH_TOKEN
+-u
+CLAUDE_CODE_OAUTH_TOKEN
 GIS_AI_GO_QUAL_206_CONFORMANCE=1
 GIS_AI_GO_QUAL_206_SOURCE_COMMIT=<QUAL206_SOURCE_COMMIT>
 <QUAL206_NODE>
@@ -286,6 +293,8 @@ qual206_mcp_server() {
     --arg server "$QUAL206_REPO/scripts/qual_206_conformance_server.mjs" \
     '{type:"stdio",command:"/usr/bin/env",args:[
       "-u","OPENAI_API_KEY","-u","CODEX_API_KEY",
+      "-u","ANTHROPIC_API_KEY","-u","ANTHROPIC_AUTH_TOKEN",
+      "-u","CLAUDE_CODE_OAUTH_TOKEN",
       "GIS_AI_GO_QUAL_206_CONFORMANCE=1",
       "GIS_AI_GO_QUAL_206_SOURCE_COMMIT="+$commit,
       $node,$proxy,"--log",$log,"--client",$client,"--",$node,$server
@@ -306,9 +315,9 @@ automation invocation. See [Model Context Protocol](https://developers.openai.co
 [configuration reference](https://developers.openai.com/codex/config-reference/).
 
 Use an empty disposable Git workspace and the exact `QUAL-206-HOST-002` corpus
-case. The MCP command strips both supported API-key variable names before starting
-the telemetry proxy, so neither the proxy nor its server child receives the
-credential. The execution command also enables Codex's default secret-name
+case. The MCP command strips all five recognised provider credential variable names
+before starting the telemetry proxy, so neither the proxy nor its server child
+receives a credential. The execution command also enables Codex's default secret-name
 exclusions, preventing a later model-spawned shell subprocess from inheriting the
 single-invocation API key:
 
@@ -320,6 +329,8 @@ git -C "$QUAL206_HOST_ROOT/codex-workspace" init -q
   CODEX_HOME="$QUAL206_HOST_ROOT/codex-home" \
   codex mcp add gis-ai-go-qual-206 -- \
   /usr/bin/env -u CODEX_API_KEY -u OPENAI_API_KEY \
+  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
+  -u CLAUDE_CODE_OAUTH_TOKEN \
   GIS_AI_GO_QUAL_206_CONFORMANCE=1 \
   "GIS_AI_GO_QUAL_206_SOURCE_COMMIT=$QUAL206_SOURCE_COMMIT" \
   "$QUAL206_NODE" "$QUAL206_REPO/scripts/qual_206_telemetry_proxy.mjs" \
@@ -332,6 +343,8 @@ umask 077
 jq -r '.cases[] | select(.id == "QUAL-206-HOST-002") | .prompt' \
   tests/interoperability/qual_206_cases.json | \
   CODEX_API_KEY=${OPENAI_API_KEY} /usr/bin/env -u OPENAI_API_KEY \
+  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
+  -u CLAUDE_CODE_OAUTH_TOKEN \
   HOME="$QUAL206_HOST_ROOT/codex-profile" \
   CODEX_HOME="$QUAL206_HOST_ROOT/codex-home" \
   codex -a never exec --strict-config --json --ephemeral --ignore-rules \
@@ -374,6 +387,8 @@ jq -n --argjson server "$MCP_SERVER_JSON" \
   '{mcpServers:{"gis-ai-go-qual-206":$server}}' \
   > "$QUAL206_HOST_ROOT/claude/mcp.json"
 /usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY \
+  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
+  -u CLAUDE_CODE_OAUTH_TOKEN \
   CLAUDE_CONFIG_DIR="$QUAL206_HOST_ROOT/claude" claude \
   --bare --print --no-session-persistence --strict-mcp-config \
   --mcp-config "$QUAL206_HOST_ROOT/claude/mcp.json" \
@@ -400,6 +415,12 @@ Repeat that health check by writing only this public-safe object to the isolated
         "OPENAI_API_KEY",
         "-u",
         "CODEX_API_KEY",
+        "-u",
+        "ANTHROPIC_API_KEY",
+        "-u",
+        "ANTHROPIC_AUTH_TOKEN",
+        "-u",
+        "CLAUDE_CODE_OAUTH_TOKEN",
         "<QUAL206_NODE>",
         "<QUAL206_REPO>/scripts/qual_206_telemetry_proxy.mjs",
         "--log",
@@ -423,6 +444,8 @@ Then run:
 
 ```bash
 /usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY \
+  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
+  -u CLAUDE_CODE_OAUTH_TOKEN \
   CLAUDE_CONFIG_DIR="$QUAL206_HOST_ROOT/claude" claude mcp list
 ```
 
@@ -437,7 +460,9 @@ AG_BIN='/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity
 MCP_SERVER_JSON="$(qual206_mcp_server antigravity antigravity-ide-1.107.0)"
 MCP_DEFINITION_JSON="$(jq -cn --argjson server "$MCP_SERVER_JSON" \
   '$server | del(.type) + {name:"gis-ai-go-qual-206"}')"
-/usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY "$AG_BIN" \
+/usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY \
+  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
+  -u CLAUDE_CODE_OAUTH_TOKEN "$AG_BIN" \
   --user-data-dir "$QUAL206_HOST_ROOT/antigravity/user-data" \
   --extensions-dir "$QUAL206_HOST_ROOT/antigravity/extensions" \
   --sync off --new-window --add-mcp "$MCP_DEFINITION_JSON" \
@@ -456,7 +481,9 @@ For VS Code, use the same isolated launch pattern:
 MCP_SERVER_JSON="$(qual206_mcp_server vscode vscode-1.134.0)"
 MCP_DEFINITION_JSON="$(jq -cn --argjson server "$MCP_SERVER_JSON" \
   '$server | del(.type) + {name:"gis-ai-go-qual-206"}')"
-/usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY code \
+/usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY \
+  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
+  -u CLAUDE_CODE_OAUTH_TOKEN code \
   --user-data-dir "$QUAL206_HOST_ROOT/vscode/user-data" \
   --extensions-dir "$QUAL206_HOST_ROOT/vscode/extensions" \
   --sync off --new-window --add-mcp "$MCP_DEFINITION_JSON" \
@@ -564,9 +591,10 @@ node scripts/qual_206_telemetry_proxy.mjs \
   --legacy-stdio-conformance-only
 ```
 
-For a host registry, retain the `/usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY`
-outer command from the independent-host procedure. Replace only the final server
-command with this ordered pair:
+For a host registry, retain the outer `/usr/bin/env` command from the
+independent-host procedure that removes all five recognised OpenAI and Anthropic
+credential variables. Replace only the final server command with this ordered
+pair:
 
 ```text
 <QUAL206_NODE> <QUAL206_REPO>/scripts/qual_206_legacy_conformance_server.mjs
@@ -637,6 +665,43 @@ independent-host gate.
 This fallback is local-only. Do not attach it to the existing ChatGPT tunnel,
 change that tunnel's profile, publish its address, activate a production tool or
 infer general host compatibility from the official-client regression.
+
+### Updated Claude Code protocol observation
+
+On 24 August 2026, the owner-approved Anthropic updater changed the installed
+Claude Code from `2.1.204` to `2.1.241`. At the observation point the official npm
+registry labelled `2.1.231` stable and `2.1.241` latest; the observed arm64 binary
+SHA-256 was
+`1495eb7c42d3b4451f5f1cd38b6d498d22a4a38c802bc2be5c1cf1795e64820d`.
+The official MCP target remained the final `2026-07-28` release recorded as
+`S-MCP-SPEC` in the source ledger.
+
+Two isolated `claude mcp list` checks used disposable profile roots with mode
+`0700`, primary configuration and telemetry files with mode `0600`, an allowlisted
+MCP child environment and no provider credential. Claude generated `0755` backup
+subdirectories containing one `0644` and one `0600` configuration backup; both
+subdirectories remained unreachable outside their enclosing `0700` profile roots.
+Both checks were bound to a clean detached checkout of exact protected-main commit
+`dda0eb9f776e64bcd45069e77b4acbcd4d495e01`, tree
+`258e6f3b3f62abccf04795e015f6961e06740fcf`. The exact preflight passed after the
+known local loopback sandbox restriction was removed.
+
+Claude Code `2.1.241` offered protocol `2025-11-25`. The strict modern server
+therefore returned `-32022` rather than silently downgrading the canonical
+`2026-07-28` surface. The constructor-only fallback then completed initialisation,
+the initialised notification and `tools/list`, and exited with no pending request.
+The closed, path-free
+[`2.1.241 observation`](../../tests/interoperability/evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json)
+binds both private-log digests and preserves the earlier `2.1.204` schema and
+evidence digests.
+
+This is an explained client-version variance, not modern-protocol or capability
+acceptance. It exercised no model task, tool call, resource read, exact-five
+assembly, live provider, remote HTTP host, registration, activation, deployment or
+release. Do not widen the shipped protocol boundary to make this host appear
+compatible. A different independent desktop host must first prove
+`server/discover` or another valid `2026-07-28` opening before running the bounded
+capability pack.
 
 ## Historical failure-derived cases
 

--- a/schemas/qual-206-claude-code-stdio-observation.schema.json
+++ b/schemas/qual-206-claude-code-stdio-observation.schema.json
@@ -1,0 +1,954 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:qual-206-claude-code-stdio-observation:v1",
+  "title": "QUAL-206 Claude Code STDIO observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_contract",
+    "status",
+    "observed_on",
+    "source",
+    "host",
+    "protocol_target",
+    "historical_lineage",
+    "attempts",
+    "isolation",
+    "limitations",
+    "boundary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.qual-206-claude-code-stdio-observation.v1"
+    },
+    "schema_contract": {
+      "$ref": "#/$defs/schemaContract"
+    },
+    "status": {
+      "const": "strict-modern-not-ready-fallback-ready-capability-unscored"
+    },
+    "observed_on": {
+      "const": "2026-08-24"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "host": {
+      "$ref": "#/$defs/host"
+    },
+    "protocol_target": {
+      "$ref": "#/$defs/protocolTarget"
+    },
+    "historical_lineage": {
+      "$ref": "#/$defs/historicalLineage"
+    },
+    "attempts": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/modernAttempt"
+        },
+        {
+          "$ref": "#/$defs/fallbackAttempt"
+        }
+      ],
+      "items": false
+    },
+    "isolation": {
+      "$ref": "#/$defs/isolation"
+    },
+    "limitations": {
+      "$ref": "#/$defs/limitations"
+    },
+    "boundary": {
+      "const": "Accepted protected-main Claude Code protocol observation only. Claude Code 2.1.241 offered MCP 2025-11-25, so the strict 2026-07-28 STDIO surface correctly rejected it while the constructor-only fallback completed initialisation and tools/list. No model, tool call, resource read, exact-five production assembly, provider, remote HTTP host, registration, activation, deployment or release was exercised. Capability and the independent-host gate remain unscored and incomplete."
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "schemaContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "const": "schemas/qual-206-claude-code-stdio-observation.schema.json"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "sourceFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^(?:apps|scripts)/(?!\\.{1,2}(?:/|$))[A-Za-z0-9._-]+(?:/(?!\\.{1,2}(?:/|$))[A-Za-z0-9._-]+)*$"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit",
+        "tree",
+        "protected_main",
+        "version",
+        "detached_checkout",
+        "worktree_changes_uncommitted",
+        "production_registration",
+        "production_activation",
+        "public_endpoint_created",
+        "runtime_files",
+        "build"
+      ],
+      "properties": {
+        "repository": {
+          "const": "chris-page-gov/gis-ai-go"
+        },
+        "commit": {
+          "const": "dda0eb9f776e64bcd45069e77b4acbcd4d495e01"
+        },
+        "tree": {
+          "const": "258e6f3b3f62abccf04795e015f6961e06740fcf"
+        },
+        "protected_main": {
+          "const": true
+        },
+        "version": {
+          "const": "0.1.0"
+        },
+        "detached_checkout": {
+          "const": true
+        },
+        "worktree_changes_uncommitted": {
+          "const": false
+        },
+        "production_registration": {
+          "const": false
+        },
+        "production_activation": {
+          "const": false
+        },
+        "public_endpoint_created": {
+          "const": false
+        },
+        "runtime_files": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "prefixItems": [
+            {
+              "const": {
+                "path": "apps/mcp-gateway/src/mcp-server.ts",
+                "sha256": "e2c5cec027f3049d0a501b885a0ab6336d7e6059690df54ac7b257945807b454"
+              }
+            },
+            {
+              "const": {
+                "path": "apps/mcp-gateway/src/mcp-stdio.ts",
+                "sha256": "5e8d87020d1efe34b2b83940f60d2df5926f466c12473fffc156463c9a6cef30"
+              }
+            },
+            {
+              "const": {
+                "path": "scripts/qual_206_conformance_server.mjs",
+                "sha256": "aba0f4415bc9f94443be8b79eee06b03bdd275ca9854218dee30102c20a6778f"
+              }
+            },
+            {
+              "const": {
+                "path": "scripts/qual_206_legacy_conformance_server.mjs",
+                "sha256": "bf87bec24357d5fd6d419bd8b4374642ab46a2f3dfa6d9baebde46f7498edb9c"
+              }
+            },
+            {
+              "const": {
+                "path": "scripts/qual_206_telemetry_proxy.mjs",
+                "sha256": "3800e4458932ee1324ad03d64007f23f76f49682a6eabdc191ecf6eaccb501d5"
+              }
+            }
+          ],
+          "items": false
+        },
+        "build": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "command",
+            "dependencies_installed_with_frozen_lockfile",
+            "preflight_passed",
+            "loopback_permission_required",
+            "lockfile",
+            "compiled_entrypoints"
+          ],
+          "properties": {
+            "command": {
+              "const": "pnpm run test:interoperability"
+            },
+            "dependencies_installed_with_frozen_lockfile": {
+              "const": true
+            },
+            "preflight_passed": {
+              "const": true
+            },
+            "loopback_permission_required": {
+              "const": true
+            },
+            "lockfile": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path",
+                "sha256"
+              ],
+              "properties": {
+                "path": {
+                  "const": "pnpm-lock.yaml"
+                },
+                "sha256": {
+                  "const": "640208aa66d26241514025b33dbde50bc14be7bbd33641eec9977e87699bb4ec"
+                }
+              }
+            },
+            "compiled_entrypoints": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "prefixItems": [
+                {
+                  "const": {
+                    "path": "apps/mcp-gateway/dist/src/mcp-server.js",
+                    "sha256": "71fdde3b45363d366b62e7c4219c2cc77efbfbfe9d9e5d110f656e76ee9d2ab1"
+                  }
+                },
+                {
+                  "const": {
+                    "path": "apps/mcp-gateway/dist/src/mcp-stdio.js",
+                    "sha256": "17a04b0b1f0a5549157c8e07119ac1d7a895b86d9a73312aaaa2561fd1e092e3"
+                  }
+                }
+              ],
+              "items": false
+            }
+          }
+        }
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "platform",
+        "architecture",
+        "binary_sha256",
+        "command",
+        "update"
+      ],
+      "properties": {
+        "name": {
+          "const": "Claude Code"
+        },
+        "version": {
+          "const": "2.1.241"
+        },
+        "platform": {
+          "const": "darwin"
+        },
+        "architecture": {
+          "const": "arm64"
+        },
+        "binary_sha256": {
+          "const": "1495eb7c42d3b4451f5f1cd38b6d498d22a4a38c802bc2be5c1cf1795e64820d"
+        },
+        "command": {
+          "const": "mcp list"
+        },
+        "update": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "method",
+            "from_version",
+            "to_version",
+            "registry_package",
+            "registry_stable",
+            "registry_latest",
+            "latest_at_observation"
+          ],
+          "properties": {
+            "method": {
+              "const": "claude update"
+            },
+            "from_version": {
+              "const": "2.1.204"
+            },
+            "to_version": {
+              "const": "2.1.241"
+            },
+            "registry_package": {
+              "const": "@anthropic-ai/claude-code"
+            },
+            "registry_stable": {
+              "const": "2.1.231"
+            },
+            "registry_latest": {
+              "const": "2.1.241"
+            },
+            "latest_at_observation": {
+              "const": true
+            }
+          }
+        }
+      }
+    },
+    "protocolTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "status_at_observation",
+        "source_id"
+      ],
+      "properties": {
+        "version": {
+          "const": "2026-07-28"
+        },
+        "status_at_observation": {
+          "const": "latest-published"
+        },
+        "source_id": {
+          "const": "S-MCP-SPEC"
+        }
+      }
+    },
+    "historicalLineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_sha256",
+        "evidence_sha256",
+        "relationship"
+      ],
+      "properties": {
+        "schema_sha256": {
+          "const": "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a"
+        },
+        "evidence_sha256": {
+          "const": "a3d40e2013095baf977bad336366c0fb429a05b6a5a267c3e069595e4cdb1a6b"
+        },
+        "relationship": {
+          "const": "preserved-separate-not-superseded"
+        }
+      }
+    },
+    "requestFrame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method_label",
+        "frame_bytes",
+        "frame_sha256",
+        "parameters_bytes",
+        "parameters_sha256"
+      ],
+      "properties": {
+        "method_label": {
+          "enum": [
+            "other",
+            "tools/list"
+          ]
+        },
+        "frame_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1048576
+        },
+        "frame_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "parameters_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1048576
+        },
+        "parameters_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "responseFrame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "duration_ms",
+        "frame_bytes",
+        "frame_sha256"
+      ],
+      "properties": {
+        "outcome": {
+          "enum": [
+            "success",
+            "error"
+          ]
+        },
+        "error_code": {
+          "type": "integer"
+        },
+        "duration_ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "frame_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1048576
+        },
+        "frame_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "error"
+              }
+            },
+            "required": [
+              "outcome"
+            ]
+          },
+          "then": {
+            "required": [
+              "error_code"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "error_code"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "telemetryBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "node_version",
+        "source_commit",
+        "retained_private_bytes",
+        "retained_private_sha256",
+        "retained_private_mode",
+        "event_count",
+        "event_counts",
+        "initialize_request",
+        "initialize_response",
+        "invalid_frame_count",
+        "non_json_frame_count",
+        "truncated_frame_count",
+        "server_stderr_event_count",
+        "exit_code",
+        "pending_request_count",
+        "raw_content_published"
+      ],
+      "properties": {
+        "schema": {
+          "const": "gis-ai-go.qual-206-host-telemetry.v1"
+        },
+        "node_version": {
+          "const": "v26.7.0"
+        },
+        "source_commit": {
+          "const": "dda0eb9f776e64bcd45069e77b4acbcd4d495e01"
+        },
+        "retained_private_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "retained_private_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "retained_private_mode": {
+          "const": "0600"
+        },
+        "event_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16
+        },
+        "event_counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_start",
+            "request",
+            "response",
+            "session_end"
+          ],
+          "properties": {
+            "session_start": {
+              "const": 1
+            },
+            "request": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4
+            },
+            "response": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4
+            },
+            "session_end": {
+              "const": 1
+            }
+          }
+        },
+        "initialize_request": {
+          "$ref": "#/$defs/requestFrame"
+        },
+        "initialize_response": {
+          "$ref": "#/$defs/responseFrame"
+        },
+        "initialized_notification": {
+          "$ref": "#/$defs/requestFrame"
+        },
+        "tools_list_request": {
+          "$ref": "#/$defs/requestFrame"
+        },
+        "tools_list_response": {
+          "$ref": "#/$defs/responseFrame"
+        },
+        "invalid_frame_count": {
+          "const": 0
+        },
+        "non_json_frame_count": {
+          "const": 0
+        },
+        "truncated_frame_count": {
+          "const": 0
+        },
+        "server_stderr_event_count": {
+          "const": 0
+        },
+        "exit_code": {
+          "const": 0
+        },
+        "pending_request_count": {
+          "const": 0
+        },
+        "raw_content_published": {
+          "const": false
+        }
+      }
+    },
+    "modernAttempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "server_surface",
+        "transport",
+        "client_requested_protocol",
+        "server_protocol",
+        "transport_readiness",
+        "capability",
+        "classification",
+        "host_result",
+        "error_code",
+        "initialize_success",
+        "tools_list_success",
+        "tool_call_observed",
+        "resource_read_observed",
+        "telemetry"
+      ],
+      "properties": {
+        "kind": {
+          "const": "strict-modern"
+        },
+        "server_surface": {
+          "const": "canonical-2026-07-28-conformance"
+        },
+        "transport": {
+          "const": "stdio"
+        },
+        "client_requested_protocol": {
+          "const": "2025-11-25"
+        },
+        "server_protocol": {
+          "const": "2026-07-28"
+        },
+        "transport_readiness": {
+          "const": "not-ready"
+        },
+        "capability": {
+          "const": "unscored"
+        },
+        "classification": {
+          "const": "legacy-initialise-rejected-by-modern-surface"
+        },
+        "host_result": {
+          "const": "Failed to connect"
+        },
+        "error_code": {
+          "const": -32022
+        },
+        "initialize_success": {
+          "const": false
+        },
+        "tools_list_success": {
+          "const": false
+        },
+        "tool_call_observed": {
+          "const": false
+        },
+        "resource_read_observed": {
+          "const": false
+        },
+        "telemetry": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/telemetryBase"
+            },
+            {
+              "properties": {
+                "event_count": {
+                  "const": 4
+                },
+                "event_counts": {
+                  "const": {
+                    "session_start": 1,
+                    "request": 1,
+                    "response": 1,
+                    "session_end": 1
+                  }
+                },
+                "initialize_request": {
+                  "properties": {
+                    "method_label": {
+                      "const": "other"
+                    }
+                  }
+                },
+                "initialize_response": {
+                  "properties": {
+                    "outcome": {
+                      "const": "error"
+                    },
+                    "error_code": {
+                      "const": -32022
+                    }
+                  }
+                }
+              },
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "initialized_notification"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "tools_list_request"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "tools_list_response"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fallbackAttempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "server_surface",
+        "transport",
+        "client_requested_protocol",
+        "negotiated_protocol",
+        "transport_readiness",
+        "capability",
+        "classification",
+        "host_result",
+        "initialize_success",
+        "tools_list_success",
+        "tool_call_observed",
+        "resource_read_observed",
+        "telemetry"
+      ],
+      "properties": {
+        "kind": {
+          "const": "constructor-only-fallback"
+        },
+        "server_surface": {
+          "const": "test-only-legacy-conformance"
+        },
+        "transport": {
+          "const": "stdio"
+        },
+        "client_requested_protocol": {
+          "const": "2025-11-25"
+        },
+        "negotiated_protocol": {
+          "const": "2025-06-18"
+        },
+        "transport_readiness": {
+          "const": "ready"
+        },
+        "capability": {
+          "const": "unscored"
+        },
+        "classification": {
+          "const": "legacy-handshake-and-tool-list-pass"
+        },
+        "host_result": {
+          "const": "Connected"
+        },
+        "initialize_success": {
+          "const": true
+        },
+        "tools_list_success": {
+          "const": true
+        },
+        "tool_call_observed": {
+          "const": false
+        },
+        "resource_read_observed": {
+          "const": false
+        },
+        "telemetry": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/telemetryBase"
+            },
+            {
+              "required": [
+                "initialized_notification",
+                "tools_list_request",
+                "tools_list_response"
+              ],
+              "properties": {
+                "event_count": {
+                  "const": 7
+                },
+                "event_counts": {
+                  "const": {
+                    "session_start": 1,
+                    "request": 3,
+                    "response": 2,
+                    "session_end": 1
+                  }
+                },
+                "initialize_request": {
+                  "properties": {
+                    "method_label": {
+                      "const": "other"
+                    }
+                  }
+                },
+                "initialize_response": {
+                  "properties": {
+                    "outcome": {
+                      "const": "success"
+                    }
+                  }
+                },
+                "initialized_notification": {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/requestFrame"
+                    },
+                    {
+                      "properties": {
+                        "method_label": {
+                          "const": "other"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "tools_list_request": {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/requestFrame"
+                    },
+                    {
+                      "properties": {
+                        "method_label": {
+                          "const": "tools/list"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "tools_list_response": {
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/responseFrame"
+                    },
+                    {
+                      "properties": {
+                        "outcome": {
+                          "const": "success"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temporary_profiles",
+        "profile_root_mode",
+        "backup_directory_mode",
+        "primary_configuration_mode",
+        "generated_backup_modes",
+        "normal_profile_used",
+        "credential_variables_removed",
+        "mcp_child_environment_allowlisted",
+        "retained_private_logs",
+        "credential_value_pattern_matches",
+        "remaining_isolated_processes_after_cleanup",
+        "raw_host_logs_published"
+      ],
+      "properties": {
+        "temporary_profiles": {
+          "const": 2
+        },
+        "profile_root_mode": {
+          "const": "0700"
+        },
+        "backup_directory_mode": {
+          "const": "0755"
+        },
+        "primary_configuration_mode": {
+          "const": "0600"
+        },
+        "generated_backup_modes": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "prefixItems": [
+            {
+              "const": "0644"
+            },
+            {
+              "const": "0600"
+            }
+          ],
+          "items": false
+        },
+        "normal_profile_used": {
+          "const": false
+        },
+        "credential_variables_removed": {
+          "const": 5
+        },
+        "mcp_child_environment_allowlisted": {
+          "const": true
+        },
+        "retained_private_logs": {
+          "const": 2
+        },
+        "credential_value_pattern_matches": {
+          "const": 0
+        },
+        "remaining_isolated_processes_after_cleanup": {
+          "const": 0
+        },
+        "raw_host_logs_published": {
+          "const": false
+        }
+      }
+    },
+    "limitations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "modern_transport_ready",
+        "legacy_transport_ready",
+        "capability_result_claimed",
+        "independent_host_gate_completed",
+        "exact_five_assembly_exercised",
+        "model_task_requested",
+        "live_provider_called",
+        "remote_http_observed",
+        "activation_or_release_claimed"
+      ],
+      "properties": {
+        "modern_transport_ready": {
+          "const": false
+        },
+        "legacy_transport_ready": {
+          "const": true
+        },
+        "capability_result_claimed": {
+          "const": false
+        },
+        "independent_host_gate_completed": {
+          "const": false
+        },
+        "exact_five_assembly_exercised": {
+          "const": false
+        },
+        "model_task_requested": {
+          "const": false
+        },
+        "live_provider_called": {
+          "const": false
+        },
+        "remote_http_observed": {
+          "const": false
+        },
+        "activation_or_release_claimed": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -849,6 +849,22 @@ def main() -> None:
             ],
         ),
         (
+            "qual-206-claude-code-stdio-observation.schema.json",
+            [
+                (
+                    "tests/interoperability/evidence/"
+                    "claude-code-2.1.241-stdio-observation-2026-08-24.json",
+                    load_json(
+                        ROOT
+                        / "tests"
+                        / "interoperability"
+                        / "evidence"
+                        / "claude-code-2.1.241-stdio-observation-2026-08-24.json"
+                    ),
+                )
+            ],
+        ),
+        (
             "decision.schema.json",
             [
                 (record["id"], record)

--- a/tests/contract/test_qual_206_claude_code_stdio_observation.py
+++ b/tests/contract/test_qual_206_claude_code_stdio_observation.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "qual-206-claude-code-stdio-observation.schema.json"
+EVIDENCE_PATH = (
+    ROOT
+    / "tests"
+    / "interoperability"
+    / "evidence"
+    / "claude-code-2.1.241-stdio-observation-2026-08-24.json"
+)
+RUNBOOK_PATH = ROOT / "docs" / "operations" / "QUAL-206_INTEROPERABILITY.md"
+HISTORICAL_SCHEMA_PATH = ROOT / "schemas" / "qual-206-legacy-stdio-readiness.schema.json"
+HISTORICAL_EVIDENCE_PATH = (
+    ROOT
+    / "tests"
+    / "interoperability"
+    / "evidence"
+    / "claude-code-legacy-stdio-readiness-2026-08-23.json"
+)
+SOURCE_COMMIT = "dda0eb9f776e64bcd45069e77b4acbcd4d495e01"
+SOURCE_TREE = "258e6f3b3f62abccf04795e015f6961e06740fcf"
+SCHEMA_SHA256 = "78b9a8071a6954028576f397c98dd0fc4b87dddbaf72654f6459407b280e2a9b"
+EVIDENCE_SHA256 = "d2cd72b7f16a0bafd8a7190b87b14f150b7fa975f6d70f5e779eb9ddf5f92478"
+HISTORICAL_SCHEMA_SHA256 = (
+    "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a"
+)
+HISTORICAL_EVIDENCE_SHA256 = (
+    "a3d40e2013095baf977bad336366c0fb429a05b6a5a267c3e069595e4cdb1a6b"
+)
+LOCKFILE_SHA256 = "640208aa66d26241514025b33dbde50bc14be7bbd33641eec9977e87699bb4ec"
+EXPECTED_RUNTIME_FILES = [
+    (
+        "apps/mcp-gateway/src/mcp-server.ts",
+        "e2c5cec027f3049d0a501b885a0ab6336d7e6059690df54ac7b257945807b454",
+    ),
+    (
+        "apps/mcp-gateway/src/mcp-stdio.ts",
+        "5e8d87020d1efe34b2b83940f60d2df5926f466c12473fffc156463c9a6cef30",
+    ),
+    (
+        "scripts/qual_206_conformance_server.mjs",
+        "aba0f4415bc9f94443be8b79eee06b03bdd275ca9854218dee30102c20a6778f",
+    ),
+    (
+        "scripts/qual_206_legacy_conformance_server.mjs",
+        "bf87bec24357d5fd6d419bd8b4374642ab46a2f3dfa6d9baebde46f7498edb9c",
+    ),
+    (
+        "scripts/qual_206_telemetry_proxy.mjs",
+        "3800e4458932ee1324ad03d64007f23f76f49682a6eabdc191ecf6eaccb501d5",
+    ),
+]
+EXPECTED_COMPILED_ENTRYPOINTS = [
+    (
+        "apps/mcp-gateway/dist/src/mcp-server.js",
+        "71fdde3b45363d366b62e7c4219c2cc77efbfbfe9d9e5d110f656e76ee9d2ab1",
+    ),
+    (
+        "apps/mcp-gateway/dist/src/mcp-stdio.js",
+        "17a04b0b1f0a5549157c8e07119ac1d7a895b86d9a73312aaaa2561fd1e092e3",
+    ),
+]
+BOUNDARY = (
+    "Accepted protected-main Claude Code protocol observation only. Claude Code "
+    "2.1.241 offered MCP 2025-11-25, so the strict 2026-07-28 STDIO surface "
+    "correctly rejected it while the constructor-only fallback completed "
+    "initialisation and tools/list. No model, tool call, resource read, exact-five "
+    "production assembly, provider, remote HTTP host, registration, activation, "
+    "deployment or release was exercised. Capability and the independent-host gate "
+    "remain unscored and incomplete."
+)
+PUBLIC_EVIDENCE_FORBIDDEN = re.compile(
+    r"(?:"
+    r"/Users/|/home/|/Volumes/|/private/tmp/|file://|"
+    r"[A-Za-z]:\\\\Users\\\\|"
+    r"\bsk-[A-Za-z0-9_-]{8,}|\bgh[opusr]_[A-Za-z0-9]{8,}|"
+    r"\bxox[baprs]-[A-Za-z0-9-]{8,}|\bAKIA[0-9A-Z]{16}|"
+    r"\bBearer\s+[A-Za-z0-9._~-]+|"
+    r"OPENAI_API_KEY|CODEX_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|"
+    r"CLAUDE_CODE_OAUTH_TOKEN|"
+    r"https?://(?:chatgpt\.com/c/|claude\.ai/chat/)|"
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-"
+    r"[0-9a-f]{12}\b"
+    r")",
+    re.IGNORECASE,
+)
+FORBIDDEN_FIELD_NAMES = {
+    "command_sha256",
+    "environment",
+    "headers",
+    "log_path",
+    "profile_path",
+    "prompt",
+    "raw_command",
+    "raw_result",
+    "session_id",
+    "session_id_sha256",
+}
+
+
+def reject_non_standard_number(value: str) -> None:
+    raise ValueError(f"Non-standard JSON number: {value}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=reject_non_standard_number,
+    )
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def git_output(*arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise AssertionError(f"git {' '.join(arguments)} failed: {message}")
+    return result.stdout
+
+
+def git_blob(commit: str, path: str) -> bytes:
+    return git_output("show", f"{commit}:{path}")
+
+
+def assert_contract_objects_are_closed(
+    test_case: unittest.TestCase,
+    node: object,
+    path: str = "$",
+) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            test_case.assertIs(
+                node.get("additionalProperties"),
+                False,
+                f"{path} must reject unknown properties",
+            )
+        for key, value in node.items():
+            assert_contract_objects_are_closed(test_case, value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            assert_contract_objects_are_closed(test_case, value, f"{path}[{index}]")
+
+
+def nested_field_names(node: object) -> set[str]:
+    names: set[str] = set()
+    if isinstance(node, dict):
+        names.update(node)
+        for value in node.values():
+            names.update(nested_field_names(value))
+    elif isinstance(node, list):
+        for value in node:
+            names.update(nested_field_names(value))
+    return names
+
+
+class Qual206ClaudeCodeStdioObservationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = load_json(SCHEMA_PATH)
+        cls.document = load_json(EVIDENCE_PATH)
+        cls.validator = Draft202012Validator(
+            cls.schema,
+            format_checker=FormatChecker(),
+        )
+
+    def assert_invalid(self, value: object) -> None:
+        self.assertTrue(list(self.validator.iter_errors(value)))
+
+    def test_closed_schema_accepts_exact_canonical_evidence(self) -> None:
+        Draft202012Validator.check_schema(self.schema)
+        assert_contract_objects_are_closed(self, self.schema)
+        errors = sorted(
+            self.validator.iter_errors(self.document),
+            key=lambda error: list(error.absolute_path),
+        )
+        self.assertEqual(
+            [],
+            [
+                f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: "
+                f"{error.message}"
+                for error in errors
+            ],
+        )
+        expected_bytes = (
+            json.dumps(self.document, ensure_ascii=False, indent=2) + "\n"
+        ).encode()
+        self.assertEqual(EVIDENCE_PATH.read_bytes(), expected_bytes)
+        self.assertEqual(sha256_bytes(SCHEMA_PATH.read_bytes()), SCHEMA_SHA256)
+        self.assertEqual(sha256_bytes(EVIDENCE_PATH.read_bytes()), EVIDENCE_SHA256)
+        self.assertEqual(
+            self.document["schema_contract"],
+            {
+                "path": "schemas/qual-206-claude-code-stdio-observation.schema.json",
+                "sha256": SCHEMA_SHA256,
+            },
+        )
+
+    def test_record_binds_exact_protected_main_source_materials(self) -> None:
+        source = self.document["source"]
+        self.assertEqual(source["commit"], SOURCE_COMMIT)
+        self.assertEqual(source["tree"], SOURCE_TREE)
+        self.assertEqual(
+            git_output("rev-parse", f"{SOURCE_COMMIT}^{{tree}}").decode().strip(),
+            SOURCE_TREE,
+        )
+        runtime = [(item["path"], item["sha256"]) for item in source["runtime_files"]]
+        self.assertEqual(runtime, EXPECTED_RUNTIME_FILES)
+        for path, expected_digest in EXPECTED_RUNTIME_FILES:
+            with self.subTest(path=path):
+                self.assertEqual(sha256_bytes(git_blob(SOURCE_COMMIT, path)), expected_digest)
+        build = source["build"]
+        self.assertEqual(build["lockfile"]["sha256"], LOCKFILE_SHA256)
+        self.assertEqual(
+            sha256_bytes(git_blob(SOURCE_COMMIT, "pnpm-lock.yaml")),
+            LOCKFILE_SHA256,
+        )
+        self.assertEqual(
+            [
+                (item["path"], item["sha256"])
+                for item in build["compiled_entrypoints"]
+            ],
+            EXPECTED_COMPILED_ENTRYPOINTS,
+        )
+        self.assertTrue(build["preflight_passed"])
+        self.assertTrue(build["loopback_permission_required"])
+
+    def test_historical_observation_remains_byte_exact_and_separate(self) -> None:
+        self.assertEqual(
+            sha256_bytes(HISTORICAL_SCHEMA_PATH.read_bytes()),
+            HISTORICAL_SCHEMA_SHA256,
+        )
+        self.assertEqual(
+            sha256_bytes(HISTORICAL_EVIDENCE_PATH.read_bytes()),
+            HISTORICAL_EVIDENCE_SHA256,
+        )
+        self.assertEqual(
+            self.document["historical_lineage"],
+            {
+                "schema_sha256": HISTORICAL_SCHEMA_SHA256,
+                "evidence_sha256": HISTORICAL_EVIDENCE_SHA256,
+                "relationship": "preserved-separate-not-superseded",
+            },
+        )
+
+    def test_attempts_distinguish_modern_failure_from_fallback_readiness(self) -> None:
+        modern, fallback = self.document["attempts"]
+        self.assertEqual((modern["kind"], fallback["kind"]), (
+            "strict-modern",
+            "constructor-only-fallback",
+        ))
+        self.assertEqual(modern["client_requested_protocol"], "2025-11-25")
+        self.assertEqual(fallback["client_requested_protocol"], "2025-11-25")
+        self.assertEqual(modern["server_protocol"], "2026-07-28")
+        self.assertEqual(fallback["negotiated_protocol"], "2025-06-18")
+        self.assertEqual((modern["transport_readiness"], fallback["transport_readiness"]), (
+            "not-ready",
+            "ready",
+        ))
+        self.assertEqual((modern["capability"], fallback["capability"]), (
+            "unscored",
+            "unscored",
+        ))
+        self.assertEqual(modern["error_code"], -32022)
+        self.assertFalse(modern["initialize_success"])
+        self.assertFalse(modern["tools_list_success"])
+        self.assertTrue(fallback["initialize_success"])
+        self.assertTrue(fallback["tools_list_success"])
+        self.assertEqual(
+            modern["telemetry"]["initialize_request"],
+            fallback["telemetry"]["initialize_request"],
+        )
+        historical = load_json(HISTORICAL_EVIDENCE_PATH)["telemetry"]
+        self.assertEqual(
+            fallback["telemetry"]["initialize_response"]["frame_sha256"],
+            historical["initialize_response"]["frame_sha256"],
+        )
+        self.assertEqual(
+            fallback["telemetry"]["tools_list_response"]["frame_sha256"],
+            historical["tools_list_response"]["frame_sha256"],
+        )
+        self.assertNotIn("tools_list_request", modern["telemetry"])
+        self.assertNotIn("tools_list_response", modern["telemetry"])
+
+        for attempt in (modern, fallback):
+            telemetry = attempt["telemetry"]
+            self.assertEqual(
+                telemetry["event_count"],
+                sum(telemetry["event_counts"].values()),
+            )
+            for response_name in (
+                "initialize_response",
+                *(("tools_list_response",) if attempt is fallback else ()),
+            ):
+                duration = telemetry[response_name]["duration_ms"]
+                self.assertTrue(math.isfinite(duration))
+                self.assertGreaterEqual(duration, 0)
+            for count_name in (
+                "invalid_frame_count",
+                "non_json_frame_count",
+                "truncated_frame_count",
+                "server_stderr_event_count",
+                "pending_request_count",
+            ):
+                self.assertEqual(telemetry[count_name], 0)
+            self.assertEqual(telemetry["exit_code"], 0)
+            self.assertFalse(telemetry["raw_content_published"])
+            self.assertFalse(attempt["tool_call_observed"])
+            self.assertFalse(attempt["resource_read_observed"])
+
+        limitations = self.document["limitations"]
+        self.assertFalse(limitations["modern_transport_ready"])
+        self.assertTrue(limitations["legacy_transport_ready"])
+        self.assertFalse(limitations["capability_result_claimed"])
+        self.assertFalse(limitations["independent_host_gate_completed"])
+        self.assertFalse(limitations["exact_five_assembly_exercised"])
+        self.assertFalse(limitations["model_task_requested"])
+        self.assertFalse(limitations["live_provider_called"])
+        self.assertFalse(limitations["remote_http_observed"])
+        self.assertFalse(limitations["activation_or_release_claimed"])
+        self.assertEqual(self.document["boundary"], BOUNDARY)
+
+        self.assertEqual(
+            self.document["isolation"],
+            {
+                "temporary_profiles": 2,
+                "profile_root_mode": "0700",
+                "backup_directory_mode": "0755",
+                "primary_configuration_mode": "0600",
+                "generated_backup_modes": ["0644", "0600"],
+                "normal_profile_used": False,
+                "credential_variables_removed": 5,
+                "mcp_child_environment_allowlisted": True,
+                "retained_private_logs": 2,
+                "credential_value_pattern_matches": 0,
+                "remaining_isolated_processes_after_cleanup": 0,
+                "raw_host_logs_published": False,
+            },
+        )
+
+    def test_protocol_target_is_the_source_ledger_release(self) -> None:
+        source_ledger = load_json(ROOT / "docs" / "source-ledger" / "sources.json")
+        sources = source_ledger["sources"]
+        source = next(item for item in sources if item["id"] == "S-MCP-SPEC")
+        self.assertEqual(source["published"], "2026-07-28")
+        self.assertEqual(source["maturity"], "final-general-availability")
+        self.assertEqual(
+            self.document["protocol_target"],
+            {
+                "version": "2026-07-28",
+                "status_at_observation": "latest-published",
+                "source_id": "S-MCP-SPEC",
+            },
+        )
+
+    def test_public_record_contains_no_path_secret_session_or_raw_payload(self) -> None:
+        public_text = EVIDENCE_PATH.read_text(encoding="utf-8")
+        self.assertIsNone(PUBLIC_EVIDENCE_FORBIDDEN.search(public_text))
+        self.assertTrue(FORBIDDEN_FIELD_NAMES.isdisjoint(nested_field_names(self.document)))
+
+    def test_repeat_procedure_strips_all_five_provider_credentials(self) -> None:
+        runbook = RUNBOOK_PATH.read_text(encoding="utf-8")
+        compact_runbook = re.sub(r"\s+", "", runbook)
+        mcp_sequence = (
+            '"-u","OPENAI_API_KEY","-u","CODEX_API_KEY",'
+            '"-u","ANTHROPIC_API_KEY","-u","ANTHROPIC_AUTH_TOKEN",'
+            '"-u","CLAUDE_CODE_OAUTH_TOKEN"'
+        )
+        self.assertIn(mcp_sequence, compact_runbook)
+
+        stripped_parent_sequence = "\n".join(
+            (
+                "/usr/bin/env -u OPENAI_API_KEY -u CODEX_API_KEY \\",
+                "  -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \\",
+                "  -u CLAUDE_CODE_OAUTH_TOKEN",
+            )
+        )
+        self.assertGreaterEqual(runbook.count(stripped_parent_sequence), 4)
+
+    def test_hostile_or_inflated_mutations_are_rejected(self) -> None:
+        mutations: list[tuple[str, Any]] = []
+
+        for label, path, value in (
+            ("wrong source commit", ("source", "commit"), "0" * 40),
+            ("production registration", ("source", "production_registration"), True),
+            ("modern readiness inflation", ("attempts", 0, "transport_readiness"), "ready"),
+            ("modern capability inflation", ("attempts", 0, "capability"), "passed"),
+            ("fallback capability inflation", ("attempts", 1, "capability"), "passed"),
+            ("independent host claim", ("limitations", "independent_host_gate_completed"), True),
+            ("exact-five claim", ("limitations", "exact_five_assembly_exercised"), True),
+            ("provider claim", ("limitations", "live_provider_called"), True),
+            ("remote HTTP claim", ("limitations", "remote_http_observed"), True),
+            ("release claim", ("limitations", "activation_or_release_claimed"), True),
+        ):
+            mutation = copy.deepcopy(self.document)
+            target: Any = mutation
+            for part in path[:-1]:
+                target = target[part]
+            target[path[-1]] = value
+            mutations.append((label, mutation))
+
+        swapped_attempts = copy.deepcopy(self.document)
+        swapped_attempts["attempts"] = list(reversed(swapped_attempts["attempts"]))
+        mutations.append(("attempt order", swapped_attempts))
+
+        modern_list = copy.deepcopy(self.document)
+        modern_list["attempts"][0]["telemetry"]["tools_list_request"] = copy.deepcopy(
+            self.document["attempts"][1]["telemetry"]["tools_list_request"]
+        )
+        mutations.append(("modern tools/list inflation", modern_list))
+
+        missing_fallback_list = copy.deepcopy(self.document)
+        del missing_fallback_list["attempts"][1]["telemetry"]["tools_list_response"]
+        mutations.append(("missing fallback tools/list", missing_fallback_list))
+
+        successful_error = copy.deepcopy(self.document)
+        successful_error["attempts"][1]["telemetry"]["initialize_response"][
+            "error_code"
+        ] = -32022
+        mutations.append(("error on success response", successful_error))
+
+        missing_error = copy.deepcopy(self.document)
+        del missing_error["attempts"][0]["telemetry"]["initialize_response"][
+            "error_code"
+        ]
+        mutations.append(("missing error code", missing_error))
+
+        modern_success = copy.deepcopy(self.document)
+        modern_success["attempts"][0]["telemetry"]["initialize_response"][
+            "outcome"
+        ] = "success"
+        del modern_success["attempts"][0]["telemetry"]["initialize_response"][
+            "error_code"
+        ]
+        mutations.append(("modern success contradiction", modern_success))
+
+        fallback_initialize_error = copy.deepcopy(self.document)
+        fallback_initialize_error["attempts"][1]["telemetry"]["initialize_response"].update(
+            {"outcome": "error", "error_code": -32022}
+        )
+        mutations.append(("fallback initialize error", fallback_initialize_error))
+
+        fallback_list_error = copy.deepcopy(self.document)
+        fallback_list_error["attempts"][1]["telemetry"]["tools_list_response"].update(
+            {"outcome": "error", "error_code": -32603}
+        )
+        mutations.append(("fallback tools/list error", fallback_list_error))
+
+        divergent_error = copy.deepcopy(self.document)
+        divergent_error["attempts"][0]["telemetry"]["initialize_response"][
+            "error_code"
+        ] = -32603
+        mutations.append(("divergent inner error", divergent_error))
+
+        wrong_list_method = copy.deepcopy(self.document)
+        wrong_list_method["attempts"][1]["telemetry"]["tools_list_request"][
+            "method_label"
+        ] = "other"
+        mutations.append(("wrong tools/list method", wrong_list_method))
+
+        inconsistent_event_count = copy.deepcopy(self.document)
+        inconsistent_event_count["attempts"][1]["telemetry"]["event_count"] = 1
+        mutations.append(("inconsistent event count", inconsistent_event_count))
+
+        duplicate_runtime = copy.deepcopy(self.document)
+        duplicate_runtime["source"]["runtime_files"] = [
+            copy.deepcopy(self.document["source"]["runtime_files"][0])
+            for _ in range(5)
+        ]
+        mutations.append(("duplicate runtime bindings", duplicate_runtime))
+
+        absolute_path = copy.deepcopy(self.document)
+        absolute_path["source"]["runtime_files"][0]["path"] = (
+            "/" + "Users" + "/example/runtime.ts"
+        )
+        mutations.append(("absolute path", absolute_path))
+
+        for label, path in (
+            (
+                "parent traversal",
+                "apps/../../" + "Users" + "/example/private.log",
+            ),
+            ("current-directory segment", "scripts/./runtime.mjs"),
+            ("empty path segment", "apps//runtime.ts"),
+        ):
+            traversal = copy.deepcopy(self.document)
+            traversal["source"]["runtime_files"][0]["path"] = path
+            mutations.append((label, traversal))
+
+        session = copy.deepcopy(self.document)
+        session["attempts"][0]["telemetry"]["session_id_sha256"] = "0" * 64
+        mutations.append(("session identifier", session))
+
+        unknown = copy.deepcopy(self.document)
+        unknown["unexpected"] = True
+        mutations.append(("unknown root field", unknown))
+
+        for label, mutation in mutations:
+            with self.subTest(label=label):
+                self.assert_invalid(mutation)
+
+    def test_non_standard_json_numbers_are_rejected_at_load_boundary(self) -> None:
+        with self.assertRaises(ValueError):
+            json.loads('{"duration_ms": NaN}', parse_constant=reject_non_standard_number)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/interoperability/README.md
+++ b/tests/interoperability/README.md
@@ -79,5 +79,14 @@ readiness only. No model authentication, model task, tool call, resource read, l
 provider, remote HTTP host, exact-five production assembly, registration,
 activation, deployment or release was exercised, so capability remains unscored.
 
+The additive
+[Claude Code 2.1.241 observation](evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json)
+records the approved client update and two isolated checks from exact protected
+main `dda0eb9f776e64bcd45069e77b4acbcd4d495e01`. Version `2.1.241` offered MCP
+`2025-11-25`: the strict `2026-07-28` entrypoint rejected that opening with
+`-32022`, while the constructor-only fallback connected and completed
+`tools/list`. No model, operation, resource, provider or remote HTTP host was
+exercised. The earlier `2.1.204` record remains byte-exact and separate.
+
 See the [QUAL-206 interoperability runbook](../../docs/operations/QUAL-206_INTEROPERABILITY.md)
 for repeatable ChatGPT secure-tunnel and independent-host procedures.

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -36,6 +36,17 @@ host, exact-five production assembly, registration, activation, deployment or
 release was exercised. It does not alter the earlier modern-only `not_ready` record
 or upgrade the uncommitted exploratory fallback record.
 
+The later
+[`Claude Code 2.1.241 STDIO observation`](claude-code-2.1.241-stdio-observation-2026-08-24.json)
+preserves that historical record and binds two new credential-free `mcp list`
+attempts to exact protected-main commit
+`dda0eb9f776e64bcd45069e77b4acbcd4d495e01`. The current client offered MCP
+`2025-11-25`, so the canonical `2026-07-28` surface correctly returned `-32022`.
+The separately named constructor-only fallback completed initialisation and
+`tools/list`. This establishes only fallback transport readiness: the strict modern
+path is not ready, capability is unscored and the independent-host gate remains
+incomplete. Raw telemetry and disposable profiles remain private and local.
+
 The historical records continue to bind the unchanged ten-case
 [`qual_206_cases.json`](../qual_206_cases.json) bytes. The separate
 [`qual_206_cases_expansion.json`](../qual_206_cases_expansion.json) is design-time,

--- a/tests/interoperability/evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json
+++ b/tests/interoperability/evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json
@@ -1,0 +1,243 @@
+{
+  "schema": "gis-ai-go.qual-206-claude-code-stdio-observation.v1",
+  "schema_contract": {
+    "path": "schemas/qual-206-claude-code-stdio-observation.schema.json",
+    "sha256": "78b9a8071a6954028576f397c98dd0fc4b87dddbaf72654f6459407b280e2a9b"
+  },
+  "status": "strict-modern-not-ready-fallback-ready-capability-unscored",
+  "observed_on": "2026-08-24",
+  "source": {
+    "repository": "chris-page-gov/gis-ai-go",
+    "commit": "dda0eb9f776e64bcd45069e77b4acbcd4d495e01",
+    "tree": "258e6f3b3f62abccf04795e015f6961e06740fcf",
+    "protected_main": true,
+    "version": "0.1.0",
+    "detached_checkout": true,
+    "worktree_changes_uncommitted": false,
+    "production_registration": false,
+    "production_activation": false,
+    "public_endpoint_created": false,
+    "runtime_files": [
+      {
+        "path": "apps/mcp-gateway/src/mcp-server.ts",
+        "sha256": "e2c5cec027f3049d0a501b885a0ab6336d7e6059690df54ac7b257945807b454"
+      },
+      {
+        "path": "apps/mcp-gateway/src/mcp-stdio.ts",
+        "sha256": "5e8d87020d1efe34b2b83940f60d2df5926f466c12473fffc156463c9a6cef30"
+      },
+      {
+        "path": "scripts/qual_206_conformance_server.mjs",
+        "sha256": "aba0f4415bc9f94443be8b79eee06b03bdd275ca9854218dee30102c20a6778f"
+      },
+      {
+        "path": "scripts/qual_206_legacy_conformance_server.mjs",
+        "sha256": "bf87bec24357d5fd6d419bd8b4374642ab46a2f3dfa6d9baebde46f7498edb9c"
+      },
+      {
+        "path": "scripts/qual_206_telemetry_proxy.mjs",
+        "sha256": "3800e4458932ee1324ad03d64007f23f76f49682a6eabdc191ecf6eaccb501d5"
+      }
+    ],
+    "build": {
+      "command": "pnpm run test:interoperability",
+      "dependencies_installed_with_frozen_lockfile": true,
+      "preflight_passed": true,
+      "loopback_permission_required": true,
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "sha256": "640208aa66d26241514025b33dbde50bc14be7bbd33641eec9977e87699bb4ec"
+      },
+      "compiled_entrypoints": [
+        {
+          "path": "apps/mcp-gateway/dist/src/mcp-server.js",
+          "sha256": "71fdde3b45363d366b62e7c4219c2cc77efbfbfe9d9e5d110f656e76ee9d2ab1"
+        },
+        {
+          "path": "apps/mcp-gateway/dist/src/mcp-stdio.js",
+          "sha256": "17a04b0b1f0a5549157c8e07119ac1d7a895b86d9a73312aaaa2561fd1e092e3"
+        }
+      ]
+    }
+  },
+  "host": {
+    "name": "Claude Code",
+    "version": "2.1.241",
+    "platform": "darwin",
+    "architecture": "arm64",
+    "binary_sha256": "1495eb7c42d3b4451f5f1cd38b6d498d22a4a38c802bc2be5c1cf1795e64820d",
+    "command": "mcp list",
+    "update": {
+      "method": "claude update",
+      "from_version": "2.1.204",
+      "to_version": "2.1.241",
+      "registry_package": "@anthropic-ai/claude-code",
+      "registry_stable": "2.1.231",
+      "registry_latest": "2.1.241",
+      "latest_at_observation": true
+    }
+  },
+  "protocol_target": {
+    "version": "2026-07-28",
+    "status_at_observation": "latest-published",
+    "source_id": "S-MCP-SPEC"
+  },
+  "historical_lineage": {
+    "schema_sha256": "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a",
+    "evidence_sha256": "a3d40e2013095baf977bad336366c0fb429a05b6a5a267c3e069595e4cdb1a6b",
+    "relationship": "preserved-separate-not-superseded"
+  },
+  "attempts": [
+    {
+      "kind": "strict-modern",
+      "server_surface": "canonical-2026-07-28-conformance",
+      "transport": "stdio",
+      "client_requested_protocol": "2025-11-25",
+      "server_protocol": "2026-07-28",
+      "transport_readiness": "not-ready",
+      "capability": "unscored",
+      "classification": "legacy-initialise-rejected-by-modern-surface",
+      "host_result": "Failed to connect",
+      "error_code": -32022,
+      "initialize_success": false,
+      "tools_list_success": false,
+      "tool_call_observed": false,
+      "resource_read_observed": false,
+      "telemetry": {
+        "schema": "gis-ai-go.qual-206-host-telemetry.v1",
+        "node_version": "v26.7.0",
+        "source_commit": "dda0eb9f776e64bcd45069e77b4acbcd4d495e01",
+        "retained_private_bytes": 1527,
+        "retained_private_sha256": "387e19ff71bddaabd8223bc7f6ed65a73440be37afc6d860e92c2fbd41367fab",
+        "retained_private_mode": "0600",
+        "event_count": 4,
+        "event_counts": {
+          "session_start": 1,
+          "request": 1,
+          "response": 1,
+          "session_end": 1
+        },
+        "initialize_request": {
+          "method_label": "other",
+          "frame_bytes": 323,
+          "frame_sha256": "414f9f230e1f6410b2fd08bfe2b53ee20c94dd2b2a5f866e32d5ab02eee96ede",
+          "parameters_bytes": 267,
+          "parameters_sha256": "3f07a31ea0c1b7e4e13c55d4024d3cdd51ca500733494d3f92907107f9a7d38b"
+        },
+        "initialize_response": {
+          "outcome": "error",
+          "error_code": -32022,
+          "duration_ms": 182.385334,
+          "frame_bytes": 162,
+          "frame_sha256": "0b17e091073c1d8bfd2df6decbaba2dfd2f57679333d352053faebf0f8d7cab3"
+        },
+        "invalid_frame_count": 0,
+        "non_json_frame_count": 0,
+        "truncated_frame_count": 0,
+        "server_stderr_event_count": 0,
+        "exit_code": 0,
+        "pending_request_count": 0,
+        "raw_content_published": false
+      }
+    },
+    {
+      "kind": "constructor-only-fallback",
+      "server_surface": "test-only-legacy-conformance",
+      "transport": "stdio",
+      "client_requested_protocol": "2025-11-25",
+      "negotiated_protocol": "2025-06-18",
+      "transport_readiness": "ready",
+      "capability": "unscored",
+      "classification": "legacy-handshake-and-tool-list-pass",
+      "host_result": "Connected",
+      "initialize_success": true,
+      "tools_list_success": true,
+      "tool_call_observed": false,
+      "resource_read_observed": false,
+      "telemetry": {
+        "schema": "gis-ai-go.qual-206-host-telemetry.v1",
+        "node_version": "v26.7.0",
+        "source_commit": "dda0eb9f776e64bcd45069e77b4acbcd4d495e01",
+        "retained_private_bytes": 2858,
+        "retained_private_sha256": "a82ef554dc8c33d34d5689f5ef736616564a38d057877d4fa72ec965e1ee9f24",
+        "retained_private_mode": "0600",
+        "event_count": 7,
+        "event_counts": {
+          "session_start": 1,
+          "request": 3,
+          "response": 2,
+          "session_end": 1
+        },
+        "initialize_request": {
+          "method_label": "other",
+          "frame_bytes": 323,
+          "frame_sha256": "414f9f230e1f6410b2fd08bfe2b53ee20c94dd2b2a5f866e32d5ab02eee96ede",
+          "parameters_bytes": 267,
+          "parameters_sha256": "3f07a31ea0c1b7e4e13c55d4024d3cdd51ca500733494d3f92907107f9a7d38b"
+        },
+        "initialize_response": {
+          "outcome": "success",
+          "duration_ms": 197.629584,
+          "frame_bytes": 391,
+          "frame_sha256": "a4f84e28cb3cacdbc16c13c870aa0797e2ca7c09bf43ad72947bcfbdb7b9a279"
+        },
+        "initialized_notification": {
+          "method_label": "other",
+          "frame_bytes": 54,
+          "frame_sha256": "1991440c743375cc3f711ec3788c732cfff71984933a8bf73701ff563427860d",
+          "parameters_bytes": 4,
+          "parameters_sha256": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+        },
+        "tools_list_request": {
+          "method_label": "tools/list",
+          "frame_bytes": 46,
+          "frame_sha256": "75f0c7627a35c7e96a0a88482622a0d1ec7e81c0eb5414a88ba7aab9450cf73b",
+          "parameters_bytes": 4,
+          "parameters_sha256": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+        },
+        "tools_list_response": {
+          "outcome": "success",
+          "duration_ms": 1.471875,
+          "frame_bytes": 47304,
+          "frame_sha256": "30b56ca69a8767fe393ceaf3c86d29ca91d3026f73255c56bff7616fd7ea7cb5"
+        },
+        "invalid_frame_count": 0,
+        "non_json_frame_count": 0,
+        "truncated_frame_count": 0,
+        "server_stderr_event_count": 0,
+        "exit_code": 0,
+        "pending_request_count": 0,
+        "raw_content_published": false
+      }
+    }
+  ],
+  "isolation": {
+    "temporary_profiles": 2,
+    "profile_root_mode": "0700",
+    "backup_directory_mode": "0755",
+    "primary_configuration_mode": "0600",
+    "generated_backup_modes": [
+      "0644",
+      "0600"
+    ],
+    "normal_profile_used": false,
+    "credential_variables_removed": 5,
+    "mcp_child_environment_allowlisted": true,
+    "retained_private_logs": 2,
+    "credential_value_pattern_matches": 0,
+    "remaining_isolated_processes_after_cleanup": 0,
+    "raw_host_logs_published": false
+  },
+  "limitations": {
+    "modern_transport_ready": false,
+    "legacy_transport_ready": true,
+    "capability_result_claimed": false,
+    "independent_host_gate_completed": false,
+    "exact_five_assembly_exercised": false,
+    "model_task_requested": false,
+    "live_provider_called": false,
+    "remote_http_observed": false,
+    "activation_or_release_claimed": false
+  },
+  "boundary": "Accepted protected-main Claude Code protocol observation only. Claude Code 2.1.241 offered MCP 2025-11-25, so the strict 2026-07-28 STDIO surface correctly rejected it while the constructor-only fallback completed initialisation and tools/list. No model, tool call, resource read, exact-five production assembly, provider, remote HTTP host, registration, activation, deployment or release was exercised. Capability and the independent-host gate remain unscored and incomplete."
+}


### PR DESCRIPTION
## Outcome

- Work item: QUAL-206, related to #24.
- Release target: `v0.2.0`.
- User-visible outcome: records the current Claude Code protocol boundary without
  widening the supported MCP surface or claiming capability acceptance.

## Scope

- Included:
  - preserve the historical Claude Code `2.1.204` evidence byte-exact;
  - bind two credential-free Claude Code `2.1.241` `mcp list` observations to
    protected-main source commit `dda0eb9f776e64bcd45069e77b4acbcd4d495e01`;
  - record that the client offered MCP `2025-11-25`, the strict `2026-07-28`
    surface rejected it with `-32022`, and the constructor-only fallback completed
    initialisation and `tools/list`;
  - add a closed schema, source-bound evidence, hostile-mutation tests and a
    repeat procedure that strips all five recognised OpenAI and Anthropic
    credential variables;
  - reconcile the current protected-main OCI assurance and QUAL-206 status.
- Not included:
  - a model task, tool call, resource read or exact-five production assembly;
  - capability scoring or completion of the independent-host gate;
  - a live provider, remote HTTP host, registration, activation, deployment, tag
    or release;
  - publication of raw host logs, temporary profiles or machine-local paths.

## Evidence

- [x] Relevant tests added or updated
- [x] `pnpm run check` passes
- [x] Source, data, rights and licence provenance reviewed
- [x] Security and privacy boundary reviewed
- [x] Accessibility impact marked not applicable: evidence, schema, tests and
  operational documentation only; no user interface changed
- [x] Changelog fragment added
- [x] Deployment boundary and rollback recorded

Three independent reviews found no remaining actionable issue after amendments.
The final schema rejects contradictory success/error outcomes, divergent error
codes, inconsistent event totals, wrong method labels, duplicate source bindings,
absolute paths and traversal paths. Private raw telemetry remains local and is
bound only by size and SHA-256 in the public record.

## Verification

Exact commit: `8ca5bed8087f7e106bc7ccfa70b407ec8d4662b3`.

- `pnpm run check`
  - type checks and TypeScript suites passed, including 210 gateway tests;
  - 16 interoperability tests and all 7 deterministic local receipts passed;
  - 309 repository Python tests and 22 execution-service tests passed;
  - execution-container acceptance passed;
  - all 27 browser tests passed;
  - two clean locked release builds were byte-identical;
  - 71 schemas and 102 records validated;
  - 429 local links, 183 research hashes and 2 ledger snapshots resolved;
  - 793 text files passed the secret and machine-path scan;
  - diagrams and the 169-component repository SBOM regenerated successfully.
- Current and historical focused evidence suites: 14 tests passed.
- Independent raw-log/source audit recomputed the source, binary, frame, parameter,
  private-log, schema and evidence digests.

## Deployment and rollback

Deployment target: not deployed. The candidate remains unregistered and inactive;
readiness remains blocked. This change makes no provider call and creates no public
endpoint.

Rollback: revert commit `8ca5bed8087f7e106bc7ccfa70b407ec8d4662b3` if the additive observation must be
removed. The historical `2.1.204` record is unchanged.
