### PR TITLE
fix(qual-206): bind Claude 2.1.245 parent identity

### DIFF
--- a/changelog.d/QUAL-206-claude-2-1-245-parent-identity.fixed.md
+++ b/changelog.d/QUAL-206-claude-2-1-245-parent-identity.fixed.md
@@ -1,0 +1,4 @@
+- Preserve fail-closed Claude parent-process binding on macOS when Claude Code
+  `2.1.245` reports only the `claude` basename by selecting exactly one mapped text
+  executable whose device, inode and size remain bound while checking the
+  independently supplied byte length and SHA-256 identity.

--- a/docs/operations/QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md
+++ b/docs/operations/QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md
@@ -4,16 +4,19 @@ This runbook covers a private, credential-free transport observation of Claude
 Code against the inactive strict-modern GIS AI GO fixture. It does not replace the
 exact 14-request conformance journey and does not score host capability.
 
-Claude Code `2.1.241` supports MCP `2026-07-28`, but its modern STDIO negotiation
-uses two direct child processes. The first is a disposable `server/discover` probe;
-the second is the modern session. A single-process collector with fixed output
-paths cannot represent that behaviour safely.
+The accepted Claude Code `2.1.241` evidence supports MCP `2026-07-28`, but its
+modern STDIO negotiation uses two direct child processes. The first is a disposable
+`server/discover` probe; the second is the modern session. A single-process
+collector with fixed output paths cannot represent that behaviour safely. The
+locally installed `2.1.245` binary retains those protocol markers but changes the
+macOS process-name evidence described below.
 
 ## Source-by-source decision matrix
 
 | Source | Supported finding | Implementation consequence | Disposition |
 | --- | --- | --- | --- |
 | Local Claude Code `2.1.241` binary | The binary contains the final `2026-07-28` protocol, `server/discover` handling and automatic negotiation. In automatic mode it launches a disposable discovery process before the modern session. | Capture two direct Claude children under one run identity; do not reuse fixed output paths. | Supported and implemented additively. |
+| Local Claude Code `2.1.245` binary and failed-closed preflight | On macOS, `ps -o comm=` now reports the immediate parent as the basename `claude`, rather than the absolute versioned executable path used by `2.1.241`. The binary still contains the `2026-07-28`, `server/discover`, v2 and automatic-negotiation markers. | Treat `ps` as the first bounded process-name check. Enumerate that exact PID's mapped `txt` files with fixed `/usr/sbin/lsof`, bind each candidate's device, inode and size to the reopened canonical regular file, then accept only one whose byte length and SHA-256 equal the independently supplied expected identity. | Compatibility repair implemented; a new protected-main observation is still required and no `2.1.245` readiness claim is made here. |
 | [Official Claude MCP runtime documentation](https://code.claude.com/docs/en/mcp#MCP-client-runtimes) | The v2 runtime is available from Claude Code `2.1.232`; modern STDIO negotiation is selected with `MCP_PROTOCOL_NEGOTIATION=auto`. | Pin `MCP_SDK_GENERATION=v2` and `MCP_PROTOCOL_NEGOTIATION=auto` in the isolated observation environment. | Supported and required for this observation. |
 | [Official Claude environment-variable reference](https://code.claude.com/docs/en/env-vars) | Claude runtime and non-essential traffic controls can be set per invocation. | Use a disposable profile and an allowlisted invocation environment; do not change normal Claude settings. | Supported and required for isolation. |
 | [MCP `2026-07-28` release](https://blog.modelcontextprotocol.io/posts/2026-07-28/) | `server/discover` is the optional stateless opening for the final protocol. | Require one successful negotiation probe and a second session with no legacy `initialize`. | Supported protocol target. |
@@ -29,6 +32,19 @@ The local binary observed during preflight was:
 
 Recompute those values immediately before every observation. A changed binary is a
 new host candidate and must not be accepted under these values.
+
+The installed `2.1.245` candidate measured on 25 August 2026 has version
+`2.1.245 (Claude Code)`, byte length `376109392` and SHA-256
+`9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1`.
+Its first credential-free preflight failed closed before allocating an observer
+capture because the previous macOS check required `ps` to return an absolute path.
+The private diagnostic established that the same immediate PID had the versioned
+binary mapped as a text executable. The repair uses `lsof` only to discover bounded
+candidate mappings. Each reopened path must retain that mapping's device, inode and
+size throughout stable hashing; the pre-recorded byte length and digest remain
+authoritative, and zero or more than one matching canonical file fails closed. Do
+not relabel that diagnostic as transport readiness. Run a fresh observation with a
+new root and run identity only after this repair reaches protected `main`.
 
 ## Composite observation contract
 
@@ -135,7 +151,7 @@ identity values:
         "--claude-composite-observation-only",
         "--capture-root", "<PRIVATE_CAPTURE_ROOT>",
         "--run-id", "<RUN_UUID>",
-        "--client", "claude-code-2.1.241",
+        "--client", "<CLAUDE_CLIENT_VERSION>",
         "--source-commit", "<PROTECTED_MAIN_COMMIT>",
         "--expected-parent-sha256", "<CLAUDE_EXECUTABLE_SHA256>",
         "--expected-parent-bytes", "<CLAUDE_EXECUTABLE_BYTES>"

--- a/scripts/qual_206_claude_stdio_observer.mjs
+++ b/scripts/qual_206_claude_stdio_observer.mjs
@@ -402,11 +402,141 @@ function fsyncDirectory(path) {
   }
 }
 
-function immediateParentExecutable() {
+export function parseDarwinTextExecutableMappings(parentPid, output) {
+  if (!Number.isSafeInteger(parentPid) || parentPid <= 1) {
+    fail("the Darwin parent process identifier is invalid");
+  }
+  if (
+    typeof output !== "string" || output.length === 0 || output.length > 65_536 ||
+    output.includes("\0")
+  ) {
+    fail("the Darwin parent text-file listing is invalid");
+  }
+  const lines = output.trimEnd().split("\n");
+  if (lines.shift() !== `p${String(parentPid)}` || lines.length === 0) {
+    fail("the Darwin parent text-file listing does not bind the expected process");
+  }
+  const mappings = [];
+  let mapping = null;
+
+  function finishMapping() {
+    if (mapping === null) return;
+    if (!exactKeys(mapping, ["bytes", "device", "inode", "path"])) {
+      fail("the Darwin parent text-file listing has an incomplete mapping");
+    }
+    mappings.push(Object.freeze(mapping));
+    mapping = null;
+  }
+
+  for (const line of lines) {
+    if (line === "ftxt") {
+      finishMapping();
+      mapping = {};
+      continue;
+    }
+    if (mapping === null || line.length < 2) {
+      fail("the Darwin parent text-file listing has an unexpected shape");
+    }
+    const value = line.slice(1);
+    let name;
+    if (line.startsWith("D") && /^0x[0-9a-f]+$/u.test(value)) {
+      name = "device";
+    } else if (line.startsWith("i") && /^[1-9][0-9]*$/u.test(value)) {
+      name = "inode";
+    } else if (line.startsWith("s") && /^[1-9][0-9]*$/u.test(value)) {
+      if (BigInt(value) > BigInt(MAX_EXECUTABLE_BYTES)) {
+        fail("the Darwin parent text-file listing contains an oversized mapping");
+      }
+      name = "bytes";
+    } else if (line.startsWith("n") && isAbsolute(value)) {
+      name = "path";
+    } else {
+      fail("the Darwin parent text-file listing contains an invalid field");
+    }
+    if (Object.hasOwn(mapping, name)) {
+      fail("the Darwin parent text-file listing contains a duplicate field");
+    }
+    mapping[name] = value;
+  }
+  finishMapping();
+  if (mappings.length === 0) {
+    fail("the Darwin parent text-file listing contains no executable candidates");
+  }
+  return Object.freeze(mappings);
+}
+
+function sameBigIntFileState(left, right) {
+  return left.dev === right.dev && left.ino === right.ino &&
+    left.mode === right.mode && left.uid === right.uid &&
+    left.nlink === right.nlink && left.size === right.size &&
+    left.mtimeNs === right.mtimeNs;
+}
+
+function mappingMatchesFileState(mapping, state) {
+  return mapping.device === `0x${state.dev.toString(16)}` &&
+    mapping.inode === state.ino.toString() &&
+    mapping.bytes === state.size.toString();
+}
+
+export function selectExpectedParentExecutable(candidatesValue, expectedSha256, expectedBytes) {
+  if (
+    !Array.isArray(candidatesValue) || candidatesValue.length === 0 ||
+    !SHA256.test(expectedSha256) ||
+    !Number.isSafeInteger(expectedBytes) || expectedBytes <= 0 ||
+    expectedBytes > MAX_EXECUTABLE_BYTES
+  ) {
+    fail("the expected parent executable selection is invalid");
+  }
+  const candidates = new Map();
+  for (const candidate of candidatesValue) {
+    const mapping = plainRecord(candidate) ? candidate : null;
+    const path = mapping === null ? candidate : mapping.path;
+    if (
+      (mapping !== null && !exactKeys(mapping, ["bytes", "device", "inode", "path"])) ||
+      typeof path !== "string" || !isAbsolute(path)
+    ) {
+      fail("a parent executable candidate path is invalid");
+    }
+    const resolved = realpathSync(path);
+    if (candidates.has(resolved)) continue;
+    const before = lstatSync(resolved, { bigint: true });
+    if (!before.isFile() || before.size !== BigInt(expectedBytes)) continue;
+    if (mapping !== null && !mappingMatchesFileState(mapping, before)) continue;
+    const measurement = hashStableRegularFile(
+      resolved,
+      "immediate parent executable candidate",
+    );
+    const after = lstatSync(resolved, { bigint: true });
+    if (
+      mapping !== null &&
+      (!sameBigIntFileState(before, after) || !mappingMatchesFileState(mapping, after))
+    ) {
+      fail("the mapped parent executable candidate changed during verification");
+    }
+    if (
+      measurement.bytes === expectedBytes &&
+      measurement.sha256 === expectedSha256
+    ) {
+      candidates.set(resolved, measurement);
+    }
+  }
+  if (candidates.size !== 1) {
+    fail("the immediate parent executable does not have one expected identity");
+  }
+  return candidates.values().next().value;
+}
+
+function immediateParentExecutable(expectedSha256, expectedBytes) {
   if (!Number.isSafeInteger(process.ppid) || process.ppid <= 1) {
     fail("the immediate parent process cannot be identified");
   }
-  if (process.platform === "linux") return realpathSync(`/proc/${process.ppid}/exe`);
+  if (process.platform === "linux") {
+    return selectExpectedParentExecutable(
+      [realpathSync(`/proc/${process.ppid}/exe`)],
+      expectedSha256,
+      expectedBytes,
+    );
+  }
   if (process.platform === "darwin") {
     const output = execFileSync(
       "/bin/ps",
@@ -418,10 +548,31 @@ function immediateParentExecutable() {
         timeout: 5_000,
       },
     ).trim();
-    if (!isAbsolute(output) || output.includes("\0") || output.includes("\n")) {
-      fail("the immediate parent executable path is not absolute and singular");
+    if (output.length === 0 || output.includes("\0") || output.includes("\n")) {
+      fail("the immediate parent executable name is not singular");
     }
-    return realpathSync(output);
+    const textFiles = execFileSync(
+      "/usr/sbin/lsof",
+      ["-a", "-p", String(process.ppid), "-d", "txt", "-FpfnDsi"],
+      {
+        encoding: "utf8",
+        env: { LANG: "C", LC_ALL: "C", PATH: "/usr/bin:/bin:/usr/sbin" },
+        maxBuffer: 65_536,
+        timeout: 5_000,
+      },
+    );
+    let mappings = parseDarwinTextExecutableMappings(process.ppid, textFiles);
+    if (isAbsolute(output)) {
+      const expectedPath = realpathSync(output);
+      mappings = mappings.filter((mapping) => {
+        try {
+          return realpathSync(mapping.path) === expectedPath;
+        } catch {
+          return false;
+        }
+      });
+    }
+    return selectExpectedParentExecutable(mappings, expectedSha256, expectedBytes);
   }
   fail(`immediate parent executable binding is unsupported on ${process.platform}`);
 }
@@ -674,9 +825,9 @@ function startObserver(options) {
     fail("observer environment contains a recognised credential variable");
   }
   const source = sourceCheckoutFacts(options.sourceCommit);
-  const parent = hashStableRegularFile(
-    immediateParentExecutable(),
-    "immediate parent executable",
+  const parent = immediateParentExecutable(
+    options.expectedParentSha256,
+    options.expectedParentBytes,
   );
   if (
     parent.sha256 !== options.expectedParentSha256 ||

--- a/tests/interoperability/test_qual_206_claude_stdio_observer.mjs
+++ b/tests/interoperability/test_qual_206_claude_stdio_observer.mjs
@@ -30,6 +30,8 @@ import {
   GRACEFUL_CLOSE_KILL_MILLISECONDS,
   GRACEFUL_CLOSE_TERM_MILLISECONDS,
   parseClaudeObserverArguments,
+  parseDarwinTextExecutableMappings,
+  selectExpectedParentExecutable,
 } from "../../scripts/qual_206_claude_stdio_observer.mjs";
 
 const ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -95,6 +97,17 @@ function executableIdentity() {
   return Object.freeze({
     bytes: statSync(executable).size,
     sha256: createHash("sha256").update(readFileSync(executable)).digest("hex"),
+  });
+}
+
+function executableMapping() {
+  const path = realpathSync(process.execPath);
+  const state = lstatSync(path, { bigint: true });
+  return Object.freeze({
+    bytes: state.size.toString(),
+    device: `0x${state.dev.toString(16)}`,
+    inode: state.ino.toString(),
+    path,
   });
 }
 
@@ -254,6 +267,100 @@ function writeRawFrame(stream, value) {
     });
   });
 }
+
+test("Darwin text mappings bind one expected executable when ps reports a basename", () => {
+  const parentPid = 42_849;
+  const executable = executableMapping();
+  const mappings = parseDarwinTextExecutableMappings(
+    parentPid,
+    [
+      `p${String(parentPid)}`,
+      "ftxt",
+      `D${executable.device}`,
+      `s${executable.bytes}`,
+      `i${executable.inode}`,
+      `n${executable.path}`,
+      "ftxt",
+      "D0x1000011",
+      "s2374000",
+      "i1152921500312573276",
+      "n/usr/lib/dyld",
+      "",
+    ].join("\n"),
+  );
+  assert.deepEqual(mappings, [
+    executable,
+    {
+      bytes: "2374000",
+      device: "0x1000011",
+      inode: "1152921500312573276",
+      path: "/usr/lib/dyld",
+    },
+  ]);
+
+  const expected = executableIdentity();
+  assert.deepEqual(
+    selectExpectedParentExecutable(mappings, expected.sha256, expected.bytes),
+    expected,
+  );
+  assert.throws(
+    () => selectExpectedParentExecutable(mappings, "0".repeat(64), expected.bytes),
+    /does not have one expected identity/u,
+  );
+});
+
+test("Darwin text mapping parsing rejects process and path ambiguity", () => {
+  assert.throws(
+    () => parseDarwinTextExecutableMappings(
+      42_849,
+      "p42848\nftxt\nD0x1\ns1\ni1\nn/usr/bin/claude\n",
+    ),
+    /does not bind the expected process/u,
+  );
+  assert.throws(
+    () => parseDarwinTextExecutableMappings(
+      42_849,
+      "p42849\nftxt\nD0x1\ns1\ni1\nnclaude\n",
+    ),
+    /invalid field/u,
+  );
+  assert.throws(
+    () => parseDarwinTextExecutableMappings(42_849, "p42849\nn/usr/bin/claude\n"),
+    /unexpected shape/u,
+  );
+});
+
+test("mapped executable selection rejects a pathname with the wrong mapped inode", () => {
+  const executable = executableMapping();
+  const expected = executableIdentity();
+  assert.throws(
+    () => selectExpectedParentExecutable(
+      [{ ...executable, inode: String(BigInt(executable.inode) + 1n) }],
+      expected.sha256,
+      expected.bytes,
+    ),
+    /does not have one expected identity/u,
+  );
+});
+
+test("parent executable selection rejects two matching mapped files", (t) => {
+  const root = privateRoot(t);
+  const executable = readFileSync(realpathSync(process.execPath));
+  const first = join(root, "first-parent");
+  const second = join(root, "second-parent");
+  writeFileSync(first, executable, { mode: 0o600 });
+  writeFileSync(second, executable, { mode: 0o600 });
+  const expected = executableIdentity();
+
+  assert.throws(
+    () => selectExpectedParentExecutable(
+      [first, second],
+      expected.sha256,
+      expected.bytes,
+    ),
+    /does not have one expected identity/u,
+  );
+});
 
 function readEvents(path) {
   return readFileSync(path, "utf8")

--- a/tests/interoperability/test_qual_206_claude_stdio_observer.mjs
+++ b/tests/interoperability/test_qual_206_claude_stdio_observer.mjs
@@ -100,8 +100,8 @@ function executableIdentity() {
   });
 }
 
-function executableMapping() {
-  const path = realpathSync(process.execPath);
+function regularFileMapping(pathValue) {
+  const path = realpathSync(pathValue);
   const state = lstatSync(path, { bigint: true });
   return Object.freeze({
     bytes: state.size.toString(),
@@ -109,6 +109,10 @@ function executableMapping() {
     inode: state.ino.toString(),
     path,
   });
+}
+
+function executableMapping() {
+  return regularFileMapping(process.execPath);
 }
 
 function privateRoot(t) {
@@ -271,6 +275,7 @@ function writeRawFrame(stream, value) {
 test("Darwin text mappings bind one expected executable when ps reports a basename", () => {
   const parentPid = 42_849;
   const executable = executableMapping();
+  const other = regularFileMapping(EVENT_SCHEMA_PATH);
   const mappings = parseDarwinTextExecutableMappings(
     parentPid,
     [
@@ -281,21 +286,16 @@ test("Darwin text mappings bind one expected executable when ps reports a basena
       `i${executable.inode}`,
       `n${executable.path}`,
       "ftxt",
-      "D0x1000011",
-      "s2374000",
-      "i1152921500312573276",
-      "n/usr/lib/dyld",
+      `D${other.device}`,
+      `s${other.bytes}`,
+      `i${other.inode}`,
+      `n${other.path}`,
       "",
     ].join("\n"),
   );
   assert.deepEqual(mappings, [
     executable,
-    {
-      bytes: "2374000",
-      device: "0x1000011",
-      inode: "1152921500312573276",
-      path: "/usr/lib/dyld",
-    },
+    other,
   ]);
 
   const expected = executableIdentity();


### PR DESCRIPTION
## Summary

- accept Claude Code 2.1.245 on macOS when `ps` reports only the `claude` basename
- bind the selected mapped text executable's device, inode and size throughout stable SHA-256 verification
- fail closed on malformed mappings, wrong process identity, wrong digest, mapped-inode drift or multiple matches
- preserve the existing Claude 2.1.241 evidence and withhold any 2.1.245 readiness, capability, provider, remote-host, deployment or release claim

## Verification

- `node --test tests/interoperability/test_qual_206_claude_stdio_observer.mjs` — 16 passed
- focused Python assurance — 25 passed
- `pnpm run check` — passed in full, including 404 repository Python tests, 22 geo-execution tests, 27 browser tests, byte-identical release builds, contract/link/secret checks, diagrams and SBOM
- independent final review — no P0–P2 findings or material same-pattern regression gap
- bounded Codex Security diff scan `6c63cf7d-d2e5-4ecb-99e0-cf94ca5402c3` — no reportable findings; its one operator-only provenance observation was nevertheless hardened in the final patch

## Next gate

After this reaches protected `main`, run a fresh credential-free Claude Code 2.1.245 composite observation under a new private root and run identity. Do not reuse or relabel the failed-closed diagnostic capture.

Relates to #24.
