### PR TITLE
fix(qual-206): accept safe Claude SIGINT disposal

### DIFF
--- a/changelog.d/QUAL-206-claude-sigint-close.fixed.md
+++ b/changelog.d/QUAL-206-claude-sigint-close.fixed.md
@@ -1,0 +1,4 @@
+- Accept Claude Code's empirically observed `SIGINT` disposal only after a complete,
+  contract-valid MCP `2026-07-28` exchange, while retaining fail-closed handling for
+  early signals and the existing bounded child-shutdown and offline-verification
+  controls.

--- a/docs/operations/QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md
+++ b/docs/operations/QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md
@@ -60,6 +60,14 @@ call or third process. `capability_scored`, `host_capability` and
 `source_binding_ready` remain false constants. This proves bounded transport
 readiness only.
 
+Claude may dispose of a completed observer with `SIGTERM` or `SIGINT`. The
+observer accepts either signal only after every observed request has one matched,
+contract-valid response claiming MCP `2026-07-28`; it then applies the same
+sub-second child shutdown boundary. A signal before that point remains an anomaly
+and fails closed. The first failed-closed exact-main attempt established this
+distinction: the discovery child used `SIGTERM`, while the completed modern
+`tools/list` child used `SIGINT`.
+
 ## Repository assurance
 
 Build the gateway contracts, then run the observer and independent verifier tests:

--- a/schemas/qual-206-claude-composite-host-event-v1.schema.json
+++ b/schemas/qual-206-claude-composite-host-event-v1.schema.json
@@ -149,7 +149,14 @@
     "runtime_materials_stable": {"type": "boolean"},
     "source_checkout_stable": {"type": "boolean"},
     "closure_stimulus": {
-      "enum": ["stdin-eof", "sigterm", "stdin-eof-and-sigterm", "none"]
+      "enum": [
+        "stdin-eof",
+        "sigint",
+        "sigterm",
+        "stdin-eof-and-sigint",
+        "stdin-eof-and-sigterm",
+        "none"
+      ]
     },
     "request_count": {"$ref": "#/$defs/nonNegativeSafeInteger"},
     "response_count": {"$ref": "#/$defs/nonNegativeSafeInteger"},

--- a/scripts/qual_206_claude_stdio_observer.mjs
+++ b/scripts/qual_206_claude_stdio_observer.mjs
@@ -713,7 +713,7 @@ function startObserver(options) {
   let responseOrdinal = 0;
   let sawLegacyInitialize = false;
   let hostInputEnded = false;
-  let hostSigtermObserved = false;
+  let hostCloseSignal = null;
   let fatalError = null;
   let closed = false;
 
@@ -1272,10 +1272,13 @@ function startObserver(options) {
         requestContexts.every(({ protocolClaim }) => protocolClaim === PROTOCOL_TARGET) &&
         responseOrdinal === requestOrdinal && responseContracts.length === requestOrdinal &&
         responseContracts.every(Boolean);
+      const hostSignalStimulus = hostCloseSignal === "SIGINT"
+        ? "sigint"
+        : hostCloseSignal === "SIGTERM" ? "sigterm" : null;
       const basePassed = code === 0 && signal === null && stderrEventCount === 0 &&
         streamsGraceful && auditComplete && runtimeMaterialsStable && sourceStable &&
         (counts.get("anomaly") ?? 0) === 0 &&
-        (hostInputEnded || hostSigtermObserved);
+        (hostInputEnded || hostSignalStimulus !== null);
       const sessionProfile = basePassed && probe
         ? "negotiation-probe"
         : basePassed && modern ? "modern-session" : "invalid";
@@ -1290,9 +1293,9 @@ function startObserver(options) {
         source_binding_ready: false,
         runtime_materials_stable: runtimeMaterialsStable,
         source_checkout_stable: sourceStable,
-        closure_stimulus: hostInputEnded && hostSigtermObserved
-          ? "stdin-eof-and-sigterm"
-          : hostSigtermObserved ? "sigterm" : hostInputEnded ? "stdin-eof" : "none",
+        closure_stimulus: hostInputEnded && hostSignalStimulus !== null
+          ? `stdin-eof-and-${hostSignalStimulus}`
+          : hostSignalStimulus ?? (hostInputEnded ? "stdin-eof" : "none"),
         exit_code: code,
         signal,
         request_count: requestOrdinal,
@@ -1362,9 +1365,8 @@ function startObserver(options) {
     }
   });
 
-  process.once("SIGINT", () => captureFatal("observer-signal"));
-  process.on("SIGTERM", () => {
-    if (hostSigtermObserved) {
+  function handleHostCloseSignal(signal) {
+    if (hostCloseSignal !== null) {
       gracefulChildCloser.begin();
       return;
     }
@@ -1377,7 +1379,7 @@ function startObserver(options) {
       captureFatal("observer-signal");
       return;
     }
-    hostSigtermObserved = true;
+    hostCloseSignal = signal;
     try {
       endStream("host-stdin", inputTap, true);
       process.stdin.pause();
@@ -1386,7 +1388,10 @@ function startObserver(options) {
     } catch {
       captureFatal("safe-host-close-failure");
     }
-  });
+  }
+
+  process.on("SIGINT", () => handleHostCloseSignal("SIGINT"));
+  process.on("SIGTERM", () => handleHostCloseSignal("SIGTERM"));
   return child;
 }
 

--- a/scripts/verify_qual_206_claude_composite_observation.py
+++ b/scripts/verify_qual_206_claude_composite_observation.py
@@ -535,7 +535,13 @@ def _require_clean_session_end(end: dict[str, Any]) -> None:
         or end["runtime_materials_stable"] is not True
         or end["source_checkout_stable"] is not True
         or end["closure_stimulus"]
-        not in {"stdin-eof", "sigterm", "stdin-eof-and-sigterm"}
+        not in {
+            "stdin-eof",
+            "sigint",
+            "sigterm",
+            "stdin-eof-and-sigint",
+            "stdin-eof-and-sigterm",
+        }
         or end["temporary_state_removed"] is not True
     ):
         fail("session-end does not describe one clean, complete observation")

--- a/tests/contract/test_qual_206_claude_composite_observation.py
+++ b/tests/contract/test_qual_206_claude_composite_observation.py
@@ -757,6 +757,14 @@ class Qual206ClaudeCompositeObservationTests(unittest.TestCase):
         with self.assertRaisesRegex(VERIFIER.VerificationError, "clean, complete"):
             self.verify(root)
 
+    def test_accepts_safe_sigint_close(self) -> None:
+        root = self.write_root(second={"closure_stimulus": "sigint"})
+        self.verify(root)
+
+    def test_accepts_safe_stdin_eof_and_sigint_close(self) -> None:
+        root = self.write_root(second={"closure_stimulus": "stdin-eof-and-sigint"})
+        self.verify(root)
+
     def test_rejects_legacy_notification_and_host_traffic_after_child_exit(self) -> None:
         cases = {
             "legacy notification": {

--- a/tests/interoperability/test_qual_206_claude_stdio_observer.mjs
+++ b/tests/interoperability/test_qual_206_claude_stdio_observer.mjs
@@ -479,7 +479,7 @@ test("probe and modern sessions allocate unique private slots and close manifest
   }
 });
 
-test("host SIGTERM after a complete probe or modern exchange closes safely", async (t) => {
+test("host SIGTERM or SIGINT after a complete exchange closes safely", async (t) => {
   const captureRoot = privateRoot(t);
   const runId = randomUUID();
   const probe = startObserver(captureRoot, runId);
@@ -507,14 +507,13 @@ test("host SIGTERM after a complete probe or modern exchange closes safely", asy
   const probeSignalStarted = process.hrtime.bigint();
   assert.equal(probe.child.kill("SIGTERM"), true);
   const modernSignalStarted = process.hrtime.bigint();
-  modern.child.stdin.end();
-  assert.equal(modern.child.kill("SIGTERM"), true);
+  assert.equal(modern.child.kill("SIGINT"), true);
   const completions = await Promise.all([
     withTimeout(probe.completion, "SIGTERM probe close").then((result) => ({
       elapsedMs: Number(process.hrtime.bigint() - probeSignalStarted) / 1_000_000,
       result,
     })),
-    withTimeout(modern.completion, "SIGTERM tools close").then((result) => ({
+    withTimeout(modern.completion, "SIGINT tools close").then((result) => ({
       elapsedMs: Number(process.hrtime.bigint() - modernSignalStarted) / 1_000_000,
       result,
     })),
@@ -544,8 +543,15 @@ test("host SIGTERM after a complete probe or modern exchange closes safely", asy
   );
   const stimuli = captures.map(({ events }) => events.at(-1).closure_stimulus);
   assert.ok(stimuli.includes("sigterm"));
+  assert.ok(stimuli.includes("sigint"));
   assert.ok(stimuli.every((value) =>
-    ["sigterm", "stdin-eof", "stdin-eof-and-sigterm"].includes(value)));
+    [
+      "sigint",
+      "sigterm",
+      "stdin-eof",
+      "stdin-eof-and-sigint",
+      "stdin-eof-and-sigterm",
+    ].includes(value)));
 });
 
 test("host SIGTERM before a complete request-response exchange fails closed", async (t) => {
@@ -582,6 +588,45 @@ test("host SIGTERM before a complete request-response exchange fails closed", as
     "incomplete-signal-version",
     "incomplete-private-request",
     "incomplete-private-reason",
+  ]) {
+    assert.equal(capture.text.includes(value), false);
+  }
+});
+
+test("host SIGINT before a complete request-response exchange fails closed", async (t) => {
+  const captureRoot = privateRoot(t);
+  const runId = randomUUID();
+  const observer = startObserver(captureRoot, runId);
+  await writeFrame(observer.child.stdin, {
+    jsonrpc: "2.0",
+    method: "notifications/cancelled",
+    params: {
+      _meta: modernMeta("incomplete-sigint-client", "incomplete-sigint-version"),
+      requestId: "incomplete-sigint-request",
+      reason: "incomplete-sigint-reason",
+    },
+  });
+  await waitForCapturedEvent(
+    captureRoot,
+    ({ event }) => event === "notification",
+    "incomplete SIGINT notification capture",
+  );
+  assert.equal(observer.child.kill("SIGINT"), true);
+  const result = await withTimeout(observer.completion, "incomplete SIGINT close");
+  assert.equal(result.code, 2, result.stderr);
+  const [slot] = readdirSync(captureRoot);
+  const capture = verifyCapture(join(captureRoot, slot), runId);
+  assert.equal(capture.manifest.session_profile, "invalid");
+  assert.equal(capture.events.at(-1).closure_stimulus, "none");
+  assert.ok(capture.events.some(
+    ({ event, classification }) =>
+      event === "anomaly" && classification === "observer-signal",
+  ));
+  for (const value of [
+    "incomplete-sigint-client",
+    "incomplete-sigint-version",
+    "incomplete-sigint-request",
+    "incomplete-sigint-reason",
   ]) {
     assert.equal(capture.text.includes(value), false);
   }


### PR DESCRIPTION
## Summary

- accept Claude Code `2.1.241` `SIGINT` disposal only after a complete,
  contract-valid MCP `2026-07-28` request and response exchange;
- preserve the existing safe `SIGTERM` path, idempotent EOF/TERM/KILL child closer,
  exact source and parent binding, zero-provider audit and private capture boundary;
- keep early `SIGINT` and `SIGTERM` fail closed with an anomaly and no readiness
  claim; and
- extend the closed event schema, independent verifier, runbook and regression
  coverage for the observed signal variance.

The first exact-main health attempt passed `server/discover` and the modern
`tools/list` response, then failed closed because Claude disposed of the completed
modern child with `SIGINT`. Its raw capture remains private and is not committed.
The discovery child used `SIGTERM`. This patch recognises that bounded lifecycle
variance without weakening request, response, protocol, source, audit or shutdown
requirements.

## Verification

- focused process-level observer suite: 12/12 passed;
- independent offline verifier suite: 17/17 passed;
- independent read-only review: no remaining P0-P2 finding; and
- full `pnpm run check`: passed, including type checks, 210 gateway tests,
  interoperability, 366 plus 22 Python tests, 27 browser/accessibility tests,
  deterministic double build, 77-schema validation, links, secret/path scan,
  diagrams and SBOM.

The health check used no model prompt, provider credential, provider call, live
data, registration, activation, deployment, tag or release. Host capability and
source binding remain unscored until a fresh exact protected-main observation
passes the independent verifier.
