### PR TITLE
feat(qual-206): add strict-modern evidence compiler

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Delivery progress
 
-Last updated: 24 August 2026
+Last updated: 25 August 2026
 
 ## Current outcome
 
@@ -18,6 +18,10 @@ The supported target active set is exactly `catalogue.search`,
 - preserve the source-bound Claude Code `2.1.204` result and the additive `2.1.241`
   protocol observation separately from capability scoring; `2.1.241` offers MCP
   `2025-11-25`, so it cannot close the strict `2026-07-28` desktop-host gate;
+- preserve the accepted exact-five local demonstration on protected `main` and use
+  its fixed-provider, temporary-state boundary for colleague-facing explanation;
+- prepare an additive strict-modern capture compiler that cannot promote a
+  summary-level real-host observation into a capability pass;
 - complete the remaining strict-modern independent desktop-STDIO and remote-HTTP
   host evidence; and
 - continue provider-neutral preparation, but stop before public provisioning or
@@ -247,6 +251,18 @@ or release is claimed.
   `not_ready` or exploratory records and exercised no model authentication, model task,
   tool call, resource read, exact-five production assembly, live provider, remote
   HTTP host, registration, activation, deployment or release; and
+- the colleague-facing exact-five local demonstration merged through
+  [pull request 60](https://github.com/chris-page-gov/gis-ai-go/pull/60) as
+  protected-main commit `0459a1c6559aa8394509ccdac18e275f6f567e86`. Protected-main
+  [run 32786878749](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32786878749)
+  passed repository, producer and independent OCI derivation, byte comparison and
+  provenance assurance, while
+  [run 32786878420](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32786878420)
+  passed CodeQL for Actions, JavaScript/TypeScript and Python. The real local STDIO
+  journey demonstrates the unregistered exact-five assembly, fixed ONS-shaped
+  fixture response, temporary evidence state, structured/plain-text parity and
+  provider-egress guard without a live provider call, public listener, deployment,
+  registration, activation or release; and
 - acceptance requires both the complete local repository gate, which passes on this
   matrix tree, and the protected pull-request and protected-main checks. The local
   gate includes all TypeScript and Python tests, 27 real-browser tests,
@@ -255,10 +271,11 @@ or release is claimed.
 
 ## Next
 
-1. Use a different independent desktop host whose first frame proves a valid
-   `2026-07-28` opening, then complete the bounded capability pack and remaining
-   remote-HTTP host evidence. Claude Code `2.1.241` is an explained legacy-only
-   transport result, not the modern host acceptance.
+1. Complete the versioned event-level exact-five collector, then use a different
+   independent desktop host whose first frame proves a valid `2026-07-28` opening.
+   Complete the bounded capability pack and remaining remote-HTTP host evidence.
+   Claude Code `2.1.241` is an explained legacy-only transport result, not the
+   modern host acceptance.
 2. Retain the exact protected-main UBI, independent-derivation and provenance
    evidence from runs `32760872035` and `32760871684`; rebuild and repeat it after
    every later source-changing activation or release commit.
@@ -314,6 +331,18 @@ or release is claimed.
   the open product.
 
 ## Latest evidence
+
+- QUAL-206 local demonstration acceptance: protected
+  [pull request 60](https://github.com/chris-page-gov/gis-ai-go/pull/60) merged as
+  `0459a1c6559aa8394509ccdac18e275f6f567e86`; protected-main repository, OCI,
+  byte-comparison and provenance assurance passed in
+  [run 32786878749](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32786878749),
+  and CodeQL passed in
+  [run 32786878420](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32786878420).
+  The repeatable local run uses real STDIO and the immutable unregistered exact-five
+  assembly, but only deterministic ONS-shaped fixture data and temporary state. It
+  records zero guarded provider-egress calls and makes no independent-host, live
+  provider, public endpoint, deployment, activation, registry or release claim;
 
 - Protected-main combined candidate acceptance on 24 August 2026: integration
   [pull request 57](https://github.com/chris-page-gov/gis-ai-go/pull/57) and repair

--- a/changelog.d/QUAL-206-strict-modern-evidence.added.md
+++ b/changelog.d/QUAL-206-strict-modern-evidence.added.md
@@ -1,0 +1,3 @@
+- Add closed private-capture and public-projection contracts for preparatory MCP
+  `2026-07-28` host evidence, with shared RFC 8785 identities, non-overwriting secure
+  file handling and an explicit summary-only ceiling on real-host claims.

--- a/docs/operations/QUAL-206_STRICT_MODERN_EVIDENCE.md
+++ b/docs/operations/QUAL-206_STRICT_MODERN_EVIDENCE.md
@@ -1,0 +1,98 @@
+# QUAL-206 strict-modern evidence preparation
+
+This preparatory compiler turns one private, closed host-capture summary into a
+minimised public projection for the MCP `2026-07-28` target. It is additive to the
+accepted QUAL-206 evidence. It does not upgrade or replace any earlier Claude,
+Codex, ChatGPT or legacy result.
+
+The compiler is deliberately capped below real-host capability acceptance. The
+current telemetry wrapper is a summary source, not a versioned event-level
+exact-five collector. A real capture can therefore be `not_ready` or
+`ready_unscored`; only a clearly labelled synthetic fixture can exercise the
+compiler's `capability_pass` state. All production, provider, registry, deployment,
+release and completed-gate claims remain false.
+
+## Trust boundaries
+
+### 1. Private capture
+
+The operator retains the manifest and telemetry locally in a directory with mode
+`0700`; each input file must have mode `0600`, one hard link and current-user
+ownership. The compiler opens each path through no-follow directory descriptors,
+rejects symbolic links and hard links, bounds the bytes and checks that the file did
+not change while it was read. Raw prompts, arguments, results, headers, environment
+values, session identifiers and compiler-owned outcome fields are not accepted in
+the manifest.
+
+The raw telemetry is checked against the private digest and byte count in the
+manifest, but neither value is published. This avoids turning a retained private
+transcript into a linkable public identifier or a brute-force oracle.
+
+### 2. Compiler
+
+The compiler validates the closed capture schema, derives the status and negative
+claims, applies the public privacy allowlist and validates the closed public schema.
+It binds its own source, both schemas and the shared canonical-identity source and
+built runtime. The compiler rejects drift from the reviewed hashes of the three
+generated identity-runtime files. The output identity uses the repository's RFC
+8785 implementation and the domain
+`gis-ai-go.qual-206-strict-modern-host-evidence.v2`.
+
+For an observed-host summary, the source inventory is exact rather than
+caller-selectable. Tracked inputs are compared with the stated commit through
+`git show`; generated identity runtime files are compared byte-for-byte with the
+recorded digests. The commit must be an ancestor of the local `origin/main` ref.
+This is a source-binding check, not independent proof that the remote protected
+branch or the host process used those bytes.
+
+### 3. Public projection
+
+The projection contains fixed classifications, bounded counters, allowlisted host
+and protocol metadata, source digests, derived outcomes and explicit limitations.
+It contains no raw telemetry path or content, raw telemetry digest or byte count,
+request identifier, prompt, result, credential, hostname, username or arbitrary
+operator prose. Output creation is exclusive: an existing evidence file is never
+overwritten.
+
+## Claim-to-source matrix
+
+| Public field or claim | Source | Current assurance |
+| --- | --- | --- |
+| Capture classification and time | Closed private manifest | Schema-valid summary |
+| Protocol and readiness outcome | Compiler derivation from bounded observation fields and closed counters | Summary-level only |
+| Exact-five capability | Synthetic fixture only | Cannot become a real-host claim |
+| Source commit, tree and material digests | Git objects plus local generated identity runtime | Source-bound; local `origin/main` ancestry only |
+| Compiler and schema identity | Compiler-read source and built files | Bound into the RFC 8785 evidence identity |
+| Private telemetry | Owner-controlled local file | Content, path, digest and byte count withheld |
+| Live provider, remote HTTP and production lifecycle claims | Compiler constants | Always false in this contract |
+| Earlier Claude and base-corpus evidence | Fixed additive lineage hashes | `preserved-separate-not-superseded` |
+
+## Run the compiler
+
+Build the shared evidence package first, then compile into a new output path:
+
+```bash
+pnpm --filter @gis-ai-go/evidence run build
+uv run --locked --cache-dir .uv-cache python \
+  scripts/compile_qual_206_strict_modern_evidence.py \
+  --capture-root PRIVATE_CAPTURE_ROOT \
+  --capture capture.json \
+  --output NEW_PUBLIC_EVIDENCE.json
+```
+
+`PRIVATE_CAPTURE_ROOT` must be an absolute owner-only directory. The command fails
+if the output already exists. Keep the private input outside the repository and do
+not commit it.
+
+## Remaining acceptance work
+
+A versioned event-level collector must independently validate one complete session:
+the exact opening sequence, request and response pairing, unique identifiers,
+allowed methods, exact-five operations, resources, cancellation, unsupported
+traffic, close, process exit and stderr. It must bind the actual host executable and
+deterministic runtime build. Only that later collector and compiler can support a
+real-host capability result.
+
+Separate governed evidence is still required for remote HTTP, a live provider,
+public runtime identity and TLS, storage and recovery, operations, deployment,
+registry publication, activation and release.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -39,6 +39,7 @@ and no public MCP service or API is deployed.
 - [TOOLS-205 governed candidate assembly](TOOLS-205_GOVERNED_CANDIDATE_ASSEMBLY.md)
 - [QUAL-206 host interoperability and secure-tunnel runbook](QUAL-206_INTEROPERABILITY.md)
 - [QUAL-206 local demonstration](QUAL-206_LOCAL_DEMONSTRATION.md)
+- [QUAL-206 strict-modern evidence preparation](QUAL-206_STRICT_MODERN_EVIDENCE.md)
 - [QUAL-206 Stage 2 release threat record](../threat-model/QUAL-206_STAGE_2_RELEASE.md)
 - [QUAL-206 gateway image vulnerability disposition](QUAL-206_IMAGE_VULNERABILITY_DISPOSITION.md)
 - [TOOLS-205 inactive public-read v2 contracts](TOOLS-205_PUBLIC_READ_V2_CONTRACTS.md)

--- a/schemas/qual-206-strict-modern-host-capture.schema.json
+++ b/schemas/qual-206-strict-modern-host-capture.schema.json
@@ -1,0 +1,804 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:qual-206-strict-modern-host-capture:v1",
+  "title": "QUAL-206 strict-modern private host capture",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "capture_kind",
+    "observed_at",
+    "source",
+    "host",
+    "protocol",
+    "surface",
+    "corpus",
+    "isolation",
+    "telemetry",
+    "observation"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.qual-206-strict-modern-host-capture.v1"
+    },
+    "capture_kind": {
+      "enum": ["synthetic-test-fixture", "observed-host-session"]
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "host": {
+      "$ref": "#/$defs/host"
+    },
+    "protocol": {
+      "$ref": "#/$defs/protocol"
+    },
+    "surface": {
+      "$ref": "#/$defs/surface"
+    },
+    "corpus": {
+      "$ref": "#/$defs/corpus"
+    },
+    "isolation": {
+      "$ref": "#/$defs/isolation"
+    },
+    "telemetry": {
+      "$ref": "#/$defs/telemetry"
+    },
+    "observation": {
+      "$ref": "#/$defs/observation"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "safePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*\\\\)(?!.*//)[A-Za-z0-9._/-]+$"
+    },
+    "publicText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 320,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "operation": {
+      "enum": [
+        "catalogue.search",
+        "catalogue.describe",
+        "selection.resolve",
+        "data.query",
+        "evidence.inspect"
+      ]
+    },
+    "resource": {
+      "enum": [
+        "catalogue.public",
+        "catalogue.record",
+        "evidence.receipt"
+      ]
+    },
+    "material": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "sha256"],
+      "properties": {
+        "role": {
+          "enum": [
+            "build-receipt",
+            "capture-schema",
+            "compiler",
+            "evidence-schema",
+            "identity-helper",
+            "launcher",
+            "lockfile",
+            "manifest",
+            "compiled",
+            "provider-egress-guard",
+            "source",
+            "telemetry-wrapper"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit",
+        "tree",
+        "protected_main",
+        "detached_checkout",
+        "worktree_clean",
+        "product_version",
+        "materials"
+      ],
+      "properties": {
+        "repository": {
+          "const": "chris-page-gov/gis-ai-go"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "tree": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "protected_main": {
+          "type": "boolean"
+        },
+        "detached_checkout": {
+          "type": "boolean"
+        },
+        "worktree_clean": {
+          "type": "boolean"
+        },
+        "product_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
+        },
+        "materials": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/material"
+          }
+        }
+      }
+    },
+    "binaryIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "sha256"],
+      "properties": {
+        "kind": {
+          "const": "binary"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "packageIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "name", "version", "sha256"],
+      "properties": {
+        "kind": {
+          "const": "package"
+        },
+        "name": {
+          "enum": [
+            "@anthropic-ai/claude-code",
+            "codex",
+            "chatgpt",
+            "generic-independent-mcp-host",
+            "synthetic-test-host"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._+-]+$"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "serviceIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "sha256"],
+      "properties": {
+        "kind": {
+          "const": "service"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "platform",
+        "architecture",
+        "identity",
+        "probe",
+        "model_authentication_supplied",
+        "model_task_requested"
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "claude-code",
+            "codex",
+            "chatgpt",
+            "generic-independent-mcp-host",
+            "synthetic-test-host"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._+-]+$"
+        },
+        "platform": {
+          "enum": ["darwin", "linux", "windows", "hosted"]
+        },
+        "architecture": {
+          "enum": ["arm64", "x86_64", "other", "not-applicable"]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/binaryIdentity"
+            },
+            {
+              "$ref": "#/$defs/packageIdentity"
+            },
+            {
+              "$ref": "#/$defs/serviceIdentity"
+            }
+          ]
+        },
+        "probe": {
+          "enum": ["mcp-list", "model-task", "manual-client"]
+        },
+        "model_authentication_supplied": {
+          "type": "boolean"
+        },
+        "model_task_requested": {
+          "type": "boolean"
+        }
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_version",
+        "target_source_id",
+        "client_requested_version",
+        "server_supported_versions",
+        "negotiated_version"
+      ],
+      "properties": {
+        "target_version": {
+          "const": "2026-07-28"
+        },
+        "target_source_id": {
+          "const": "S-MCP-SPEC"
+        },
+        "client_requested_version": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "server_supported_versions": {
+          "const": ["2026-07-28"]
+        },
+        "negotiated_version": {
+          "oneOf": [
+            {
+              "const": "2026-07-28"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["assembly", "transport", "operations", "resources"],
+      "properties": {
+        "assembly": {
+          "const": "candidate-unregistered-exact-five"
+        },
+        "transport": {
+          "enum": ["stdio", "streamable-http"]
+        },
+        "operations": {
+          "const": [
+            "catalogue.search",
+            "catalogue.describe",
+            "selection.resolve",
+            "data.query",
+            "evidence.inspect"
+          ]
+        },
+        "resources": {
+          "const": [
+            "catalogue.public",
+            "catalogue.record",
+            "evidence.receipt"
+          ]
+        }
+      }
+    },
+    "corpusReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "corpus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base", "expansion", "case_ids"],
+      "properties": {
+        "base": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/corpusReference"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "tests/interoperability/qual_206_cases.json"
+                },
+                "sha256": {
+                  "const": "23ac9bc1a76d524bd0e250b11b9ba321b09e66bd5921f1463f50c150001cd389"
+                }
+              }
+            }
+          ]
+        },
+        "expansion": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/corpusReference"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "tests/interoperability/qual_206_cases_expansion.json"
+                },
+                "sha256": {
+                  "const": "e70c21b371593c2dae863999745f1fecf2152ff80f0b025a1ccbec135b47f4af"
+                }
+              }
+            }
+          ]
+        },
+        "case_ids": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 18,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^QUAL-206-HOST-0(?:0[1-9]|1[0-8])$"
+          }
+        }
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temporary_profile",
+        "profile_root_mode",
+        "primary_configuration_mode",
+        "normal_profile_used",
+        "normal_profile_mutation_observed",
+        "credential_variables_removed_count",
+        "mcp_child_environment_allowlisted",
+        "credential_value_pattern_matches",
+        "remaining_processes_after_cleanup",
+        "raw_host_logs_published",
+        "os_network_isolation_enforced",
+        "provider_egress_guard_exercised"
+      ],
+      "properties": {
+        "temporary_profile": {
+          "const": true
+        },
+        "profile_root_mode": {
+          "const": "0700"
+        },
+        "primary_configuration_mode": {
+          "const": "0600"
+        },
+        "normal_profile_used": {
+          "const": false
+        },
+        "normal_profile_mutation_observed": {
+          "const": false
+        },
+        "credential_variables_removed_count": {
+          "type": "integer",
+          "minimum": 5,
+          "maximum": 64
+        },
+        "mcp_child_environment_allowlisted": {
+          "const": true
+        },
+        "credential_value_pattern_matches": {
+          "const": 0
+        },
+        "remaining_processes_after_cleanup": {
+          "const": 0
+        },
+        "raw_host_logs_published": {
+          "const": false
+        },
+        "os_network_isolation_enforced": {
+          "type": "boolean"
+        },
+        "provider_egress_guard_exercised": {
+          "type": "boolean"
+        }
+      }
+    },
+    "privateTelemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "bytes", "sha256", "mode"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 8388608
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "mode": {
+          "const": "0600"
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "retained_private",
+        "event_count",
+        "session_start_count",
+        "request_count",
+        "notification_count",
+        "response_count",
+        "session_end_count",
+        "anomaly_count",
+        "malformed_frame_count",
+        "non_json_frame_count",
+        "truncated_frame_count",
+        "server_stderr_count",
+        "pending_request_count",
+        "exit_code",
+        "raw_content_published"
+      ],
+      "properties": {
+        "schema": {
+          "const": "gis-ai-go.qual-206-host-capture-summary.v1"
+        },
+        "retained_private": {
+          "$ref": "#/$defs/privateTelemetry"
+        },
+        "event_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "session_start_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "request_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50000
+        },
+        "notification_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50000
+        },
+        "response_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50000
+        },
+        "session_end_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "anomaly_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "malformed_frame_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "non_json_frame_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "truncated_frame_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "server_stderr_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "pending_request_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50000
+        },
+        "exit_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "raw_content_published": {
+          "const": false
+        }
+      }
+    },
+    "stageObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed", "outcome", "error_code"],
+      "properties": {
+        "observed": {
+          "type": "boolean"
+        },
+        "outcome": {
+          "enum": ["success", "error", "not-observed"]
+        },
+        "error_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "toolsListObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed", "outcome", "operations", "error_code"],
+      "properties": {
+        "observed": {
+          "type": "boolean"
+        },
+        "outcome": {
+          "enum": ["success", "error", "not-observed"]
+        },
+        "operations": {
+          "type": "array",
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/operation"
+          }
+        },
+        "error_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "resourcesListObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed", "outcome", "resources", "error_code"],
+      "properties": {
+        "observed": {
+          "type": "boolean"
+        },
+        "outcome": {
+          "enum": ["success", "error", "not-observed"]
+        },
+        "resources": {
+          "type": "array",
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resource"
+          }
+        },
+        "error_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "toolResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "outcome",
+        "structured_plain_text_parity",
+        "receipt_present",
+        "request_sha256",
+        "response_sha256"
+      ],
+      "properties": {
+        "operation": {
+          "$ref": "#/$defs/operation"
+        },
+        "outcome": {
+          "enum": ["success", "bounded-error", "cancelled"]
+        },
+        "structured_plain_text_parity": {
+          "enum": ["passed", "failed", "not-tested"]
+        },
+        "receipt_present": {
+          "type": "boolean"
+        },
+        "request_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "response_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "resourceResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource", "outcome", "response_sha256"],
+      "properties": {
+        "resource": {
+          "$ref": "#/$defs/resource"
+        },
+        "outcome": {
+          "const": "success"
+        },
+        "response_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "assertionObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed", "outcome"],
+      "properties": {
+        "observed": {
+          "type": "boolean"
+        },
+        "outcome": {
+          "enum": ["passed", "failed", "not-tested"]
+        }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host_report",
+        "initialize",
+        "initialized_notification_observed",
+        "tools_list",
+        "resources_list",
+        "tool_results",
+        "resource_results",
+        "cancellation",
+        "unsupported_traffic"
+      ],
+      "properties": {
+        "host_report": {
+          "enum": [
+            "connected",
+            "failed-to-connect",
+            "process-failed",
+            "authentication-failed",
+            "configuration-failed",
+            "not-observed"
+          ]
+        },
+        "initialize": {
+          "$ref": "#/$defs/stageObservation"
+        },
+        "initialized_notification_observed": {
+          "type": "boolean"
+        },
+        "tools_list": {
+          "$ref": "#/$defs/toolsListObservation"
+        },
+        "resources_list": {
+          "$ref": "#/$defs/resourcesListObservation"
+        },
+        "tool_results": {
+          "type": "array",
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/$defs/toolResult"
+          }
+        },
+        "resource_results": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/$defs/resourceResult"
+          }
+        },
+        "cancellation": {
+          "$ref": "#/$defs/assertionObservation"
+        },
+        "unsupported_traffic": {
+          "$ref": "#/$defs/assertionObservation"
+        }
+      }
+    }
+  }
+}

--- a/schemas/qual-206-strict-modern-host-evidence.schema.json
+++ b/schemas/qual-206-strict-modern-host-evidence.schema.json
@@ -1,0 +1,1199 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:qual-206-strict-modern-host-evidence:v2",
+  "title": "QUAL-206 strict-modern public host evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "evidence_id",
+    "classification",
+    "status",
+    "observed_at",
+    "schema_contract",
+    "compiler_contract",
+    "lineage",
+    "source",
+    "host",
+    "protocol",
+    "surface",
+    "readiness",
+    "capability",
+    "telemetry",
+    "isolation",
+    "claims",
+    "limitations",
+    "boundary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.qual-206-strict-modern-host-evidence.v2"
+    },
+    "evidence_id": {
+      "type": "string",
+      "pattern": "^gis-ai-go:qual-206-strict-modern-host-evidence:sha256:[0-9a-f]{64}$"
+    },
+    "classification": {
+      "enum": [
+        "synthetic-test-only",
+        "pre-activation-strict-modern-host-summary"
+      ]
+    },
+    "status": {
+      "enum": ["not_ready", "ready_unscored", "capability_pass"]
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_contract": {
+      "$ref": "#/$defs/schemaContract"
+    },
+    "compiler_contract": {
+      "$ref": "#/$defs/compilerContract"
+    },
+    "lineage": {
+      "$ref": "#/$defs/lineage"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "host": {
+      "$ref": "#/$defs/host"
+    },
+    "protocol": {
+      "$ref": "#/$defs/protocol"
+    },
+    "surface": {
+      "$ref": "#/$defs/surface"
+    },
+    "readiness": {
+      "$ref": "#/$defs/readiness"
+    },
+    "capability": {
+      "$ref": "#/$defs/capability"
+    },
+    "telemetry": {
+      "$ref": "#/$defs/telemetry"
+    },
+    "isolation": {
+      "$ref": "#/$defs/isolation"
+    },
+    "claims": {
+      "$ref": "#/$defs/claims"
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 16,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/publicText"
+      }
+    },
+    "boundary": {
+      "const": "Pre-activation, summary-level host capture only. It is not event-level capability evidence and does not authorise or prove registration, activation, deployment, release or completion of QUAL-206."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "not_ready"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "readiness": {
+            "properties": {
+              "outcome": {
+                "const": "not_ready"
+              }
+            }
+          },
+          "capability": {
+            "properties": {
+              "outcome": {
+                "const": "unscored"
+              },
+              "exact_five_surface_discovered": {
+                "const": false
+              },
+              "exact_five_capability_exercised": {
+                "const": false
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "ready_unscored"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "readiness": {
+            "properties": {
+              "outcome": {
+                "const": "ready"
+              }
+            }
+          },
+          "capability": {
+            "properties": {
+              "outcome": {
+                "const": "unscored"
+              },
+              "exact_five_capability_exercised": {
+                "const": false
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "capability_pass"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "classification": {
+            "const": "synthetic-test-only"
+          },
+          "readiness": {
+            "properties": {
+              "outcome": {
+                "const": "ready"
+              }
+            }
+          },
+          "capability": {
+            "properties": {
+              "outcome": {
+                "const": "passed"
+              },
+              "exact_five_surface_discovered": {
+                "const": true
+              },
+              "exact_five_capability_exercised": {
+                "const": true
+              },
+              "structured_plain_text_parity": {
+                "const": "passed"
+              },
+              "cancellation": {
+                "const": "passed"
+              },
+              "unsupported_traffic": {
+                "const": "passed"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "classification": {
+            "const": "synthetic-test-only"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "claims": {
+            "properties": {
+              "live_host_session": {
+                "const": false
+              },
+              "strict_modern_transport_ready": {
+                "const": false
+              },
+              "capability_scored": {
+                "const": false
+              },
+              "exact_five_host_capability": {
+                "const": false
+              },
+              "remote_http_host": {
+                "const": false
+              }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "status": {
+            "enum": ["not_ready", "ready_unscored"]
+          },
+          "capability": {
+            "properties": {
+              "outcome": {
+                "const": "unscored"
+              },
+              "exact_five_surface_discovered": {
+                "const": false
+              },
+              "exact_five_capability_exercised": {
+                "const": false
+              },
+              "discovered_operations": {
+                "const": []
+              },
+              "discovered_resources": {
+                "const": []
+              },
+              "tool_results": {
+                "const": []
+              },
+              "resource_results": {
+                "const": []
+              },
+              "structured_plain_text_parity": {
+                "const": "not-tested"
+              },
+              "cancellation": {
+                "const": "not-tested"
+              },
+              "unsupported_traffic": {
+                "const": "not-tested"
+              }
+            }
+          },
+          "claims": {
+            "properties": {
+              "live_host_session": {
+                "const": false
+              },
+              "strict_modern_transport_ready": {
+                "const": false
+              },
+              "capability_scored": {
+                "const": false
+              },
+              "exact_five_host_capability": {
+                "const": false
+              },
+              "remote_http_host": {
+                "const": false
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "safePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*\\\\)(?!.*//)[A-Za-z0-9._/-]+$"
+    },
+    "publicText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 320,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "operation": {
+      "enum": [
+        "catalogue.search",
+        "catalogue.describe",
+        "selection.resolve",
+        "data.query",
+        "evidence.inspect"
+      ]
+    },
+    "resource": {
+      "enum": [
+        "catalogue.public",
+        "catalogue.record",
+        "evidence.receipt"
+      ]
+    },
+    "schemaContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "schemas/qual-206-strict-modern-host-evidence.schema.json"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "compilerMaterial": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "sha256"],
+      "properties": {
+        "role": {
+          "enum": [
+            "compiler",
+            "identity-helper",
+            "capture-schema",
+            "evidence-schema",
+            "canonical-source",
+            "digest-source",
+            "canonical-runtime",
+            "digest-runtime",
+            "identity-runtime"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "privateCaptureContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bytes", "sha256", "retention", "raw_content_published"],
+      "properties": {
+        "bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1048576
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "retention": {
+          "const": "operator-controlled-local"
+        },
+        "raw_content_published": {
+          "const": false
+        }
+      }
+    },
+    "compilerContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity_domain", "materials", "private_capture"],
+      "properties": {
+        "identity_domain": {
+          "const": "gis-ai-go.qual-206-strict-modern-host-evidence.v2"
+        },
+        "materials": {
+          "type": "array",
+          "minItems": 9,
+          "maxItems": 9,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/compilerMaterial"
+          }
+        },
+        "private_capture": {
+          "$ref": "#/$defs/privateCaptureContract"
+        }
+      }
+    },
+    "historicalArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relationship", "historical_artifacts"],
+      "properties": {
+        "relationship": {
+          "const": "preserved-separate-not-superseded"
+        },
+        "historical_artifacts": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/historicalArtifact"
+          }
+        }
+      }
+    },
+    "material": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "sha256"],
+      "properties": {
+        "role": {
+          "enum": [
+            "build-receipt",
+            "capture-schema",
+            "compiler",
+            "evidence-schema",
+            "identity-helper",
+            "launcher",
+            "lockfile",
+            "manifest",
+            "compiled",
+            "provider-egress-guard",
+            "source",
+            "telemetry-wrapper"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit",
+        "tree",
+        "protected_main",
+        "detached_checkout",
+        "worktree_clean",
+        "product_version",
+        "production_registration",
+        "production_activation",
+        "public_endpoint_created",
+        "materials"
+      ],
+      "properties": {
+        "repository": {
+          "const": "chris-page-gov/gis-ai-go"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "tree": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "protected_main": {
+          "type": "boolean"
+        },
+        "detached_checkout": {
+          "type": "boolean"
+        },
+        "worktree_clean": {
+          "type": "boolean"
+        },
+        "product_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
+        },
+        "production_registration": {
+          "const": false
+        },
+        "production_activation": {
+          "const": false
+        },
+        "public_endpoint_created": {
+          "const": false
+        },
+        "materials": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/material"
+          }
+        }
+      }
+    },
+    "binaryIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "sha256"],
+      "properties": {
+        "kind": {
+          "const": "binary"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "packageIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "name", "version", "sha256"],
+      "properties": {
+        "kind": {
+          "const": "package"
+        },
+        "name": {
+          "enum": [
+            "@anthropic-ai/claude-code",
+            "codex",
+            "chatgpt",
+            "generic-independent-mcp-host",
+            "synthetic-test-host"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._+-]+$"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "serviceIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "sha256"],
+      "properties": {
+        "kind": {
+          "const": "service"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "platform",
+        "architecture",
+        "identity",
+        "probe",
+        "model_authentication_supplied",
+        "model_task_requested"
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "claude-code",
+            "codex",
+            "chatgpt",
+            "generic-independent-mcp-host",
+            "synthetic-test-host"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._+-]+$"
+        },
+        "platform": {
+          "enum": ["darwin", "linux", "windows", "hosted"]
+        },
+        "architecture": {
+          "enum": ["arm64", "x86_64", "other", "not-applicable"]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/binaryIdentity"
+            },
+            {
+              "$ref": "#/$defs/packageIdentity"
+            },
+            {
+              "$ref": "#/$defs/serviceIdentity"
+            }
+          ]
+        },
+        "probe": {
+          "enum": ["mcp-list", "model-task", "manual-client"]
+        },
+        "model_authentication_supplied": {
+          "type": "boolean"
+        },
+        "model_task_requested": {
+          "type": "boolean"
+        }
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_version",
+        "target_source_id",
+        "client_requested_version",
+        "server_supported_versions",
+        "negotiated_version"
+      ],
+      "properties": {
+        "target_version": {
+          "const": "2026-07-28"
+        },
+        "target_source_id": {
+          "const": "S-MCP-SPEC"
+        },
+        "client_requested_version": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "server_supported_versions": {
+          "const": ["2026-07-28"]
+        },
+        "negotiated_version": {
+          "oneOf": [
+            {
+              "const": "2026-07-28"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "assembly",
+        "transport",
+        "operations",
+        "resources",
+        "production_registration"
+      ],
+      "properties": {
+        "assembly": {
+          "const": "candidate-unregistered-exact-five"
+        },
+        "transport": {
+          "enum": ["stdio", "streamable-http"]
+        },
+        "operations": {
+          "const": [
+            "catalogue.search",
+            "catalogue.describe",
+            "selection.resolve",
+            "data.query",
+            "evidence.inspect"
+          ]
+        },
+        "resources": {
+          "const": [
+            "catalogue.public",
+            "catalogue.record",
+            "evidence.receipt"
+          ]
+        },
+        "production_registration": {
+          "const": false
+        }
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "classification",
+        "initialize_observed",
+        "initialize_success",
+        "initialized_notification_observed",
+        "tools_list_observed",
+        "tools_list_success",
+        "host_report",
+        "error_code"
+      ],
+      "properties": {
+        "outcome": {
+          "enum": ["ready", "not_ready"]
+        },
+        "classification": {
+          "enum": [
+            "protocol-negotiation-pass",
+            "protocol-negotiation-failure",
+            "host-launch-failure",
+            "configuration-failure",
+            "authentication-failure",
+            "transport-failure",
+            "tools-list-failure"
+          ]
+        },
+        "initialize_observed": {
+          "type": "boolean"
+        },
+        "initialize_success": {
+          "type": "boolean"
+        },
+        "initialized_notification_observed": {
+          "type": "boolean"
+        },
+        "tools_list_observed": {
+          "type": "boolean"
+        },
+        "tools_list_success": {
+          "type": "boolean"
+        },
+        "host_report": {
+          "enum": [
+            "connected",
+            "failed-to-connect",
+            "process-failed",
+            "authentication-failed",
+            "configuration-failed",
+            "not-observed"
+          ]
+        },
+        "error_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "corpusReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "corpus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base", "expansion", "case_ids"],
+      "properties": {
+        "base": {
+          "$ref": "#/$defs/corpusReference"
+        },
+        "expansion": {
+          "$ref": "#/$defs/corpusReference"
+        },
+        "case_ids": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 18,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^QUAL-206-HOST-0(?:0[1-9]|1[0-8])$"
+          }
+        }
+      }
+    },
+    "toolResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "outcome",
+        "structured_plain_text_parity",
+        "receipt_present",
+        "request_sha256",
+        "response_sha256"
+      ],
+      "properties": {
+        "operation": {
+          "$ref": "#/$defs/operation"
+        },
+        "outcome": {
+          "enum": ["success", "bounded-error", "cancelled"]
+        },
+        "structured_plain_text_parity": {
+          "enum": ["passed", "failed", "not-tested"]
+        },
+        "receipt_present": {
+          "type": "boolean"
+        },
+        "request_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "response_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "resourceResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource", "outcome", "response_sha256"],
+      "properties": {
+        "resource": {
+          "$ref": "#/$defs/resource"
+        },
+        "outcome": {
+          "const": "success"
+        },
+        "response_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outcome",
+        "corpus",
+        "exact_five_surface_discovered",
+        "exact_five_capability_exercised",
+        "discovered_operations",
+        "discovered_resources",
+        "tool_results",
+        "resource_results",
+        "structured_plain_text_parity",
+        "cancellation",
+        "unsupported_traffic",
+        "model_task_requested"
+      ],
+      "properties": {
+        "outcome": {
+          "enum": ["unscored", "passed"]
+        },
+        "corpus": {
+          "$ref": "#/$defs/corpus"
+        },
+        "exact_five_surface_discovered": {
+          "type": "boolean"
+        },
+        "exact_five_capability_exercised": {
+          "type": "boolean"
+        },
+        "discovered_operations": {
+          "type": "array",
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/operation"
+          }
+        },
+        "discovered_resources": {
+          "type": "array",
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resource"
+          }
+        },
+        "tool_results": {
+          "type": "array",
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/$defs/toolResult"
+          }
+        },
+        "resource_results": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/$defs/resourceResult"
+          }
+        },
+        "structured_plain_text_parity": {
+          "enum": ["passed", "failed", "not-tested"]
+        },
+        "cancellation": {
+          "enum": ["passed", "failed", "not-tested"]
+        },
+        "unsupported_traffic": {
+          "enum": ["passed", "failed", "not-tested"]
+        },
+        "model_task_requested": {
+          "type": "boolean"
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "retained_private",
+        "event_count",
+        "event_counts",
+        "exit_code",
+        "pending_request_count"
+      ],
+      "properties": {
+        "schema": {
+          "const": "gis-ai-go.qual-206-host-capture-summary.v1"
+        },
+        "retained_private": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "retention",
+            "raw_content_published",
+            "digest_published",
+            "byte_count_published"
+          ],
+          "properties": {
+            "retention": {
+              "const": "operator-controlled-local"
+            },
+            "raw_content_published": {
+              "const": false
+            },
+            "digest_published": {
+              "const": false
+            },
+            "byte_count_published": {
+              "const": false
+            }
+          }
+        },
+        "event_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000
+        },
+        "event_counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_start",
+            "request",
+            "notification",
+            "response",
+            "session_end",
+            "anomaly",
+            "malformed_frame",
+            "non_json_frame",
+            "truncated_frame",
+            "server_stderr"
+          ],
+          "properties": {
+            "session_start": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "request": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50000
+            },
+            "notification": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50000
+            },
+            "response": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50000
+            },
+            "session_end": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "anomaly": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000
+            },
+            "malformed_frame": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000
+            },
+            "non_json_frame": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000
+            },
+            "truncated_frame": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000
+            },
+            "server_stderr": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000
+            }
+          }
+        },
+        "exit_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_request_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50000
+        }
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temporary_profile",
+        "profile_root_mode",
+        "primary_configuration_mode",
+        "normal_profile_used",
+        "normal_profile_mutation_observed",
+        "credential_variables_removed_count",
+        "mcp_child_environment_allowlisted",
+        "credential_value_pattern_matches",
+        "remaining_processes_after_cleanup",
+        "raw_host_logs_published",
+        "os_network_isolation_enforced",
+        "provider_egress_guard_exercised"
+      ],
+      "properties": {
+        "temporary_profile": {
+          "const": true
+        },
+        "profile_root_mode": {
+          "const": "0700"
+        },
+        "primary_configuration_mode": {
+          "const": "0600"
+        },
+        "normal_profile_used": {
+          "const": false
+        },
+        "normal_profile_mutation_observed": {
+          "const": false
+        },
+        "credential_variables_removed_count": {
+          "type": "integer",
+          "minimum": 5,
+          "maximum": 64
+        },
+        "mcp_child_environment_allowlisted": {
+          "const": true
+        },
+        "credential_value_pattern_matches": {
+          "const": 0
+        },
+        "remaining_processes_after_cleanup": {
+          "const": 0
+        },
+        "raw_host_logs_published": {
+          "const": false
+        },
+        "os_network_isolation_enforced": {
+          "type": "boolean"
+        },
+        "provider_egress_guard_exercised": {
+          "type": "boolean"
+        }
+      }
+    },
+    "claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "live_host_session",
+        "strict_modern_transport_ready",
+        "capability_scored",
+        "exact_five_host_capability",
+        "live_provider_call",
+        "remote_http_host",
+        "independent_host_gate_completed",
+        "production_registration",
+        "production_activation",
+        "public_deployment",
+        "registry_publication",
+        "release_acceptance",
+        "complete_qual_206"
+      ],
+      "properties": {
+        "live_host_session": {
+          "type": "boolean"
+        },
+        "strict_modern_transport_ready": {
+          "type": "boolean"
+        },
+        "capability_scored": {
+          "type": "boolean"
+        },
+        "exact_five_host_capability": {
+          "type": "boolean"
+        },
+        "live_provider_call": {
+          "const": false
+        },
+        "remote_http_host": {
+          "type": "boolean"
+        },
+        "independent_host_gate_completed": {
+          "const": false
+        },
+        "production_registration": {
+          "const": false
+        },
+        "production_activation": {
+          "const": false
+        },
+        "public_deployment": {
+          "const": false
+        },
+        "registry_publication": {
+          "const": false
+        },
+        "release_acceptance": {
+          "const": false
+        },
+        "complete_qual_206": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/scripts/compile_qual_206_strict_modern_evidence.py
+++ b/scripts/compile_qual_206_strict_modern_evidence.py
@@ -1,0 +1,1112 @@
+#!/usr/bin/env python3
+"""Compile one private QUAL-206 host capture into bounded public evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAPTURE_SCHEMA_PATH = ROOT / "schemas" / "qual-206-strict-modern-host-capture.schema.json"
+EVIDENCE_SCHEMA_PATH = ROOT / "schemas" / "qual-206-strict-modern-host-evidence.schema.json"
+IDENTITY_HELPER_PATH = ROOT / "scripts" / "qual_206_strict_modern_identity.mjs"
+MAX_CAPTURE_BYTES = 1_048_576
+MAX_PRIVATE_TELEMETRY_BYTES = 8_388_608
+EXACT_OPERATIONS = [
+    "catalogue.search",
+    "catalogue.describe",
+    "selection.resolve",
+    "data.query",
+    "evidence.inspect",
+]
+EXACT_RESOURCES = [
+    "catalogue.public",
+    "catalogue.record",
+    "evidence.receipt",
+]
+REQUIRED_CAPABILITY_CASES = {
+    f"QUAL-206-HOST-{index:03d}" for index in range(1, 11)
+}
+BOUNDARY = (
+    "Pre-activation, summary-level host capture only. It is not event-level "
+    "capability evidence and does not authorise or prove registration, activation, "
+    "deployment, release or completion of QUAL-206."
+)
+IDENTITY_PREFIX = "gis-ai-go:qual-206-strict-modern-host-evidence:sha256:"
+IDENTITY_DOMAIN = "gis-ai-go.qual-206-strict-modern-host-evidence.v2"
+GIT_BOUND_ROLES = {
+    "source",
+    "launcher",
+    "telemetry-wrapper",
+    "lockfile",
+    "provider-egress-guard",
+    "manifest",
+    "compiler",
+    "identity-helper",
+    "capture-schema",
+    "evidence-schema",
+    "build-receipt",
+}
+REQUIRED_OBSERVED_MATERIALS = {
+    ("compiler", "scripts/compile_qual_206_strict_modern_evidence.py"),
+    ("identity-helper", "scripts/qual_206_strict_modern_identity.mjs"),
+    ("capture-schema", "schemas/qual-206-strict-modern-host-capture.schema.json"),
+    ("evidence-schema", "schemas/qual-206-strict-modern-host-evidence.schema.json"),
+    ("launcher", "tests/interoperability/fixtures/qual_206_exact_five_stdio_server.mjs"),
+    ("telemetry-wrapper", "scripts/qual_206_telemetry_proxy.mjs"),
+    (
+        "provider-egress-guard",
+        "tests/interoperability/fixtures/qual_206_provider_egress_guard.mjs",
+    ),
+    ("manifest", "package.json"),
+    ("lockfile", "pnpm-lock.yaml"),
+    ("source", "packages/evidence/src/canonical-json.ts"),
+    ("source", "packages/evidence/src/digest.ts"),
+    ("source", "packages/evidence/src/index.ts"),
+    ("compiled", "packages/evidence/dist/src/canonical-json.js"),
+    ("compiled", "packages/evidence/dist/src/digest.js"),
+    ("compiled", "packages/evidence/dist/src/index.js"),
+    ("build-receipt", "evaluation/qual-206-local-evaluation-receipts.v1.json"),
+}
+PINNED_IDENTITY_RUNTIME_SHA256 = {
+    "packages/evidence/dist/src/canonical-json.js": (
+        "0b898e4597f5f4f90d5feda5ef9d80c9ea14409f531c2378ff2c9e0a3529c624"
+    ),
+    "packages/evidence/dist/src/digest.js": (
+        "295226181b1a5441b075b47efa9d00a36b664dd91b090daff9bfb046300fd81f"
+    ),
+    "packages/evidence/dist/src/index.js": (
+        "51129a84578ed1cf46fa5bdf2f6afe32fa875874acd99c55e7416889c68070dd"
+    ),
+}
+HISTORICAL_LINEAGE = [
+    {
+        "path": "schemas/qual-206-claude-code-stdio-observation.schema.json",
+        "sha256": "78b9a8071a6954028576f397c98dd0fc4b87dddbaf72654f6459407b280e2a9b",
+    },
+    {
+        "path": (
+            "tests/interoperability/evidence/"
+            "claude-code-2.1.241-stdio-observation-2026-08-24.json"
+        ),
+        "sha256": "d2cd72b7f16a0bafd8a7190b87b14f150b7fa975f6d70f5e779eb9ddf5f92478",
+    },
+    {
+        "path": "schemas/qual-206-legacy-stdio-readiness.schema.json",
+        "sha256": "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a",
+    },
+    {
+        "path": (
+            "tests/interoperability/evidence/"
+            "claude-code-legacy-stdio-readiness-2026-08-23.json"
+        ),
+        "sha256": "a3d40e2013095baf977bad336366c0fb429a05b6a5a267c3e069595e4cdb1a6b",
+    },
+    {
+        "path": "tests/interoperability/qual_206_cases.json",
+        "sha256": "23ac9bc1a76d524bd0e250b11b9ba321b09e66bd5921f1463f50c150001cd389",
+    },
+]
+CAPTURE_FORBIDDEN_KEYS = {
+    "arguments",
+    "boundary",
+    "capability",
+    "claims",
+    "command_sha256",
+    "environment",
+    "evidence_id",
+    "headers",
+    "prompt",
+    "raw_command",
+    "raw_payload",
+    "raw_result",
+    "readiness",
+    "result_content",
+    "session_id",
+    "session_id_sha256",
+    "status",
+}
+PUBLIC_FORBIDDEN_KEYS = {
+    "arguments",
+    "command_sha256",
+    "device_id",
+    "environment",
+    "headers",
+    "hostname",
+    "prompt",
+    "raw_command",
+    "raw_payload",
+    "raw_result",
+    "result_content",
+    "session_id",
+    "session_id_sha256",
+    "username",
+}
+PUBLIC_FORBIDDEN_PATTERN = re.compile(
+    r"(?:"
+    r"/Users/|/home/|/Volumes/|/private/tmp/|file://|"
+    r"[A-Za-z]:\\\\Users\\\\|"
+    r"\bsk-[A-Za-z0-9_-]{8,}|\bgh[opusr]_[A-Za-z0-9]{8,}|"
+    r"\bxox[baprs]-[A-Za-z0-9-]{8,}|\bAKIA[0-9A-Z]{16}|"
+    r"\bBearer\s+[A-Za-z0-9._~-]+|"
+    r"OPENAI_API_KEY|CODEX_API_KEY|ANTHROPIC_API_KEY|"
+    r"ANTHROPIC_AUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN|"
+    r"https?://(?:chatgpt\.com/c/|claude\.ai/chat/)|"
+    r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|"
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-"
+    r"[0-9a-f]{12}\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+class EvidenceError(ValueError):
+    """A fail-closed evidence compilation error."""
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def reject_non_standard_number(value: str) -> None:
+    raise EvidenceError(f"non-standard JSON number: {value}")
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise EvidenceError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+def assert_no_surrogate_code_points(value: object, path: str = "$") -> None:
+    if isinstance(value, str):
+        if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+            raise EvidenceError(f"{path} contains a surrogate code point")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            assert_no_surrogate_code_points(key, f"{path}.<key>")
+            assert_no_surrogate_code_points(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            assert_no_surrogate_code_points(item, f"{path}[{index}]")
+
+
+def parse_json_bytes(value: bytes, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(
+            value.decode("utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_non_standard_number,
+        )
+    except UnicodeDecodeError as error:
+        raise EvidenceError(f"{label} is not UTF-8") from error
+    except json.JSONDecodeError as error:
+        raise EvidenceError(f"{label} is not valid JSON: {error.msg}") from error
+    if not isinstance(parsed, dict):
+        raise EvidenceError(f"{label} must contain one JSON object")
+    assert_no_surrogate_code_points(parsed)
+    return parsed
+
+
+def load_schema(path: Path) -> dict[str, Any]:
+    schema = parse_json_bytes(path.read_bytes(), str(path.relative_to(ROOT)))
+    Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def format_errors(
+    validator: Draft202012Validator,
+    value: object,
+) -> list[str]:
+    errors = sorted(
+        validator.iter_errors(value),
+        key=lambda error: [str(part) for part in error.absolute_path],
+    )
+    return [
+        f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+        for error in errors
+    ]
+
+
+def validate(validator: Draft202012Validator, value: object, label: str) -> None:
+    errors = format_errors(validator, value)
+    if errors:
+        raise EvidenceError(f"{label} failed schema validation: {'; '.join(errors)}")
+
+
+def require_mode(path: Path, expected: int, label: str) -> os.stat_result:
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode):
+        raise EvidenceError(f"{label} must not be a symbolic link")
+    if not stat.S_ISREG(metadata.st_mode) and label != "capture root":
+        raise EvidenceError(f"{label} must be a regular file")
+    if label == "capture root" and not stat.S_ISDIR(metadata.st_mode):
+        raise EvidenceError("capture root must be a directory")
+    if metadata.st_uid != os.getuid():
+        raise EvidenceError(f"{label} must be owned by the current user")
+    if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+        raise EvidenceError(f"{label} must have exactly one hard link")
+    mode = stat.S_IMODE(metadata.st_mode)
+    if mode != expected:
+        raise EvidenceError(f"{label} must have mode {expected:04o}, found {mode:04o}")
+    return metadata
+
+
+def normalise_capture_root(value: str) -> Path:
+    supplied = Path(value)
+    if not supplied.is_absolute():
+        raise EvidenceError("capture root must be absolute")
+    require_mode(supplied, 0o700, "capture root")
+    resolved = supplied.resolve(strict=True)
+    if resolved != supplied:
+        raise EvidenceError("capture root must not resolve through an alias")
+    return resolved
+
+
+def ensure_no_symlink_components(root: Path, path: Path, label: str) -> None:
+    try:
+        relative = path.relative_to(root)
+    except ValueError as error:
+        raise EvidenceError(f"{label} must remain beneath the capture root") from error
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if stat.S_ISLNK(current.lstat().st_mode):
+            raise EvidenceError(f"{label} must not traverse a symbolic link")
+
+
+def private_relative_path(root: Path, value: str | Path, label: str) -> PurePosixPath:
+    supplied = Path(value)
+    if supplied.is_absolute():
+        try:
+            supplied = supplied.relative_to(root)
+        except ValueError as error:
+            raise EvidenceError(f"{label} must remain beneath the capture root") from error
+    logical = PurePosixPath(supplied.as_posix())
+    if (
+        not logical.parts
+        or logical.is_absolute()
+        or any(part in {"", ".", ".."} for part in logical.parts)
+        or "\\" in logical.as_posix()
+        or "\x00" in logical.as_posix()
+    ):
+        raise EvidenceError(f"{label} has an unsafe private path")
+    return logical
+
+
+def same_file_state(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        left.st_dev,
+        left.st_ino,
+        left.st_mode,
+        left.st_uid,
+        left.st_nlink,
+        left.st_size,
+        left.st_mtime_ns,
+    ) == (
+        right.st_dev,
+        right.st_ino,
+        right.st_mode,
+        right.st_uid,
+        right.st_nlink,
+        right.st_size,
+        right.st_mtime_ns,
+    )
+
+
+def read_private_file(
+    root: Path,
+    value: str | Path,
+    label: str,
+    maximum: int,
+) -> bytes:
+    """Read a private file through directory descriptors without following links."""
+
+    if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+        raise EvidenceError("secure private capture reads are unsupported on this platform")
+    logical = private_relative_path(root, value, label)
+    initial_root = require_mode(root, 0o700, "capture root")
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    file_flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+    root_descriptor = os.open(root, directory_flags)
+    descriptors = [root_descriptor]
+    file_descriptor: int | None = None
+    try:
+        if not same_file_state(initial_root, os.fstat(root_descriptor)):
+            raise EvidenceError("capture root changed while it was opened")
+        directory_descriptor = root_descriptor
+        for part in logical.parts[:-1]:
+            child_descriptor = os.open(part, directory_flags, dir_fd=directory_descriptor)
+            descriptors.append(child_descriptor)
+            child = os.fstat(child_descriptor)
+            if not stat.S_ISDIR(child.st_mode) or child.st_uid != os.getuid():
+                raise EvidenceError(f"{label} traverses an unsafe private directory")
+            if stat.S_IMODE(child.st_mode) != 0o700:
+                raise EvidenceError(f"{label} private directories must have mode 0700")
+            directory_descriptor = child_descriptor
+
+        file_descriptor = os.open(logical.parts[-1], file_flags, dir_fd=directory_descriptor)
+        before = os.fstat(file_descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise EvidenceError(f"{label} must be a regular file")
+        if before.st_uid != os.getuid() or stat.S_IMODE(before.st_mode) != 0o600:
+            raise EvidenceError(f"{label} must be owner-only mode 0600")
+        if before.st_nlink != 1:
+            raise EvidenceError(f"{label} must have exactly one hard link")
+        if before.st_size <= 0 or before.st_size > maximum:
+            raise EvidenceError(f"{label} size is outside the accepted boundary")
+
+        chunks: list[bytes] = []
+        remaining = maximum + 1
+        while remaining:
+            chunk = os.read(file_descriptor, min(65_536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        content = b"".join(chunks)
+        after = os.fstat(file_descriptor)
+        if len(content) > maximum or len(content) != before.st_size:
+            raise EvidenceError(f"{label} grew, shrank or exceeded its size boundary")
+        if not same_file_state(before, after):
+            raise EvidenceError(f"{label} changed while it was read")
+        current_root = root.lstat()
+        if not same_file_state(initial_root, current_root):
+            raise EvidenceError("capture root changed while private input was read")
+        return content
+    finally:
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def safe_repository_path(value: str) -> str:
+    if not value or "\\" in value or "\x00" in value:
+        raise EvidenceError(f"unsafe repository path: {value!r}")
+    logical = PurePosixPath(value)
+    if logical.is_absolute() or any(part in {"", ".", ".."} for part in logical.parts):
+        raise EvidenceError(f"unsafe repository path: {value!r}")
+    if logical.as_posix() != value:
+        raise EvidenceError(f"non-canonical repository path: {value!r}")
+    return value
+
+
+def nested_field_names(node: object) -> set[str]:
+    names: set[str] = set()
+    if isinstance(node, dict):
+        names.update(node)
+        for value in node.values():
+            names.update(nested_field_names(value))
+    elif isinstance(node, list):
+        for value in node:
+            names.update(nested_field_names(value))
+    return names
+
+
+def assert_capture_has_no_claim_fields(capture: dict[str, Any]) -> None:
+    forbidden = CAPTURE_FORBIDDEN_KEYS.intersection(nested_field_names(capture))
+    if forbidden:
+        raise EvidenceError(
+            "private capture contains compiler-owned or unsafe fields: "
+            + ", ".join(sorted(forbidden))
+        )
+
+
+def git_output(*arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvidenceError(f"git {' '.join(arguments)} failed: {message}")
+    return result.stdout
+
+
+def read_repository_material(path: str) -> bytes:
+    target = ROOT / safe_repository_path(path)
+    if target.resolve(strict=True) != target:
+        raise EvidenceError(f"repository material must not traverse a link: {path}")
+    before = target.lstat()
+    if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+        raise EvidenceError(f"repository material must be a single-link regular file: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(target, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not same_file_state(before, opened):
+            raise EvidenceError(f"repository material changed while it was opened: {path}")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 65_536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+        if not same_file_state(opened, after):
+            raise EvidenceError(f"repository material changed while it was read: {path}")
+        content = b"".join(chunks)
+        if len(content) != opened.st_size:
+            raise EvidenceError(f"repository material was not read completely: {path}")
+        return content
+    finally:
+        os.close(descriptor)
+
+
+def verify_observed_source(capture: dict[str, Any]) -> None:
+    source = capture["source"]
+    for field in ("protected_main", "detached_checkout", "worktree_clean"):
+        if source[field] is not True:
+            raise EvidenceError(f"observed host source requires {field}=true")
+
+    commit = source["commit"]
+    expected_tree = source["tree"]
+    actual_tree = git_output("rev-parse", f"{commit}^{{tree}}").decode().strip()
+    if actual_tree != expected_tree:
+        raise EvidenceError("source tree does not match the captured commit")
+
+    remote_main = git_output("rev-parse", "--verify", "refs/remotes/origin/main").decode().strip()
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", commit, remote_main],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if ancestor.returncode != 0:
+        raise EvidenceError("observed source commit is not accepted protected-main history")
+
+    seen_materials: set[tuple[str, str]] = set()
+    for material in source["materials"]:
+        role = material["role"]
+        path = safe_repository_path(material["path"])
+        identity = (role, path)
+        if identity in seen_materials:
+            raise EvidenceError(f"duplicate source material: {role}:{path}")
+        seen_materials.add(identity)
+        if role in GIT_BOUND_ROLES:
+            blob = git_output("show", f"{commit}:{path}")
+            if sha256_bytes(blob) != material["sha256"]:
+                raise EvidenceError(f"source material digest mismatch: {path}")
+        elif role == "compiled":
+            if sha256_bytes(read_repository_material(path)) != material["sha256"]:
+                raise EvidenceError(f"compiled material digest mismatch: {path}")
+        else:
+            raise EvidenceError(f"unrecognised source material role: {role}")
+
+    if seen_materials != REQUIRED_OBSERVED_MATERIALS:
+        missing = sorted(REQUIRED_OBSERVED_MATERIALS - seen_materials)
+        extra = sorted(seen_materials - REQUIRED_OBSERVED_MATERIALS)
+        raise EvidenceError(
+            "observed source material inventory is not closed; "
+            f"missing={missing!r}; extra={extra!r}"
+        )
+
+    for reference in (capture["corpus"]["base"], capture["corpus"]["expansion"]):
+        path = safe_repository_path(reference["path"])
+        blob = git_output("show", f"{commit}:{path}")
+        if sha256_bytes(blob) != reference["sha256"]:
+            raise EvidenceError(f"corpus digest mismatch at source commit: {path}")
+
+
+def verify_telemetry_file(root: Path, capture: dict[str, Any]) -> None:
+    retained = capture["telemetry"]["retained_private"]
+    value = read_private_file(
+        root,
+        retained["path"],
+        "private telemetry",
+        MAX_PRIVATE_TELEMETRY_BYTES,
+    )
+    if len(value) != retained["bytes"]:
+        raise EvidenceError("private telemetry byte count does not match")
+    if sha256_bytes(value) != retained["sha256"]:
+        raise EvidenceError("private telemetry digest does not match")
+
+
+def verify_telemetry_counts(capture: dict[str, Any]) -> None:
+    telemetry = capture["telemetry"]
+    count_fields = (
+        "session_start_count",
+        "request_count",
+        "notification_count",
+        "response_count",
+        "session_end_count",
+        "anomaly_count",
+        "malformed_frame_count",
+        "non_json_frame_count",
+        "truncated_frame_count",
+        "server_stderr_count",
+    )
+    if telemetry["event_count"] != sum(telemetry[field] for field in count_fields):
+        raise EvidenceError("telemetry event_count does not match its closed counters")
+    if telemetry["session_start_count"] != 1 or telemetry["session_end_count"] != 1:
+        raise EvidenceError("telemetry must contain exactly one session start and end")
+    observation = capture["observation"]
+    minimum_round_trips = sum(
+        1
+        for stage in (
+            observation["initialize"],
+            observation["tools_list"],
+            observation["resources_list"],
+        )
+        if stage["observed"]
+    ) + len(observation["tool_results"]) + len(observation["resource_results"])
+    if telemetry["request_count"] < minimum_round_trips:
+        raise EvidenceError("telemetry request_count cannot support the observed stages")
+    if telemetry["response_count"] < minimum_round_trips:
+        raise EvidenceError("telemetry response_count cannot support the observed stages")
+    if (
+        observation["initialized_notification_observed"]
+        and telemetry["notification_count"] < 1
+    ):
+        raise EvidenceError("telemetry lacks the observed initialized notification")
+    if clean_transport(capture) and telemetry["request_count"] != telemetry["response_count"]:
+        raise EvidenceError("clean telemetry must close every request with one response")
+
+
+def verify_stage(stage: dict[str, Any], label: str) -> None:
+    outcome = stage["outcome"]
+    observed = stage["observed"]
+    error_code = stage["error_code"]
+    if outcome == "success" and (not observed or error_code is not None):
+        raise EvidenceError(f"{label} success is internally inconsistent")
+    if outcome == "error" and (not observed or not isinstance(error_code, int)):
+        raise EvidenceError(f"{label} error is internally inconsistent")
+    if outcome == "not-observed" and (observed or error_code is not None):
+        raise EvidenceError(f"{label} not-observed state is internally inconsistent")
+
+
+def verify_observation(capture: dict[str, Any]) -> None:
+    observation = capture["observation"]
+    verify_stage(observation["initialize"], "initialize")
+    verify_stage(observation["tools_list"], "tools/list")
+    verify_stage(observation["resources_list"], "resources/list")
+    for key, item_key in (("tools_list", "operations"), ("resources_list", "resources")):
+        stage = observation[key]
+        if stage["outcome"] != "success" and stage[item_key]:
+            raise EvidenceError(f"{key} cannot publish discovery values without success")
+
+    tool_names = [item["operation"] for item in observation["tool_results"]]
+    if len(tool_names) != len(set(tool_names)):
+        raise EvidenceError("tool results contain a duplicate operation")
+    resource_names = [item["resource"] for item in observation["resource_results"]]
+    if len(resource_names) != len(set(resource_names)):
+        raise EvidenceError("resource results contain a duplicate resource")
+    if (
+        observation["initialized_notification_observed"]
+        and observation["initialize"]["outcome"] != "success"
+    ):
+        raise EvidenceError("initialized notification requires successful initialisation")
+    if observation["tool_results"] and observation["tools_list"]["outcome"] != "success":
+        raise EvidenceError("tool results require successful tools/list discovery")
+    if (
+        observation["resource_results"]
+        and observation["resources_list"]["outcome"] != "success"
+    ):
+        raise EvidenceError("resource results require successful resources/list discovery")
+
+
+def verify_protocol(capture: dict[str, Any]) -> None:
+    protocol = capture["protocol"]
+    negotiated = protocol["negotiated_version"]
+    if negotiated is not None and protocol["client_requested_version"] != negotiated:
+        raise EvidenceError("negotiated protocol must equal the client-requested version")
+
+
+def verify_capture_kind(capture: dict[str, Any]) -> None:
+    synthetic = capture["capture_kind"] == "synthetic-test-fixture"
+    synthetic_host = capture["host"]["name"] == "synthetic-test-host"
+    if synthetic != synthetic_host:
+        raise EvidenceError("capture kind and allowlisted host identity are inconsistent")
+    identities = [
+        (material["role"], material["path"])
+        for material in capture["source"]["materials"]
+    ]
+    if len(identities) != len(set(identities)):
+        raise EvidenceError("source materials contain a duplicate role and path")
+
+
+def clean_transport(capture: dict[str, Any]) -> bool:
+    telemetry = capture["telemetry"]
+    return (
+        telemetry["exit_code"] == 0
+        and telemetry["pending_request_count"] == 0
+        and telemetry["anomaly_count"] == 0
+        and telemetry["malformed_frame_count"] == 0
+        and telemetry["non_json_frame_count"] == 0
+        and telemetry["truncated_frame_count"] == 0
+        and telemetry["server_stderr_count"] == 0
+    )
+
+
+def derive_readiness(capture: dict[str, Any]) -> tuple[bool, str, int | None]:
+    observation = capture["observation"]
+    initialize = observation["initialize"]
+    tools_list = observation["tools_list"]
+    ready = (
+        capture["protocol"]["negotiated_version"] == "2026-07-28"
+        and capture["protocol"]["client_requested_version"] == "2026-07-28"
+        and observation["host_report"] == "connected"
+        and initialize["outcome"] == "success"
+        and observation["initialized_notification_observed"] is True
+        and tools_list["outcome"] == "success"
+        and clean_transport(capture)
+    )
+    if ready:
+        return True, "protocol-negotiation-pass", None
+    if initialize["outcome"] == "error":
+        return False, "protocol-negotiation-failure", initialize["error_code"]
+    if tools_list["outcome"] == "error":
+        return False, "tools-list-failure", tools_list["error_code"]
+    host_report = observation["host_report"]
+    classification = {
+        "process-failed": "host-launch-failure",
+        "configuration-failed": "configuration-failure",
+        "authentication-failed": "authentication-failure",
+        "failed-to-connect": "transport-failure",
+    }.get(host_report, "transport-failure")
+    return False, classification, None
+
+
+def derive_capability(capture: dict[str, Any], ready: bool) -> tuple[bool, bool, bool]:
+    observation = capture["observation"]
+    exact_discovery = (
+        ready
+        and observation["tools_list"]["operations"] == EXACT_OPERATIONS
+        and observation["resources_list"]["outcome"] == "success"
+        and observation["resources_list"]["resources"] == EXACT_RESOURCES
+    )
+    tools = observation["tool_results"]
+    tool_pass = (
+        [item["operation"] for item in tools] == EXACT_OPERATIONS
+        and all(item["outcome"] == "success" for item in tools)
+        and all(item["structured_plain_text_parity"] == "passed" for item in tools)
+        and all(item["receipt_present"] is True for item in tools)
+    )
+    resources = observation["resource_results"]
+    resource_pass = (
+        [item["resource"] for item in resources] == EXACT_RESOURCES
+        and all(item["outcome"] == "success" for item in resources)
+    )
+    cases_pass = REQUIRED_CAPABILITY_CASES.issubset(set(capture["corpus"]["case_ids"]))
+    host = capture["host"]
+    capability_pass = (
+        exact_discovery
+        and host["probe"] == "model-task"
+        and host["model_authentication_supplied"] is True
+        and host["model_task_requested"] is True
+        and tool_pass
+        and resource_pass
+        and observation["cancellation"] == {"observed": True, "outcome": "passed"}
+        and observation["unsupported_traffic"]
+        == {"observed": True, "outcome": "passed"}
+    )
+    parity_pass = len(tools) == len(EXACT_OPERATIONS) and all(
+        item["structured_plain_text_parity"] == "passed" for item in tools
+    )
+    return exact_discovery, capability_pass and cases_pass, parity_pass
+
+
+def public_telemetry(capture: dict[str, Any]) -> dict[str, Any]:
+    telemetry = capture["telemetry"]
+    return {
+        "schema": telemetry["schema"],
+        "retained_private": {
+            "retention": "operator-controlled-local",
+            "raw_content_published": False,
+            "digest_published": False,
+            "byte_count_published": False,
+        },
+        "event_count": telemetry["event_count"],
+        "event_counts": {
+            "session_start": telemetry["session_start_count"],
+            "request": telemetry["request_count"],
+            "notification": telemetry["notification_count"],
+            "response": telemetry["response_count"],
+            "session_end": telemetry["session_end_count"],
+            "anomaly": telemetry["anomaly_count"],
+            "malformed_frame": telemetry["malformed_frame_count"],
+            "non_json_frame": telemetry["non_json_frame_count"],
+            "truncated_frame": telemetry["truncated_frame_count"],
+            "server_stderr": telemetry["server_stderr_count"],
+        },
+        "exit_code": telemetry["exit_code"],
+        "pending_request_count": telemetry["pending_request_count"],
+    }
+
+
+def compiler_contract(capture_bytes: bytes) -> dict[str, Any]:
+    paths = [
+        ("compiler", "scripts/compile_qual_206_strict_modern_evidence.py"),
+        ("identity-helper", "scripts/qual_206_strict_modern_identity.mjs"),
+        ("capture-schema", "schemas/qual-206-strict-modern-host-capture.schema.json"),
+        ("evidence-schema", "schemas/qual-206-strict-modern-host-evidence.schema.json"),
+        ("canonical-source", "packages/evidence/src/canonical-json.ts"),
+        ("digest-source", "packages/evidence/src/digest.ts"),
+        ("canonical-runtime", "packages/evidence/dist/src/canonical-json.js"),
+        ("digest-runtime", "packages/evidence/dist/src/digest.js"),
+        ("identity-runtime", "packages/evidence/dist/src/index.js"),
+    ]
+    materials = []
+    for role, path in paths:
+        digest = sha256_bytes(read_repository_material(path))
+        pinned = PINNED_IDENTITY_RUNTIME_SHA256.get(path)
+        if pinned is not None and digest != pinned:
+            raise EvidenceError(f"shared canonical identity runtime drifted: {path}")
+        materials.append({"role": role, "path": path, "sha256": digest})
+    return {
+        "identity_domain": IDENTITY_DOMAIN,
+        "materials": materials,
+        "private_capture": {
+            "bytes": len(capture_bytes),
+            "sha256": sha256_bytes(capture_bytes),
+            "retention": "operator-controlled-local",
+            "raw_content_published": False,
+        },
+    }
+
+
+def shared_content_address(value: dict[str, Any]) -> str:
+    for path, expected in PINNED_IDENTITY_RUNTIME_SHA256.items():
+        if sha256_bytes(read_repository_material(path)) != expected:
+            raise EvidenceError(f"shared canonical identity runtime drifted: {path}")
+    node = shutil.which("node")
+    if node is None:
+        raise EvidenceError("Node.js is required for shared canonical evidence identity")
+    input_bytes = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    result = subprocess.run(
+        [node, str(IDENTITY_HELPER_PATH)],
+        cwd=ROOT,
+        check=False,
+        input=input_bytes,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={"PATH": os.environ.get("PATH", os.defpath)},
+        timeout=10,
+    )
+    stdout = result.stdout.decode("utf-8", errors="strict")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    if result.returncode != 0 or stderr or not stdout.endswith("\n"):
+        raise EvidenceError(
+            "shared canonical identity helper failed closed"
+            + (f": {stderr.strip()}" if stderr.strip() else "")
+        )
+    identity = stdout.removesuffix("\n")
+    if not re.fullmatch(re.escape(IDENTITY_PREFIX) + r"[0-9a-f]{64}", identity):
+        raise EvidenceError("shared canonical identity helper returned an invalid identity")
+    return identity
+
+
+def compile_evidence(capture: dict[str, Any], capture_bytes: bytes) -> dict[str, Any]:
+    ready, readiness_classification, error_code = derive_readiness(capture)
+    exact_discovery, reported_capability_pass, parity_pass = derive_capability(capture, ready)
+    synthetic = capture["capture_kind"] == "synthetic-test-fixture"
+    capability_pass = synthetic and reported_capability_pass
+    status = "capability_pass" if capability_pass else "ready_unscored" if ready else "not_ready"
+    observation = capture["observation"]
+    visible_results = observation["tool_results"] if synthetic and ready else []
+    visible_resources = observation["resource_results"] if synthetic and ready else []
+    if synthetic and parity_pass:
+        parity = "passed"
+    elif synthetic and any(
+        item["structured_plain_text_parity"] == "failed" for item in visible_results
+    ):
+        parity = "failed"
+    else:
+        parity = "not-tested"
+
+    source = dict(capture["source"])
+    source.update(
+        {
+            "protected_main": False if synthetic else source["protected_main"],
+            "detached_checkout": False if synthetic else source["detached_checkout"],
+            "worktree_clean": False if synthetic else source["worktree_clean"],
+            "production_registration": False,
+            "production_activation": False,
+            "public_endpoint_created": False,
+        }
+    )
+    surface = dict(capture["surface"])
+    surface["production_registration"] = False
+    limitations = (
+        [
+            "Synthetic fixture: this record tests the compiler and is not host evidence.",
+            "A synthetic capability pass makes no claim about a real client or provider.",
+        ]
+        if synthetic
+        else [
+            "This projection compiles a closed capture summary, not an event-level transcript.",
+            "Real host capability remains unscored until a versioned exact-five "
+            "event collector exists.",
+            "Protected-main ancestry is checked against the local origin/main ref, "
+            "not the network.",
+            "This single capture does not complete the independent-host gate.",
+        ]
+    )
+
+    evidence: dict[str, Any] = {
+        "schema": "gis-ai-go.qual-206-strict-modern-host-evidence.v2",
+        "evidence_id": "",
+        "classification": (
+            "synthetic-test-only"
+            if synthetic
+            else "pre-activation-strict-modern-host-summary"
+        ),
+        "status": status,
+        "observed_at": capture["observed_at"],
+        "schema_contract": {
+            "path": "schemas/qual-206-strict-modern-host-evidence.schema.json",
+            "sha256": sha256_bytes(EVIDENCE_SCHEMA_PATH.read_bytes()),
+        },
+        "compiler_contract": compiler_contract(capture_bytes),
+        "lineage": {
+            "relationship": "preserved-separate-not-superseded",
+            "historical_artifacts": [dict(item) for item in HISTORICAL_LINEAGE],
+        },
+        "source": source,
+        "host": capture["host"],
+        "protocol": capture["protocol"],
+        "surface": surface,
+        "readiness": {
+            "outcome": "ready" if ready else "not_ready",
+            "classification": readiness_classification,
+            "initialize_observed": observation["initialize"]["observed"],
+            "initialize_success": observation["initialize"]["outcome"] == "success",
+            "initialized_notification_observed": observation[
+                "initialized_notification_observed"
+            ],
+            "tools_list_observed": observation["tools_list"]["observed"],
+            "tools_list_success": observation["tools_list"]["outcome"] == "success",
+            "host_report": observation["host_report"],
+            "error_code": error_code,
+        },
+        "capability": {
+            "outcome": "passed" if capability_pass else "unscored",
+            "corpus": capture["corpus"],
+            "exact_five_surface_discovered": synthetic and exact_discovery,
+            "exact_five_capability_exercised": capability_pass,
+            "discovered_operations": (
+                observation["tools_list"]["operations"] if synthetic and ready else []
+            ),
+            "discovered_resources": (
+                observation["resources_list"]["resources"] if synthetic and ready else []
+            ),
+            "tool_results": visible_results,
+            "resource_results": visible_resources,
+            "structured_plain_text_parity": parity,
+            "cancellation": (
+                observation["cancellation"]["outcome"] if synthetic else "not-tested"
+            ),
+            "unsupported_traffic": (
+                observation["unsupported_traffic"]["outcome"]
+                if synthetic
+                else "not-tested"
+            ),
+            "model_task_requested": capture["host"]["model_task_requested"],
+        },
+        "telemetry": public_telemetry(capture),
+        "isolation": capture["isolation"],
+        "claims": {
+            "live_host_session": False,
+            "strict_modern_transport_ready": False,
+            "capability_scored": False,
+            "exact_five_host_capability": False,
+            "live_provider_call": False,
+            "remote_http_host": False,
+            "independent_host_gate_completed": False,
+            "production_registration": False,
+            "production_activation": False,
+            "public_deployment": False,
+            "registry_publication": False,
+            "release_acceptance": False,
+            "complete_qual_206": False,
+        },
+        "limitations": limitations,
+        "boundary": BOUNDARY,
+    }
+    identity_core = dict(evidence)
+    del identity_core["evidence_id"]
+    evidence["evidence_id"] = shared_content_address(identity_core)
+    return evidence
+
+
+def assert_public_safe(evidence: dict[str, Any]) -> None:
+    def visit(node: object, parent: str | None = None) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in PUBLIC_FORBIDDEN_KEYS:
+                    raise EvidenceError(f"public evidence contains forbidden field: {key}")
+                visit(value, key)
+        elif isinstance(node, list):
+            for value in node:
+                visit(value, parent)
+
+    visit(evidence)
+    encoded = json.dumps(evidence, ensure_ascii=False, allow_nan=False)
+    match = PUBLIC_FORBIDDEN_PATTERN.search(encoded)
+    if match:
+        raise EvidenceError("public evidence contains a private path, secret or session value")
+
+
+def canonical_output(value: dict[str, Any]) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n").encode(
+        "utf-8"
+    )
+
+
+def write_exclusive_atomic(path: Path, value: bytes) -> None:
+    if not path.is_absolute():
+        raise EvidenceError("output path must be absolute")
+    parent = path.parent
+    if not parent.exists() or not parent.is_dir():
+        raise EvidenceError("output parent directory must already exist")
+    if parent.resolve(strict=True) != parent:
+        raise EvidenceError("output parent must not traverse a symbolic link")
+    parent_metadata = parent.lstat()
+    if (
+        not stat.S_ISDIR(parent_metadata.st_mode)
+        or parent_metadata.st_uid != os.getuid()
+        or stat.S_IMODE(parent_metadata.st_mode) & 0o022
+    ):
+        raise EvidenceError("output parent must be owned by the user and not group/world writable")
+    if path.exists() or path.is_symlink():
+        raise EvidenceError("output already exists; historical evidence is never overwritten")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(
+        os, "O_NOFOLLOW", 0
+    )
+    parent_descriptor = os.open(parent, directory_flags)
+    temporary_name = f".qual-206-host-evidence-{os.getpid()}-{secrets.token_hex(12)}"
+    temporary_descriptor: int | None = None
+    try:
+        if not same_file_state(parent_metadata, os.fstat(parent_descriptor)):
+            raise EvidenceError("output parent changed while it was opened")
+        temporary_descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+        offset = 0
+        while offset < len(value):
+            written = os.write(temporary_descriptor, value[offset:])
+            if written <= 0:
+                raise EvidenceError("output write made no progress")
+            offset += written
+        os.fchmod(temporary_descriptor, 0o644)
+        os.fsync(temporary_descriptor)
+        os.close(temporary_descriptor)
+        temporary_descriptor = None
+        os.link(
+            temporary_name,
+            path.name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+        os.fsync(parent_descriptor)
+    except FileExistsError as error:
+        raise EvidenceError(
+            "output already exists; historical evidence is never overwritten"
+        ) from error
+    finally:
+        if temporary_descriptor is not None:
+            os.close(temporary_descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=parent_descriptor)
+        except FileNotFoundError:
+            pass
+        os.close(parent_descriptor)
+
+
+def compile_capture(capture_root: Path, capture_path: Path, output: Path) -> dict[str, Any]:
+    capture_schema = load_schema(CAPTURE_SCHEMA_PATH)
+    evidence_schema = load_schema(EVIDENCE_SCHEMA_PATH)
+    capture_validator = Draft202012Validator(
+        capture_schema,
+        format_checker=FormatChecker(),
+    )
+    evidence_validator = Draft202012Validator(
+        evidence_schema,
+        format_checker=FormatChecker(),
+    )
+    capture_bytes = read_private_file(
+        capture_root,
+        capture_path,
+        "capture manifest",
+        MAX_CAPTURE_BYTES,
+    )
+    capture = parse_json_bytes(capture_bytes, "capture manifest")
+    assert_capture_has_no_claim_fields(capture)
+    validate(capture_validator, capture, "capture manifest")
+    verify_telemetry_file(capture_root, capture)
+    verify_telemetry_counts(capture)
+    verify_observation(capture)
+    verify_protocol(capture)
+    verify_capture_kind(capture)
+    if capture["capture_kind"] == "observed-host-session":
+        verify_observed_source(capture)
+    evidence = compile_evidence(capture, capture_bytes)
+    assert_public_safe(evidence)
+    validate(evidence_validator, evidence, "compiled public evidence")
+    write_exclusive_atomic(output, canonical_output(evidence))
+    return evidence
+
+
+def parser() -> argparse.ArgumentParser:
+    value = argparse.ArgumentParser(
+        description=(
+            "Compile a private strict MCP 2026-07-28 host capture into bounded, "
+            "deterministic public evidence with a shared RFC 8785 identity."
+        )
+    )
+    value.add_argument("--capture-root", required=True)
+    value.add_argument("--capture", required=True)
+    value.add_argument("--output", required=True)
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = parser().parse_args(argv)
+    try:
+        root = normalise_capture_root(arguments.capture_root)
+        output = Path(arguments.output)
+        if not output.is_absolute():
+            output = (Path.cwd() / output).absolute()
+        evidence = compile_capture(root, Path(arguments.capture), output)
+    except (EvidenceError, OSError, subprocess.SubprocessError) as error:
+        print(f"QUAL-206 evidence compilation failed: {error}", file=sys.stderr)
+        return 2
+    print(
+        f"Wrote {evidence['classification']} {evidence['status']} evidence to {output}.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qual_206_strict_modern_identity.mjs
+++ b/scripts/qual_206_strict_modern_identity.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+import { contentAddress } from "../packages/evidence/dist/src/index.js";
+
+const PREFIX = "gis-ai-go:qual-206-strict-modern-host-evidence";
+const DOMAIN = "gis-ai-go.qual-206-strict-modern-host-evidence.v2";
+
+function fail(message) {
+  process.stderr.write(`QUAL-206 identity failed: ${message}\n`);
+  process.exitCode = 2;
+}
+
+function assertSafeIntegers(value, path = "$") {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new TypeError(`${path} must be an IEEE 754 safe integer`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertSafeIntegers(item, `${path}[${index}]`));
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, item] of Object.entries(value)) {
+      assertSafeIntegers(item, `${path}.${key}`);
+    }
+  }
+}
+
+if (process.argv.length !== 2) {
+  fail("arguments are not accepted");
+} else {
+  try {
+    const input = readFileSync(0, "utf8");
+    const value = JSON.parse(input);
+    if (value === null || Array.isArray(value) || typeof value !== "object") {
+      throw new TypeError("stdin must contain one JSON object");
+    }
+    assertSafeIntegers(value);
+    process.stdout.write(`${contentAddress(PREFIX, DOMAIN, value)}\n`);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : "identity input was rejected");
+  }
+}

--- a/tests/contract/test_qual_206_strict_modern_evidence.py
+++ b/tests/contract/test_qual_206_strict_modern_evidence.py
@@ -1,0 +1,804 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPILER_PATH = ROOT / "scripts" / "compile_qual_206_strict_modern_evidence.py"
+CAPTURE_SCHEMA_PATH = (
+    ROOT / "schemas" / "qual-206-strict-modern-host-capture.schema.json"
+)
+EVIDENCE_SCHEMA_PATH = (
+    ROOT / "schemas" / "qual-206-strict-modern-host-evidence.schema.json"
+)
+EXACT_OPERATIONS = [
+    "catalogue.search",
+    "catalogue.describe",
+    "selection.resolve",
+    "data.query",
+    "evidence.inspect",
+]
+EXACT_RESOURCES = [
+    "catalogue.public",
+    "catalogue.record",
+    "evidence.receipt",
+]
+HISTORICAL_V1_SHA256 = {
+    "evaluation/qual-206-local-evaluation-receipts.v1.json": (
+        "de94f097c6bbd6a9b1cb7f4eddff38933835233254f262f664cddfeaca048088"
+    ),
+    "evaluation/qual-206-local-protocol-evidence-matrix.v1.json": (
+        "ef2ce33b55b7250c00edc0b61067c048d23f374c1ba6fe07af332975cd48c541"
+    ),
+    "tests/interoperability/qual_206_cases.json": (
+        "23ac9bc1a76d524bd0e250b11b9ba321b09e66bd5921f1463f50c150001cd389"
+    ),
+    "tests/interoperability/qual_206_cases_expansion.json": (
+        "e70c21b371593c2dae863999745f1fecf2152ff80f0b025a1ccbec135b47f4af"
+    ),
+    "tests/interoperability/evidence/chatgpt-tunnel-2026-08-20.json": (
+        "5194129281837f85fef65f3d975522140570a3ecdd85bd836bc03037d434b568"
+    ),
+    "tests/interoperability/evidence/codex-cli-2026-08-20.json": (
+        "1507e1889423444867353adf520308be10bb502d07a8c0cb4c6bf70d20dae127"
+    ),
+    "tests/interoperability/evidence/independent-host-readiness-2026-08-20.json": (
+        "9cb4e569d7a1be9399a700f5d628ae7ace22318be9c7fc3cd055de326c5f7fbe"
+    ),
+    "tests/interoperability/evidence/legacy-fallback-exploratory-2026-08-20.json": (
+        "5d2c22c17b7a0c65bd3957f9d23057ab7a5d522d223ed432642250b997823537"
+    ),
+    (
+        "tests/interoperability/evidence/"
+        "claude-code-legacy-stdio-readiness-2026-08-23.json"
+    ): "a3d40e2013095baf977bad336366c0fb429a05b6a5a267c3e069595e4cdb1a6b",
+    (
+        "tests/interoperability/evidence/"
+        "claude-code-2.1.241-stdio-observation-2026-08-24.json"
+    ): "d2cd72b7f16a0bafd8a7190b87b14f150b7fa975f6d70f5e779eb9ddf5f92478",
+    "schemas/qual-206-local-evaluation-receipt-set.schema.json": (
+        "9584de9fe7531457b7b83eb7f9102ee897e2cae61a5fe1f5f68b0f6b775232d9"
+    ),
+    "schemas/qual-206-local-protocol-evidence-matrix.schema.json": (
+        "baa856f4c0d28a497360c9af0526e6e0b3aa6698f19e1857549e988f48f4931a"
+    ),
+    "schemas/qual-206-evaluation-expansion.schema.json": (
+        "1843351626b6f96cb118e575388606daa0d6f60b22b28b92d9655a14873caf8b"
+    ),
+    "schemas/qual-206-legacy-stdio-readiness.schema.json": (
+        "5ce73d3d45c762112ac932407000b4379d07d92a9e54808227cd72e6050fd02a"
+    ),
+    "schemas/qual-206-claude-code-stdio-observation.schema.json": (
+        "78b9a8071a6954028576f397c98dd0fc4b87dddbaf72654f6459407b280e2a9b"
+    ),
+}
+
+
+def load_compiler() -> Any:
+    specification = importlib.util.spec_from_file_location(
+        "qual_206_strict_modern_evidence_compiler",
+        COMPILER_PATH,
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("could not load the QUAL-206 evidence compiler")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError(f"{path} must contain one JSON object")
+    return value
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def assert_contract_objects_are_closed(
+    test_case: unittest.TestCase,
+    node: object,
+    path: str = "$",
+) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            test_case.assertIs(
+                node.get("additionalProperties"),
+                False,
+                f"{path} must reject unknown properties",
+            )
+        for key, value in node.items():
+            assert_contract_objects_are_closed(test_case, value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            assert_contract_objects_are_closed(test_case, value, f"{path}[{index}]")
+
+
+def nested_field_names(node: object) -> set[str]:
+    names: set[str] = set()
+    if isinstance(node, dict):
+        names.update(node)
+        for value in node.values():
+            names.update(nested_field_names(value))
+    elif isinstance(node, list):
+        for value in node:
+            names.update(nested_field_names(value))
+    return names
+
+
+def make_capture(state: str = "capability_pass") -> dict[str, Any]:
+    if state not in {"not_ready", "ready_unscored", "capability_pass"}:
+        raise ValueError(f"unknown fixture state: {state}")
+    ready = state != "not_ready"
+    capability = state == "capability_pass"
+    digest = "1" * 64
+    capture: dict[str, Any] = {
+        "schema": "gis-ai-go.qual-206-strict-modern-host-capture.v1",
+        "capture_kind": "synthetic-test-fixture",
+        "observed_at": "2026-08-25T09:00:00Z",
+        "source": {
+            "repository": "chris-page-gov/gis-ai-go",
+            "commit": "0" * 40,
+            "tree": "0" * 40,
+            "protected_main": False,
+            "detached_checkout": False,
+            "worktree_clean": False,
+            "product_version": "0.2.0",
+            "materials": [
+                {
+                    "role": "source",
+                    "path": "packages/evidence/src/index.ts",
+                    "sha256": digest,
+                }
+            ],
+        },
+        "host": {
+            "name": "synthetic-test-host",
+            "version": "1.0.0",
+            "platform": "darwin",
+            "architecture": "arm64",
+            "identity": {
+                "kind": "package",
+                "name": "synthetic-test-host",
+                "version": "1.0.0",
+                "sha256": "2" * 64,
+            },
+            "probe": "model-task" if capability else "mcp-list",
+            "model_authentication_supplied": capability,
+            "model_task_requested": capability,
+        },
+        "protocol": {
+            "target_version": "2026-07-28",
+            "target_source_id": "S-MCP-SPEC",
+            "client_requested_version": "2026-07-28",
+            "server_supported_versions": ["2026-07-28"],
+            "negotiated_version": "2026-07-28" if ready else None,
+        },
+        "surface": {
+            "assembly": "candidate-unregistered-exact-five",
+            "transport": "stdio",
+            "operations": EXACT_OPERATIONS,
+            "resources": EXACT_RESOURCES,
+        },
+        "corpus": {
+            "base": {
+                "path": "tests/interoperability/qual_206_cases.json",
+                "sha256": HISTORICAL_V1_SHA256[
+                    "tests/interoperability/qual_206_cases.json"
+                ],
+            },
+            "expansion": {
+                "path": "tests/interoperability/qual_206_cases_expansion.json",
+                "sha256": HISTORICAL_V1_SHA256[
+                    "tests/interoperability/qual_206_cases_expansion.json"
+                ],
+            },
+            "case_ids": [f"QUAL-206-HOST-{index:03d}" for index in range(1, 11)],
+        },
+        "isolation": {
+            "temporary_profile": True,
+            "profile_root_mode": "0700",
+            "primary_configuration_mode": "0600",
+            "normal_profile_used": False,
+            "normal_profile_mutation_observed": False,
+            "credential_variables_removed_count": 5,
+            "mcp_child_environment_allowlisted": True,
+            "credential_value_pattern_matches": 0,
+            "remaining_processes_after_cleanup": 0,
+            "raw_host_logs_published": False,
+            "os_network_isolation_enforced": True,
+            "provider_egress_guard_exercised": True,
+        },
+        "telemetry": {
+            "schema": "gis-ai-go.qual-206-host-capture-summary.v1",
+            "retained_private": {
+                "path": "telemetry.json",
+                "bytes": 1,
+                "sha256": "0" * 64,
+                "mode": "0600",
+            },
+            "event_count": 25 if capability else 9 if ready else 4,
+            "session_start_count": 1,
+            "request_count": 11 if capability else 3 if ready else 1,
+            "notification_count": 1 if ready else 0,
+            "response_count": 11 if capability else 3 if ready else 1,
+            "session_end_count": 1,
+            "anomaly_count": 0,
+            "malformed_frame_count": 0,
+            "non_json_frame_count": 0,
+            "truncated_frame_count": 0,
+            "server_stderr_count": 0,
+            "pending_request_count": 0,
+            "exit_code": 0 if ready else 1,
+            "raw_content_published": False,
+        },
+        "observation": {
+            "host_report": "connected" if ready else "failed-to-connect",
+            "initialize": {
+                "observed": True,
+                "outcome": "success" if ready else "error",
+                "error_code": None if ready else -32000,
+            },
+            "initialized_notification_observed": ready,
+            "tools_list": {
+                "observed": ready,
+                "outcome": "success" if ready else "not-observed",
+                "operations": EXACT_OPERATIONS if ready else [],
+                "error_code": None,
+            },
+            "resources_list": {
+                "observed": ready,
+                "outcome": "success" if ready else "not-observed",
+                "resources": EXACT_RESOURCES if ready else [],
+                "error_code": None,
+            },
+            "tool_results": [],
+            "resource_results": [],
+            "cancellation": {"observed": False, "outcome": "not-tested"},
+            "unsupported_traffic": {"observed": False, "outcome": "not-tested"},
+        },
+    }
+    if capability:
+        capture["observation"]["tool_results"] = [
+            {
+                "operation": operation,
+                "outcome": "success",
+                "structured_plain_text_parity": "passed",
+                "receipt_present": True,
+                "request_sha256": f"{index:x}" * 64,
+                "response_sha256": f"{index + 5:x}" * 64,
+            }
+            for index, operation in enumerate(EXACT_OPERATIONS, start=1)
+        ]
+        capture["observation"]["resource_results"] = [
+            {
+                "resource": resource,
+                "outcome": "success",
+                "response_sha256": f"{index + 10:x}" * 64,
+            }
+            for index, resource in enumerate(EXACT_RESOURCES, start=1)
+        ]
+        capture["observation"]["cancellation"] = {
+            "observed": True,
+            "outcome": "passed",
+        }
+        capture["observation"]["unsupported_traffic"] = {
+            "observed": True,
+            "outcome": "passed",
+        }
+    return capture
+
+
+def make_observed_source_capture() -> tuple[dict[str, Any], dict[str, bytes]]:
+    capture = make_capture("ready_unscored")
+    capture["capture_kind"] = "observed-host-session"
+    capture["host"].update(
+        {
+            "name": "claude-code",
+            "identity": {
+                "kind": "package",
+                "name": "@anthropic-ai/claude-code",
+                "version": "2.1.241",
+                "sha256": "3" * 64,
+            },
+        }
+    )
+    blobs: dict[str, bytes] = {}
+    materials = []
+    for role, path in sorted(COMPILER.REQUIRED_OBSERVED_MATERIALS):
+        content = f"{role}:{path}\n".encode()
+        blobs[path] = content
+        materials.append({"role": role, "path": path, "sha256": sha256_bytes(content)})
+    for reference in (capture["corpus"]["base"], capture["corpus"]["expansion"]):
+        blobs[reference["path"]] = (ROOT / reference["path"]).read_bytes()
+    capture["source"].update(
+        {
+            "commit": "a" * 40,
+            "tree": "b" * 40,
+            "protected_main": True,
+            "detached_checkout": True,
+            "worktree_clean": True,
+            "materials": materials,
+        }
+    )
+    return capture, blobs
+
+
+class PrivateCapture:
+    def __init__(self, test_case: unittest.TestCase, state: str = "capability_pass"):
+        self.test_case = test_case
+        self.temporary = tempfile.TemporaryDirectory(prefix="qual-206-strict-test-")
+        self.root = Path(self.temporary.name)
+        self.root.chmod(0o700)
+        self.capture_path = self.root / "capture.json"
+        self.telemetry_path = self.root / "telemetry.json"
+        self.output_path = self.root / "public-evidence.json"
+        self.capture = make_capture(state)
+        self.write_telemetry(b'{"private":"telemetry"}\n')
+        self.write_capture()
+
+    def write_telemetry(self, value: bytes) -> None:
+        self.telemetry_path.write_bytes(value)
+        self.telemetry_path.chmod(0o600)
+        retained = self.capture["telemetry"]["retained_private"]
+        retained["bytes"] = len(value)
+        retained["sha256"] = sha256_bytes(value)
+
+    def write_capture(self, raw: bytes | None = None) -> None:
+        value = (
+            raw
+            if raw is not None
+            else (json.dumps(self.capture, ensure_ascii=False, indent=2) + "\n").encode()
+        )
+        self.capture_path.write_bytes(value)
+        self.capture_path.chmod(0o600)
+
+    def compile(self) -> dict[str, Any]:
+        return COMPILER.compile_capture(self.root, self.capture_path, self.output_path)
+
+    def close(self) -> None:
+        self.temporary.cleanup()
+
+
+COMPILER = load_compiler()
+
+
+class Qual206StrictModernEvidenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.capture_schema = load_json(CAPTURE_SCHEMA_PATH)
+        cls.evidence_schema = load_json(EVIDENCE_SCHEMA_PATH)
+        cls.capture_validator = Draft202012Validator(
+            cls.capture_schema,
+            format_checker=FormatChecker(),
+        )
+        cls.evidence_validator = Draft202012Validator(
+            cls.evidence_schema,
+            format_checker=FormatChecker(),
+        )
+
+    def fixture(self, state: str = "capability_pass") -> PrivateCapture:
+        fixture = PrivateCapture(self, state)
+        self.addCleanup(fixture.close)
+        return fixture
+
+    def assert_valid_public_evidence(self, evidence: dict[str, Any]) -> None:
+        errors = sorted(
+            self.evidence_validator.iter_errors(evidence),
+            key=lambda error: [str(part) for part in error.absolute_path],
+        )
+        self.assertEqual(
+            [],
+            [
+                f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+                for error in errors
+            ],
+        )
+
+    def assert_compile_rejected(self, fixture: PrivateCapture, pattern: str) -> None:
+        with self.assertRaisesRegex((COMPILER.EvidenceError, OSError), pattern):
+            fixture.compile()
+
+    def verify_mocked_observed_source(
+        self,
+        capture: dict[str, Any],
+        blobs: dict[str, bytes],
+        *,
+        ancestor_returncode: int = 0,
+    ) -> None:
+        commit = capture["source"]["commit"]
+
+        def fake_git_output(*arguments: str) -> bytes:
+            if arguments == ("rev-parse", f"{commit}^{{tree}}"):
+                return b"b" * 40 + b"\n"
+            if arguments == ("rev-parse", "--verify", "refs/remotes/origin/main"):
+                return b"c" * 40 + b"\n"
+            if len(arguments) == 2 and arguments[0] == "show":
+                prefix = f"{commit}:"
+                self.assertTrue(arguments[1].startswith(prefix))
+                return blobs[arguments[1][len(prefix) :]]
+            raise AssertionError(f"unexpected git call: {arguments!r}")
+
+        with (
+            mock.patch.object(COMPILER, "git_output", side_effect=fake_git_output),
+            mock.patch.object(
+                COMPILER.subprocess,
+                "run",
+                return_value=SimpleNamespace(returncode=ancestor_returncode),
+            ),
+            mock.patch.object(
+                COMPILER,
+                "read_repository_material",
+                side_effect=lambda path: blobs[path],
+            ),
+        ):
+            COMPILER.verify_observed_source(capture)
+
+    def test_schemas_are_valid_and_all_object_contracts_are_closed(self) -> None:
+        for schema in (self.capture_schema, self.evidence_schema):
+            Draft202012Validator.check_schema(schema)
+            assert_contract_objects_are_closed(self, schema)
+
+    def test_synthetic_not_ready_compiles_fail_closed_public_evidence(self) -> None:
+        fixture = self.fixture("not_ready")
+        evidence = fixture.compile()
+        self.assertEqual(evidence["status"], "not_ready")
+        self.assertEqual(evidence["readiness"]["outcome"], "not_ready")
+        self.assertEqual(evidence["capability"]["outcome"], "unscored")
+        self.assert_valid_public_evidence(evidence)
+
+    def test_synthetic_ready_unscored_compiles_without_capability_claim(self) -> None:
+        fixture = self.fixture("ready_unscored")
+        evidence = fixture.compile()
+        self.assertEqual(evidence["status"], "ready_unscored")
+        self.assertEqual(evidence["readiness"]["outcome"], "ready")
+        self.assertEqual(evidence["capability"]["outcome"], "unscored")
+        self.assertFalse(evidence["claims"]["strict_modern_transport_ready"])
+        self.assert_valid_public_evidence(evidence)
+
+    def test_synthetic_capability_pass_exercises_compiler_without_real_claims(self) -> None:
+        fixture = self.fixture("capability_pass")
+        evidence = fixture.compile()
+        self.assertEqual(evidence["classification"], "synthetic-test-only")
+        self.assertEqual(evidence["status"], "capability_pass")
+        self.assertEqual(evidence["capability"]["outcome"], "passed")
+        self.assertTrue(evidence["capability"]["exact_five_capability_exercised"])
+        self.assertFalse(any(evidence["claims"].values()))
+        self.assert_valid_public_evidence(evidence)
+
+    def test_observed_summary_is_capped_at_ready_unscored_and_all_host_claims_false(self) -> None:
+        capture = make_capture("capability_pass")
+        capture["capture_kind"] = "observed-host-session"
+        capture["host"].update(
+            {
+                "name": "claude-code",
+                "identity": {
+                    "kind": "package",
+                    "name": "@anthropic-ai/claude-code",
+                    "version": "2.1.241",
+                    "sha256": "3" * 64,
+                },
+            }
+        )
+        capture_bytes = (json.dumps(capture, separators=(",", ":")) + "\n").encode()
+        evidence = COMPILER.compile_evidence(capture, capture_bytes)
+        self.assertEqual(
+            evidence["classification"],
+            "pre-activation-strict-modern-host-summary",
+        )
+        self.assertEqual(evidence["status"], "ready_unscored")
+        self.assertEqual(evidence["capability"]["outcome"], "unscored")
+        for claim in (
+            "live_host_session",
+            "strict_modern_transport_ready",
+            "capability_scored",
+            "exact_five_host_capability",
+            "remote_http_host",
+        ):
+            self.assertFalse(evidence["claims"][claim], claim)
+        self.assert_valid_public_evidence(evidence)
+
+    def test_observed_source_binding_accepts_only_the_closed_verified_inventory(self) -> None:
+        capture, blobs = make_observed_source_capture()
+        self.verify_mocked_observed_source(capture, blobs)
+
+        mutations: list[tuple[str, Any, str, int]] = [
+            (
+                "tree",
+                lambda value, _: value["source"].update({"tree": "d" * 40}),
+                "source tree does not match",
+                0,
+            ),
+            (
+                "ancestry",
+                lambda _value, _blobs: None,
+                "not accepted protected-main history",
+                1,
+            ),
+            (
+                "missing",
+                lambda value, _: value["source"]["materials"].pop(),
+                "inventory is not closed",
+                0,
+            ),
+            (
+                "duplicate",
+                lambda value, _: value["source"]["materials"].append(
+                    copy.deepcopy(value["source"]["materials"][0])
+                ),
+                "duplicate source material",
+                0,
+            ),
+            (
+                "tracked-digest",
+                lambda value, _: value["source"]["materials"][0].update(
+                    {"sha256": "0" * 64}
+                ),
+                "source material digest mismatch",
+                0,
+            ),
+            (
+                "compiled-digest",
+                lambda value, _: next(
+                    item
+                    for item in value["source"]["materials"]
+                    if item["role"] == "compiled"
+                ).update({"sha256": "0" * 64}),
+                "compiled material digest mismatch",
+                0,
+            ),
+            (
+                "corpus",
+                lambda value, _: value["corpus"]["base"].update(
+                    {"sha256": "0" * 64}
+                ),
+                "corpus digest mismatch",
+                0,
+            ),
+        ]
+        for label, mutate, pattern, ancestor_returncode in mutations:
+            with self.subTest(label=label):
+                changed, changed_blobs = make_observed_source_capture()
+                mutate(changed, changed_blobs)
+                with self.assertRaisesRegex(COMPILER.EvidenceError, pattern):
+                    self.verify_mocked_observed_source(
+                        changed,
+                        changed_blobs,
+                        ancestor_returncode=ancestor_returncode,
+                    )
+
+    def test_shared_rfc8785_identity_is_deterministic_and_materially_bound(self) -> None:
+        expected_vector = (
+            "gis-ai-go:qual-206-strict-modern-host-evidence:sha256:"
+            "7651a65e4c2ce6e019c2916850adc012cf5b7748c7139a5ac5776f7ffe67831d"
+        )
+        self.assertEqual(
+            COMPILER.shared_content_address({"z": 1, "a": "é"}),
+            expected_vector,
+        )
+        self.assertEqual(
+            COMPILER.shared_content_address({"a": "é", "z": 1}),
+            expected_vector,
+        )
+        for unsafe_integer in (9007199254740992, 9007199254740993):
+            with self.subTest(unsafe_integer=unsafe_integer):
+                with self.assertRaisesRegex(
+                    COMPILER.EvidenceError,
+                    "shared canonical identity helper failed closed",
+                ):
+                    COMPILER.shared_content_address({"error_code": unsafe_integer})
+        capture = make_capture("ready_unscored")
+        capture_bytes = (json.dumps(capture, separators=(",", ":")) + "\n").encode()
+        first = COMPILER.compile_evidence(copy.deepcopy(capture), capture_bytes)
+        second = COMPILER.compile_evidence(copy.deepcopy(capture), capture_bytes)
+        self.assertEqual(first["evidence_id"], second["evidence_id"])
+        changed = copy.deepcopy(capture)
+        changed["observed_at"] = "2026-08-25T09:00:01Z"
+        changed_bytes = (json.dumps(changed, separators=(",", ":")) + "\n").encode()
+        third = COMPILER.compile_evidence(changed, changed_bytes)
+        self.assertNotEqual(first["evidence_id"], third["evidence_id"])
+
+    def test_public_projection_excludes_private_paths_and_telemetry_identity(self) -> None:
+        fixture = self.fixture("capability_pass")
+        private_digest = fixture.capture["telemetry"]["retained_private"]["sha256"]
+        evidence = fixture.compile()
+        public = json.dumps(evidence, ensure_ascii=False, sort_keys=True)
+        retained = evidence["telemetry"]["retained_private"]
+        self.assertEqual(
+            set(retained),
+            {
+                "retention",
+                "raw_content_published",
+                "digest_published",
+                "byte_count_published",
+            },
+        )
+        self.assertNotIn(str(fixture.root), public)
+        self.assertNotIn("telemetry.json", public)
+        self.assertNotIn(private_digest, public)
+        self.assertFalse(
+            {"arguments", "environment", "headers", "raw_payload", "raw_result"}
+            & nested_field_names(evidence)
+        )
+        self.assert_valid_public_evidence(evidence)
+
+    def test_existing_output_is_never_overwritten(self) -> None:
+        fixture = self.fixture("ready_unscored")
+        first = fixture.compile()
+        first_bytes = fixture.output_path.read_bytes()
+        self.assertEqual(first["status"], "ready_unscored")
+        self.assert_compile_rejected(fixture, "already exists|never overwritten")
+        self.assertEqual(fixture.output_path.read_bytes(), first_bytes)
+
+    def test_output_parent_symlink_is_rejected(self) -> None:
+        fixture = self.fixture("ready_unscored")
+        actual = fixture.root / "actual-output"
+        actual.mkdir(mode=0o700)
+        link = fixture.root / "linked-output"
+        link.symlink_to(actual.name, target_is_directory=True)
+        fixture.output_path = link / "public-evidence.json"
+        self.assert_compile_rejected(fixture, "must not traverse a symbolic link")
+
+    def test_final_capture_symlink_is_rejected(self) -> None:
+        fixture = self.fixture()
+        target = fixture.root / "capture-target.json"
+        fixture.capture_path.rename(target)
+        fixture.capture_path.symlink_to(target.name)
+        self.assert_compile_rejected(
+            fixture,
+            "symbolic link|Too many levels|Not a directory",
+        )
+
+    def test_parent_symlink_in_capture_path_is_rejected(self) -> None:
+        fixture = self.fixture()
+        actual = fixture.root / "actual"
+        actual.mkdir(mode=0o700)
+        nested_capture = actual / "capture.json"
+        nested_capture.write_bytes(fixture.capture_path.read_bytes())
+        nested_capture.chmod(0o600)
+        link = fixture.root / "linked"
+        link.symlink_to(actual.name, target_is_directory=True)
+        fixture.capture_path = link / "capture.json"
+        self.assert_compile_rejected(
+            fixture,
+            "symbolic link|Too many levels|Not a directory",
+        )
+
+    def test_hardlinked_capture_is_rejected(self) -> None:
+        fixture = self.fixture()
+        os.link(fixture.capture_path, fixture.root / "capture-backup.json")
+        self.assert_compile_rejected(fixture, "exactly one hard link")
+
+    def test_non_owner_only_capture_mode_is_rejected(self) -> None:
+        fixture = self.fixture()
+        fixture.capture_path.chmod(0o640)
+        self.assert_compile_rejected(fixture, "owner-only mode 0600")
+
+    def test_fifo_capture_is_rejected_without_blocking(self) -> None:
+        fixture = self.fixture()
+        fixture.capture_path.unlink()
+        os.mkfifo(fixture.capture_path, mode=0o600)
+        self.assert_compile_rejected(fixture, "must be a regular file")
+
+    def test_oversized_capture_is_rejected_before_parsing(self) -> None:
+        fixture = self.fixture()
+        fixture.capture_path.write_bytes(b"x" * (COMPILER.MAX_CAPTURE_BYTES + 1))
+        self.assert_compile_rejected(fixture, "size is outside the accepted boundary")
+
+    def test_duplicate_json_object_key_is_rejected(self) -> None:
+        fixture = self.fixture()
+        fixture.write_capture(b'{"schema":"first","schema":"second"}\n')
+        self.assert_compile_rejected(fixture, "duplicate JSON object key: schema")
+
+    def test_non_standard_json_number_is_rejected(self) -> None:
+        fixture = self.fixture()
+        fixture.write_capture(b'{"schema":"first","event_count":NaN}\n')
+        self.assert_compile_rejected(fixture, "non-standard JSON number: NaN")
+
+    def test_malformed_utf8_is_rejected(self) -> None:
+        fixture = self.fixture()
+        fixture.write_capture(b"\xff\n")
+        self.assert_compile_rejected(fixture, "is not UTF-8")
+
+    def test_escaped_surrogate_is_rejected_before_canonical_identity(self) -> None:
+        fixture = self.fixture()
+        fixture.write_capture(b'{"schema":"\\ud800"}\n')
+        self.assert_compile_rejected(fixture, "surrogate code point")
+
+    def test_public_privacy_guard_and_real_capability_schema_fail_closed(self) -> None:
+        fixture = self.fixture("capability_pass")
+        evidence = fixture.compile()
+        leaked = copy.deepcopy(evidence)
+        leaked["host"]["version"] = "ghp_abcdefgh12345678"
+        with self.assertRaisesRegex(COMPILER.EvidenceError, "private path, secret"):
+            COMPILER.assert_public_safe(leaked)
+
+        forged = copy.deepcopy(evidence)
+        forged["classification"] = "pre-activation-strict-modern-host-summary"
+        errors = list(self.evidence_validator.iter_errors(forged))
+        self.assertTrue(errors, "real-host capability_pass must be schema-invalid")
+
+    def test_private_telemetry_digest_and_count_mismatches_are_rejected(self) -> None:
+        with self.subTest("digest"):
+            fixture = self.fixture()
+            fixture.capture["telemetry"]["retained_private"]["sha256"] = "f" * 64
+            fixture.write_capture()
+            self.assert_compile_rejected(fixture, "telemetry digest does not match")
+        with self.subTest("closed counters"):
+            fixture = self.fixture()
+            fixture.capture["telemetry"]["event_count"] += 1
+            fixture.write_capture()
+            self.assert_compile_rejected(fixture, "event_count does not match")
+
+    def test_ready_summary_requires_matching_protocol_host_and_supporting_events(self) -> None:
+        with self.subTest("protocol"):
+            fixture = self.fixture("ready_unscored")
+            fixture.capture["protocol"]["client_requested_version"] = "2025-11-25"
+            fixture.write_capture()
+            self.assert_compile_rejected(
+                fixture,
+                "negotiated protocol must equal the client-requested version",
+            )
+        with self.subTest("host"):
+            fixture = self.fixture("ready_unscored")
+            fixture.capture["observation"]["host_report"] = "failed-to-connect"
+            fixture.write_capture()
+            evidence = fixture.compile()
+            self.assertEqual(evidence["status"], "not_ready")
+            self.assertEqual(evidence["readiness"]["outcome"], "not_ready")
+        with self.subTest("counters"):
+            fixture = self.fixture("ready_unscored")
+            telemetry = fixture.capture["telemetry"]
+            telemetry["request_count"] = 0
+            telemetry["response_count"] = 0
+            telemetry["event_count"] = 3
+            fixture.write_capture()
+            self.assert_compile_rejected(
+                fixture,
+                "request_count cannot support the observed stages",
+            )
+
+    def test_historical_v1_artifacts_remain_byte_exact(self) -> None:
+        self.assertEqual(
+            COMPILER.HISTORICAL_LINEAGE,
+            [
+                {"path": path, "sha256": HISTORICAL_V1_SHA256[path]}
+                for path in (
+                    "schemas/qual-206-claude-code-stdio-observation.schema.json",
+                    (
+                        "tests/interoperability/evidence/"
+                        "claude-code-2.1.241-stdio-observation-2026-08-24.json"
+                    ),
+                    "schemas/qual-206-legacy-stdio-readiness.schema.json",
+                    (
+                        "tests/interoperability/evidence/"
+                        "claude-code-legacy-stdio-readiness-2026-08-23.json"
+                    ),
+                    "tests/interoperability/qual_206_cases.json",
+                )
+            ],
+        )
+        for relative_path, expected in HISTORICAL_V1_SHA256.items():
+            with self.subTest(path=relative_path):
+                self.assertEqual(
+                    sha256_bytes((ROOT / relative_path).read_bytes()),
+                    expected,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -52,3 +52,10 @@ The historical records continue to bind the unchanged ten-case
 [`qual_206_cases_expansion.json`](../qual_206_cases_expansion.json) is design-time,
 non-live and unscored; it is not a runtime input to those sessions and does not
 upgrade, relabel or replace their results.
+
+The additive strict-modern capture and public-evidence contracts are described in
+the
+[`QUAL-206 strict-modern evidence preparation` runbook](../../../docs/operations/QUAL-206_STRICT_MODERN_EVIDENCE.md).
+They retain private telemetry locally and compile only a minimised projection. The
+current summary-level contract cannot score a real host capability pass; that
+requires the separately versioned event-level collector described in the runbook.


### PR DESCRIPTION
## Outcome

Add a fail-closed preparatory compiler for bounded MCP `2026-07-28` host-capture
summaries. It turns a private owner-controlled capture into a minimised public
projection with source binding and RFC 8785 content identity.

This is additive to the accepted QUAL-206 evidence. It does not replace or upgrade
the earlier Claude, Codex, ChatGPT or legacy results.

## Assurance boundary

- Real-host summaries can only be `not_ready` or `ready_unscored`.
- Only a labelled synthetic fixture can exercise `capability_pass`.
- Raw telemetry content, path, digest and byte count remain private.
- The observed-source inventory is closed and checked against the stated commit;
  generated identity-runtime files are pinned byte-for-byte.
- Provider, production, registry, deployment, activation and release claims are
  always false.
- A separate versioned event-level collector and independent-host capture remain
  necessary before real-host capability acceptance.

## Verification

- Independent P0-P2 review: no remaining findings.
- Focused contract suite: 24 tests passed.
- Full `pnpm run check` passed on the final tree, including:
  - 210 gateway tests and 20 interoperability checks;
  - 333 repository Python tests and 22 execution-service tests;
  - non-root, read-only, network-none execution-container acceptance;
  - 27 real-browser tests;
  - two byte-identical locked release builds;
  - 73 schemas and 102 records validated;
  - 432 local links and 183 research hashes checked;
  - secret scan, diagram rendering and a 169-component CycloneDX SBOM.

## Explicit non-actions

No live host, provider call, public endpoint, deployment, registry publication,
activation, version change, tag or release is part of this pull request.
