### PR TITLE
test(qual-206): publish Claude 2.1.245 readiness evidence

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,20 +16,20 @@ The supported target active set is exactly `catalogue.search`,
 - retain the repository-local STDIO and client/version matrix bound to the
   protected-main v3 inspection-receipt runtime as preflight only;
 - preserve the source-bound Claude Code `2.1.204` result and the additive `2.1.241`
-  protocol observation separately from capability scoring; that exact observation
-  offered MCP `2025-11-25` and cannot close the strict `2026-07-28` desktop-host
-  gate, and remains a byte-exact historical default-negotiation record;
+  default-negotiation observation separately from capability scoring; that exact
+  observation offered MCP `2025-11-25` and cannot close the strict `2026-07-28`
+  desktop-host gate, and remains a byte-exact historical record;
 - preserve the accepted exact-five local demonstration on protected `main` and use
   its fixed-provider, temporary-state boundary for colleague-facing explanation;
 - retain the protected-main strict-modern summary compiler, exact event collector
   and replay verifier whose synthetic client cannot promote itself into an
   independent-host capability pass;
 - retain the merged bounded two-process observer and independent verifier for
-  Claude Code `2.1.241` automatic modern negotiation without changing the
-  exact-sequence collector or scoring host capability;
-- accept the separately verified MCP `2026-07-28` Claude desktop-STDIO result as
-  transport readiness only, with capability and exact-five source binding still
-  false;
+  Claude Code automatic modern negotiation without changing the exact-sequence
+  collector or scoring host capability;
+- accept the separately verified MCP `2026-07-28` Claude Code `2.1.241` and
+  `2.1.245` desktop-STDIO results as transport readiness only, with capability and
+  exact-five source binding still false;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;
@@ -338,11 +338,11 @@ or release is claimed.
 
 ## Next
 
-1. Preserve the verified Claude Code `2.1.241` strict-modern transport summary, its
-   separate historical default-negotiation record and the accepted protected-main
-   loopback HTTP projection. Complete the bounded capability pack and remaining
-   remote-HTTP host evidence without widening any transport result into a capability
-   claim.
+1. Preserve the verified Claude Code `2.1.241` and `2.1.245` strict-modern transport
+   summaries, the separate historical default-negotiation record and the accepted
+   protected-main loopback HTTP projection. Complete the bounded capability pack
+   and remaining remote-HTTP host evidence without widening any transport result
+   into a capability claim.
 2. Retain the exact protected-main UBI, independent-derivation and provenance
    evidence from runs `32760872035` and `32760871684`; rebuild and repeat it after
    every later source-changing activation or release commit.
@@ -370,10 +370,10 @@ or release is claimed.
   transcripts, deterministic local host fixtures and the pinned SDK clients do not
   establish independent live major-host capability. The retained 24 August Claude
   Code `2.1.241` default-negotiation observation remains an explained historical
-  `2025-11-25` result. The separate 25 August v2 automatic-negotiation observation
-  establishes strict MCP `2026-07-28` desktop-STDIO transport readiness, but it made
-  no model task or tool call and does not complete the capability pack or remote-HTTP
-  host evidence.
+  `2025-11-25` result. The separate 25 August v2 automatic-negotiation observations
+  for exact Claude Code `2.1.241` and `2.1.245` establish strict MCP `2026-07-28`
+  desktop-STDIO transport readiness, but neither involved a model task or tool
+  call, and neither completes the capability pack or remote-HTTP host evidence.
   Security, accessibility, governed ingress/storage admission, retention/disposal
   and host-specific lifecycle evidence remain activation gates.
 - Direct routes and MCP transports now exist on protected `main`, but the
@@ -488,6 +488,19 @@ or release is claimed.
   that exact component and retained database, not a claim of no vulnerabilities. The
   candidate remains repository-only and blocked; no publication, provider call,
   deployment, registration, activation, tag or release is claimed;
+
+- Claude Code `2.1.245` strict-modern STDIO readiness: the
+  [path-free source-bound summary](tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json)
+  records a credential-free `mcp list` observation after the macOS parent-identity
+  repair reached exact protected-main commit
+  `e905c632724ecc9d13b13452fee37328e75cc2a4`. Claude completed a contract-valid
+  MCP `2026-07-28` `server/discover` probe and a separate successful `tools/list`
+  session. Independent replay accepted both, all provider, egress, pending-request,
+  anomaly, error and stderr counters were zero, and no observer or fixture remained.
+  This is transport readiness only: capability, exact-five operations and
+  remote-HTTP evidence remain incomplete. The raw capture and client output remain
+  owner-only and local, while the 2.1.241 schema and result remain byte-exact
+  historical lineage;
 
 - Claude Code `2.1.241` strict-modern STDIO readiness: the
   [path-free source-bound summary](tests/interoperability/evidence/claude-code-2.1.241-modern-stdio-readiness-2026-08-25.json)

--- a/changelog.d/QUAL-206-claude-2-1-245-modern-readiness.changed.md
+++ b/changelog.d/QUAL-206-claude-2-1-245-modern-readiness.changed.md
@@ -1,0 +1,5 @@
+- Record the independently replayed, path-free Claude Code `2.1.245` MCP
+  `2026-07-28` STDIO transport-readiness result from exact protected `main`, while
+  preserving the 2.1.241 schema and evidence byte-for-byte and keeping capability,
+  exact-five, provider, remote-host, activation, deployment and release claims
+  false.

--- a/docs/operations/QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md
+++ b/docs/operations/QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md
@@ -4,19 +4,19 @@ This runbook covers a private, credential-free transport observation of Claude
 Code against the inactive strict-modern GIS AI GO fixture. It does not replace the
 exact 14-request conformance journey and does not score host capability.
 
-The accepted Claude Code `2.1.241` evidence supports MCP `2026-07-28`, but its
-modern STDIO negotiation uses two direct child processes. The first is a disposable
-`server/discover` probe; the second is the modern session. A single-process
-collector with fixed output paths cannot represent that behaviour safely. The
-locally installed `2.1.245` binary retains those protocol markers but changes the
-macOS process-name evidence described below.
+The accepted Claude Code `2.1.241` and `2.1.245` evidence supports MCP
+`2026-07-28`, but modern STDIO negotiation uses two direct child processes. The
+first is a disposable `server/discover` probe; the second is the modern session. A
+single-process collector with fixed output paths cannot represent that behaviour
+safely. Version `2.1.245` also changes the macOS process-name evidence described
+below.
 
 ## Source-by-source decision matrix
 
 | Source | Supported finding | Implementation consequence | Disposition |
 | --- | --- | --- | --- |
 | Local Claude Code `2.1.241` binary | The binary contains the final `2026-07-28` protocol, `server/discover` handling and automatic negotiation. In automatic mode it launches a disposable discovery process before the modern session. | Capture two direct Claude children under one run identity; do not reuse fixed output paths. | Supported and implemented additively. |
-| Local Claude Code `2.1.245` binary and failed-closed preflight | On macOS, `ps -o comm=` now reports the immediate parent as the basename `claude`, rather than the absolute versioned executable path used by `2.1.241`. The binary still contains the `2026-07-28`, `server/discover`, v2 and automatic-negotiation markers. | Treat `ps` as the first bounded process-name check. Enumerate that exact PID's mapped `txt` files with fixed `/usr/sbin/lsof`, bind each candidate's device, inode and size to the reopened canonical regular file, then accept only one whose byte length and SHA-256 equal the independently supplied expected identity. | Compatibility repair implemented; a new protected-main observation is still required and no `2.1.245` readiness claim is made here. |
+| Local Claude Code `2.1.245` binary, failed-closed preflight and accepted rerun | On macOS, `ps -o comm=` now reports the immediate parent as the basename `claude`, rather than the absolute versioned executable path used by `2.1.241`. The binary retains the `2026-07-28`, `server/discover`, v2 and automatic-negotiation markers. | Treat `ps` as the first bounded process-name check. Enumerate that exact PID's mapped `txt` files with fixed `/usr/sbin/lsof`, bind each candidate's device, inode and size to the reopened canonical regular file, then accept only one whose byte length and SHA-256 equal the independently supplied expected identity. | Compatibility repair merged and independently replayed from protected `main`; transport readiness accepted with capability unscored. |
 | [Official Claude MCP runtime documentation](https://code.claude.com/docs/en/mcp#MCP-client-runtimes) | The v2 runtime is available from Claude Code `2.1.232`; modern STDIO negotiation is selected with `MCP_PROTOCOL_NEGOTIATION=auto`. | Pin `MCP_SDK_GENERATION=v2` and `MCP_PROTOCOL_NEGOTIATION=auto` in the isolated observation environment. | Supported and required for this observation. |
 | [Official Claude environment-variable reference](https://code.claude.com/docs/en/env-vars) | Claude runtime and non-essential traffic controls can be set per invocation. | Use a disposable profile and an allowlisted invocation environment; do not change normal Claude settings. | Supported and required for isolation. |
 | [MCP `2026-07-28` release](https://blog.modelcontextprotocol.io/posts/2026-07-28/) | `server/discover` is the optional stateless opening for the final protocol. | Require one successful negotiation probe and a second session with no legacy `initialize`. | Supported protocol target. |
@@ -42,9 +42,10 @@ The private diagnostic established that the same immediate PID had the versioned
 binary mapped as a text executable. The repair uses `lsof` only to discover bounded
 candidate mappings. Each reopened path must retain that mapping's device, inode and
 size throughout stable hashing; the pre-recorded byte length and digest remain
-authoritative, and zero or more than one matching canonical file fails closed. Do
-not relabel that diagnostic as transport readiness. Run a fresh observation with a
-new root and run identity only after this repair reaches protected `main`.
+authoritative, and zero or more than one matching canonical file fails closed. The
+failed diagnostic remains private and is not relabelled as transport readiness. The
+accepted rerun described below used a new private root and run identity only after
+the repair reached protected `main`.
 
 ## Composite observation contract
 
@@ -84,7 +85,7 @@ and fails closed. The first failed-closed exact-main attempt established this
 distinction: the discovery child used `SIGTERM`, while the completed modern
 `tools/list` child used `SIGINT`.
 
-## Accepted protected-main observation
+## Accepted 2.1.241 protected-main observation
 
 On 25 August 2026, one fresh credential-free `claude mcp list` observation ran
 from clean, detached protected-main commit
@@ -114,6 +115,36 @@ provider, remote HTTP host, registration, activation, deployment or release. The
 earlier default-negotiation result remains a separate historical record and is not
 relabelled.
 
+## Accepted 2.1.245 protected-main observation
+
+On 25 August 2026, a further credential-free `claude mcp list` observation ran
+from clean, detached protected-main commit
+`e905c632724ecc9d13b13452fee37328e75cc2a4`, tree
+`c611ba2d86dcefb541814e5cd4ab3345dd8745b6`, after the macOS parent-identity
+repair merged. That source passed repository assurance, producer and independent
+gateway derivation, byte comparison, Pages and gateway provenance in GitHub
+Actions run `32868256571`, and CodeQL in run `32868252219`.
+
+The exact Claude Code `2.1.245` binary was `376109392` bytes with SHA-256
+`9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1`.
+It reported `Connected`. Independent offline replay accepted one contract-valid
+MCP `2026-07-28` `server/discover` probe and one separate contract-valid
+`tools/list` session. Both sessions recorded zero provider transports, guarded API
+invocations, aborted calls, ledger events, reported errors, pending requests,
+anomalies and stderr. No observer or fixture process remained.
+
+The invocation used a disposable profile, a closed credential-free child
+environment and the documented controls for non-essential traffic, background
+tasks, tool search, claude.ai MCP servers and subprocess credential scrubbing. The
+path-free
+[`2.1.245 public readiness summary`](../../tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json)
+publishes only allowlisted fields and digests. Raw events, manifests, client output,
+profile data, run and session identities, process IDs and local paths remain
+owner-only and local. This is strict-modern STDIO transport readiness only. It
+does not score capability or exercise an exact-five journey, model task, tool call,
+resource read, provider, remote HTTP host, registration, activation, deployment or
+release. The accepted 2.1.241 result remains byte-exact historical lineage.
+
 ## Repository assurance
 
 Build the gateway contracts, then run the observer and independent verifier tests:
@@ -125,7 +156,8 @@ pnpm --filter @gis-ai-go/tool-registry run build
 node --test tests/interoperability/test_qual_206_claude_stdio_observer.mjs
 uv run --locked --cache-dir .uv-cache python -m unittest \
   tests.contract.test_qual_206_claude_composite_observation \
-  tests.contract.test_qual_206_claude_composite_stdio_readiness
+  tests.contract.test_qual_206_claude_composite_stdio_readiness \
+  tests.contract.test_qual_206_claude_composite_stdio_readiness_v2
 pnpm run validate:contracts
 ```
 

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -10,13 +10,17 @@
   four 20 August independent-host readiness attempts remain documented as not
   ready; a separate 23 August Claude Code legacy STDIO observation from exact
   protected-main bytes passed initialisation and tool listing, with capability
-  unscored;
+  unscored; exact Claude Code `2.1.245` now also has independently replayed
+  strict-modern STDIO transport readiness from protected `main`, with capability
+  still unscored;
   deterministic `HOST-015` application recovery passes locally but remains non-live
   and unscored; capability scoring and activation remain pending
 - reviewed source base: `66507f9a6e6c0da23a8af4682268f9362d93bc06`
 - local HTTP transport evidence source: protected `main` commit
   `066a9cb22f719d22e29c95cd99857ddf694c878e`
-- Claude transport-readiness source: protected `main` commit
+- latest Claude transport-readiness source: protected `main` commit
+  `e905c632724ecc9d13b13452fee37328e75cc2a4`
+- historical Claude legacy transport-readiness source: protected `main` commit
   `30b575beb27ff805745a2864c1acf44392774046`
 - legacy fallback integration base: protected `main` commit
   `5a7e441bfc754af2bf95ec49a5ec113951c7c0bf`
@@ -242,6 +246,8 @@ MCP registry for a conformance run.
 | Claude Code 2.1.204, modern-only seam, 20 August | Strict temporary MCP configuration and non-persistent session | `not_ready`: legacy `initialize` rejected `-32022`; capability unscored |
 | Claude Code 2.1.204, protected-main legacy seam, 23 August | Isolated `mcp list` transport check against the protected-main source named below | `ready`: legacy initialisation and `tools/list` passed; capability unscored |
 | Claude Code 2.1.241, strict modern and fallback seams, 24 August | Two credential-free `mcp list` checks against exact protected main `dda0eb9` | strict `2026-07-28` `not_ready`: client offered `2025-11-25` and received `-32022`; constructor-only fallback `ready`: initialisation and `tools/list` passed; capability unscored |
+| Claude Code 2.1.241, v2 automatic negotiation, 25 August | Two-session credential-free `mcp list` observation against exact protected main `c679b6f` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
+| Claude Code 2.1.245, v2 automatic negotiation, 25 August | Fresh two-session credential-free `mcp list` observation after the parent-identity repair reached exact protected main `e905c63` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
 | VS Code 1.134.0 | Temporary workspace and MCP registry; prove correct window attachment | `not_ready`: no GitHub token and no proved chat attachment; zero MCP traffic |
 | Official SDK client | HTTP and STDIO discovery, calls, resources and shutdown | Accepted on protected `main` |
 
@@ -741,6 +747,30 @@ observed client and configuration. It does not score a tool call, complete the
 exact-five operation journey or exercise a model, provider, remote HTTP host,
 registration, activation, deployment or release. Run the separately bounded
 capability pack before claiming independent-host capability.
+
+### Claude Code 2.1.245 protected-main readiness
+
+After the macOS parent-executable compatibility repair merged, a fresh isolated
+`claude mcp list` observation used exact protected-main commit
+`e905c632724ecc9d13b13452fee37328e75cc2a4`, tree
+`c611ba2d86dcefb541814e5cd4ab3345dd8745b6`. The exact arm64 Claude Code
+`2.1.245` binary was `376109392` bytes with SHA-256
+`9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1`.
+It reported `Connected`.
+
+With the v2 runtime and automatic negotiation selected, one direct child completed
+`server/discover` and a separate direct child completed `tools/list`, both claiming
+MCP `2026-07-28`. Independent offline replay accepted both sessions. Every
+provider, egress, pending-request, anomaly, error and stderr counter was zero, and
+no observer or fixture remained. The path-free
+[`2.1.245 strict-modern readiness summary`](../../tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json)
+binds the exact source and runtime materials to retained private-capture digests.
+The earlier `2.1.241` schema and readiness record remain byte-exact lineage.
+
+This is transport readiness for that exact client and configuration, not a model or
+tool capability pass. No model task, tool call, resource read, exact-five journey,
+provider, remote HTTP host, registration, activation, deployment or release was
+exercised. The next independent-host step remains the bounded capability pack.
 
 ## Historical failure-derived cases
 

--- a/schemas/qual-206-claude-composite-stdio-readiness-v2.schema.json
+++ b/schemas/qual-206-claude-composite-stdio-readiness-v2.schema.json
@@ -1,0 +1,629 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:gis-ai-go:schema:qual-206-claude-composite-stdio-readiness:v2",
+  "title": "QUAL-206 Claude Code 2.1.245 strict-modern STDIO readiness",
+  "description": "A closed, path-free public projection of one verified two-session Claude Code 2.1.245 transport observation. It cannot score host capability.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_contract",
+    "status",
+    "observed_at",
+    "source",
+    "host",
+    "protocol_target",
+    "documentation_sources",
+    "runtime_materials",
+    "sessions",
+    "verification",
+    "isolation",
+    "historical_lineage",
+    "limitations",
+    "boundary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "gis-ai-go.qual-206-claude-composite-stdio-readiness.v2"
+    },
+    "schema_contract": {
+      "$ref": "#/$defs/schemaContract"
+    },
+    "status": {
+      "const": "strict-modern-transport-readiness-pass-capability-unscored"
+    },
+    "observed_at": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started", "completed"],
+      "properties": {
+        "started": {"const": "2026-08-25T16:12:36.853Z"},
+        "completed": {"const": "2026-08-25T16:12:37.921Z"}
+      }
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "host": {
+      "$ref": "#/$defs/host"
+    },
+    "protocol_target": {
+      "$ref": "#/$defs/protocolTarget"
+    },
+    "documentation_sources": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "const": {
+            "id": "S-CLAUDE-MCP-RUNTIME",
+            "uri": "https://code.claude.com/docs/en/mcp#MCP-client-runtimes",
+            "retrieved_on": "2026-08-25",
+            "supported_finding": "Claude Code 2.1.232 or later provides the v2 MCP runtime; STDIO modern-protocol discovery requires automatic negotiation."
+          }
+        },
+        {
+          "const": {
+            "id": "S-CLAUDE-ENVIRONMENT",
+            "uri": "https://code.claude.com/docs/en/env-vars",
+            "retrieved_on": "2026-08-25",
+            "supported_finding": "Claude Code exposes documented controls for non-essential traffic, background tasks, tool search, claude.ai MCP servers and subprocess credential scrubbing."
+          }
+        },
+        {
+          "const": {
+            "id": "S-MCP-SPEC",
+            "uri": "https://modelcontextprotocol.io/specification/2026-07-28",
+            "retrieved_on": "2026-08-25",
+            "supported_finding": "MCP 2026-07-28 is the strict-modern protocol target exercised by the observation."
+          }
+        }
+      ],
+      "items": false
+    },
+    "runtime_materials": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "prefixItems": [
+        {"const": {"path": "scripts/qual_206_claude_stdio_observer.mjs", "sha256": "86f07637913c66aeb3df62fb3a8a44aee8c47b096b82a4cf914c4cf5f44d87ae"}},
+        {"const": {"path": "scripts/qual_206_exact_five_event_collector.mjs", "sha256": "be45d157c3daed81267e03be34b02eeb8fb006d8889f436ee531e315fba6bdc0"}},
+        {"const": {"path": "tests/interoperability/fixtures/qual_206_strict_modern_event_server.mjs", "sha256": "04e274f89dc6abbb97b445e12a38a45588bd1273dbd318c0bdadb9cac6d97a98"}},
+        {"const": {"path": "tests/interoperability/fixtures/qual_206_provider_egress_guard.mjs", "sha256": "f34757b6c7c555adb37a2d5fffbb164a264a689fe603e12f25703fea8d46eafe"}},
+        {"const": {"path": "scripts/verify_qual_206_claude_composite_observation.py", "sha256": "79fd56d43ae8b644089e205a2d8fb3b0e448232a266eb00c47693f844d7fe90d"}},
+        {"const": {"path": "schemas/qual-206-claude-composite-host-event-v1.schema.json", "sha256": "3fa5d43594309ce6674da8f596ef7b55405f82a38db85458a1bbfe5b02af4dc4"}},
+        {"const": {"path": "schemas/qual-206-claude-composite-host-event-capture-v1.schema.json", "sha256": "9e8df35db3910104019d2319643a37de0dc28d6d239c8532e28c08668d162082"}}
+      ],
+      "items": false
+    },
+    "sessions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {
+          "allOf": [
+            {"$ref": "#/$defs/session"},
+            {
+              "properties": {
+                "slot": {"const": "session-1"},
+                "profile": {"const": "negotiation-probe"},
+                "started_at": {"const": "2026-08-25T16:12:36.853Z"},
+                "completed_at": {"const": "2026-08-25T16:12:37.158Z"},
+                "request": {
+                  "properties": {
+                    "method": {"const": "server/discover"},
+                    "request_id_kind": {"const": "string"},
+                    "frame_bytes": {"const": 441},
+                    "frame_sha256": {"const": "e1b7bc8140fcdd7893dd8d52f1a035ba6379725abd98ad51e260834111adc37b"}
+                  }
+                },
+                "response": {
+                  "properties": {
+                    "request_method": {"const": "server/discover"},
+                    "semantic": {"const": "discover-pass"},
+                    "duration_ms": {"const": 236.521708},
+                    "frame_bytes": {"const": 606},
+                    "frame_sha256": {"const": "ddcbbb84d2d658b089c640c85f97b6f240b5f44d90435b37c148f5d2de68e475"}
+                  }
+                },
+                "closure_stimulus": {"const": "sigterm"},
+                "retained_private_evidence": {
+                  "properties": {
+                    "manifest_bytes": {"const": 727},
+                    "manifest_sha256": {"const": "78b844092982fc38314070d0e29616867731fc40326ec8ad3c0ad80c8cfc650c"},
+                    "event_log_bytes": {"const": 10077},
+                    "event_count": {"const": 13},
+                    "last_event_sha256": {"const": "0ba21221143cefa20a45d4698adfdbe0baa2c39ad0ba280cbcd7176360a42516"},
+                    "event_log_sha256": {"const": "1b12d9d95cca278df607ee3768d292aea2f459bd00943be248879facad438b95"}
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/session"},
+            {
+              "properties": {
+                "slot": {"const": "session-2"},
+                "profile": {"const": "modern-session"},
+                "started_at": {"const": "2026-08-25T16:12:37.619Z"},
+                "completed_at": {"const": "2026-08-25T16:12:37.921Z"},
+                "request": {
+                  "properties": {
+                    "method": {"const": "tools/list"},
+                    "request_id_kind": {"const": "integer"},
+                    "frame_bytes": {"const": 412},
+                    "frame_sha256": {"const": "5e1d1d023f6bdffd7b4ea45ef8c4e8e23bd0d720ff27a44989e0b7713fac20c4"}
+                  }
+                },
+                "response": {
+                  "properties": {
+                    "request_method": {"const": "tools/list"},
+                    "semantic": {"const": "tools-list-pass"},
+                    "duration_ms": {"const": 236.087292},
+                    "frame_bytes": {"const": 146625},
+                    "frame_sha256": {"const": "14c103b7e0c93d3851b22d6b2a4de3d497437f438fc940dae6a2dc0bc2ecb85a"}
+                  }
+                },
+                "closure_stimulus": {"const": "sigint"},
+                "retained_private_evidence": {
+                  "properties": {
+                    "manifest_bytes": {"const": 724},
+                    "manifest_sha256": {"const": "04a4519d697938bc7d71fa9aa3bd995fc3ba68d544b95d59f2d1d29f45eb7eb4"},
+                    "event_log_bytes": {"const": 10073},
+                    "event_count": {"const": 13},
+                    "last_event_sha256": {"const": "b8b0462c05f0290436d55c2d1475f22c1ed922624b7bba48da2af5a3662b33cb"},
+                    "event_log_sha256": {"const": "bcc68283c99f5245a829279ac0c224e7e5fc95a7dbd97f3611ef70e98e1bb78d"}
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "verification": {
+      "$ref": "#/$defs/verification"
+    },
+    "isolation": {
+      "$ref": "#/$defs/isolation"
+    },
+    "historical_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relationship", "preserved_artifacts"],
+      "properties": {
+        "relationship": {
+          "const": "preserved-prior-2.1.241-readiness-result-not-relabelled"
+        },
+        "preserved_artifacts": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "prefixItems": [
+            {"const": {"path": "schemas/qual-206-claude-composite-stdio-readiness.schema.json", "sha256": "0999efbed9c9b4267370cf9ee0b66dfe9c36824b2b6ab9d76c3af1f87bfed930"}},
+            {"const": {"path": "tests/interoperability/evidence/claude-code-2.1.241-modern-stdio-readiness-2026-08-25.json", "sha256": "eecb01a605d678a0fc2a1603e6b3e3be340890b3c9d9c9b5f1a1eb6070043639"}}
+          ],
+          "items": false
+        }
+      }
+    },
+    "limitations": {
+      "$ref": "#/$defs/limitations"
+    },
+    "boundary": {
+      "const": "Accepted protected-main Claude Code 2.1.245 strict-modern STDIO transport-readiness evidence only. In v2 automatic negotiation, Claude completed a contract-valid MCP 2026-07-28 server/discover probe and a separate tools/list session. No model task, tool call, resource read, exact-five operation journey, provider, remote HTTP host, registration, activation, deployment or release was exercised. Capability remains unscored, and the independent-host capability and exact-five source-binding gates remain incomplete."
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "schemaContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "const": "schemas/qual-206-claude-composite-stdio-readiness-v2.schema.json"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit",
+        "tree",
+        "version",
+        "protected_main",
+        "detached_checkout",
+        "working_tree_clean",
+        "local_origin_main_matched",
+        "assurance",
+        "production_registration",
+        "production_activation",
+        "public_endpoint_created",
+        "deployment_performed",
+        "release_performed"
+      ],
+      "properties": {
+        "repository": {"const": "chris-page-gov/gis-ai-go"},
+        "commit": {"const": "e905c632724ecc9d13b13452fee37328e75cc2a4"},
+        "tree": {"const": "c611ba2d86dcefb541814e5cd4ab3345dd8745b6"},
+        "version": {"const": "0.1.0"},
+        "protected_main": {"const": true},
+        "detached_checkout": {"const": true},
+        "working_tree_clean": {"const": true},
+        "local_origin_main_matched": {"const": true},
+        "assurance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ci_run_id",
+            "codeql_run_id",
+            "repository_assurance_passed",
+            "gateway_image_assurance_passed",
+            "independent_gateway_derivation_passed",
+            "gateway_byte_comparison_passed",
+            "pages_provenance_recorded",
+            "gateway_provenance_recorded",
+            "codeql_passed"
+          ],
+          "properties": {
+            "ci_run_id": {"const": 32868256571},
+            "codeql_run_id": {"const": 32868252219},
+            "repository_assurance_passed": {"const": true},
+            "gateway_image_assurance_passed": {"const": true},
+            "independent_gateway_derivation_passed": {"const": true},
+            "gateway_byte_comparison_passed": {"const": true},
+            "pages_provenance_recorded": {"const": true},
+            "gateway_provenance_recorded": {"const": true},
+            "codeql_passed": {"const": true}
+          }
+        },
+        "production_registration": {"const": false},
+        "production_activation": {"const": false},
+        "public_endpoint_created": {"const": false},
+        "deployment_performed": {"const": false},
+        "release_performed": {"const": false}
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "platform",
+        "architecture",
+        "binary_bytes",
+        "binary_sha256",
+        "binary_path_published",
+        "command",
+        "host_result",
+        "transport_readiness",
+        "capability",
+        "model_authentication_supplied",
+        "model_task_requested",
+        "node_runtime"
+      ],
+      "properties": {
+        "name": {"const": "Claude Code"},
+        "version": {"const": "2.1.245"},
+        "platform": {"const": "darwin"},
+        "architecture": {"const": "arm64"},
+        "binary_bytes": {"const": 376109392},
+        "binary_sha256": {"const": "9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1"},
+        "binary_path_published": {"const": false},
+        "command": {"const": "mcp list"},
+        "host_result": {"const": "Connected"},
+        "transport_readiness": {"const": "ready"},
+        "capability": {"const": "unscored"},
+        "model_authentication_supplied": {"const": false},
+        "model_task_requested": {"const": false},
+        "node_runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["version", "executable_bytes", "executable_sha256", "path_published"],
+          "properties": {
+            "version": {"const": "v26.7.0"},
+            "executable_bytes": {"const": 50320},
+            "executable_sha256": {"const": "1ef99ea25fe70c9b67e7efe768ef8ee22148d3cabc703db6131b57aeb617d040"},
+            "path_published": {"const": false}
+          }
+        }
+      }
+    },
+    "protocolTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "source_id",
+        "client_runtime",
+        "stdio_negotiation",
+        "direct_child_sessions",
+        "legacy_initialize_observed"
+      ],
+      "properties": {
+        "version": {"const": "2026-07-28"},
+        "source_id": {"const": "S-MCP-SPEC"},
+        "client_runtime": {"const": "v2"},
+        "stdio_negotiation": {"const": "auto"},
+        "direct_child_sessions": {"const": 2},
+        "legacy_initialize_observed": {"const": false}
+      }
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "protocol_claim",
+        "request_id_kind",
+        "request_id_unique",
+        "frame_bytes",
+        "frame_sha256"
+      ],
+      "properties": {
+        "method": {"enum": ["server/discover", "tools/list"]},
+        "protocol_claim": {"const": "2026-07-28"},
+        "request_id_kind": {"enum": ["string", "integer"]},
+        "request_id_unique": {"const": true},
+        "frame_bytes": {"type": "integer", "minimum": 1, "maximum": 1048576},
+        "frame_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_method",
+        "outcome",
+        "error_code",
+        "correlation",
+        "contract_valid",
+        "semantic",
+        "duration_ms",
+        "frame_bytes",
+        "frame_sha256"
+      ],
+      "properties": {
+        "request_method": {"enum": ["server/discover", "tools/list"]},
+        "outcome": {"const": "success"},
+        "error_code": {"type": "null"},
+        "correlation": {"const": "matched"},
+        "contract_valid": {"const": true},
+        "semantic": {"enum": ["discover-pass", "tools-list-pass"]},
+        "duration_ms": {"type": "number", "minimum": 0, "maximum": 120000},
+        "frame_bytes": {"type": "integer", "minimum": 1, "maximum": 1048576},
+        "frame_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "auditCounters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "guarded_api_invocations",
+        "provider_transport_calls",
+        "aborted_provider_calls",
+        "ledger_events",
+        "reported_errors"
+      ],
+      "properties": {
+        "guarded_api_invocations": {"const": 0},
+        "provider_transport_calls": {"const": 0},
+        "aborted_provider_calls": {"const": 0},
+        "ledger_events": {"const": 0},
+        "reported_errors": {"const": 0}
+      }
+    },
+    "retainedPrivateEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest_bytes",
+        "manifest_sha256",
+        "event_log_bytes",
+        "event_count",
+        "last_event_sha256",
+        "event_log_sha256",
+        "raw_content_published"
+      ],
+      "properties": {
+        "manifest_bytes": {"type": "integer", "minimum": 1, "maximum": 65536},
+        "manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "event_log_bytes": {"type": "integer", "minimum": 1, "maximum": 8388608},
+        "event_count": {"type": "integer", "minimum": 3, "maximum": 512},
+        "last_event_sha256": {"$ref": "#/$defs/sha256"},
+        "event_log_sha256": {"$ref": "#/$defs/sha256"},
+        "raw_content_published": {"const": false}
+      }
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slot",
+        "profile",
+        "started_at",
+        "completed_at",
+        "protocol_session_status",
+        "request",
+        "response",
+        "closure_stimulus",
+        "exit_code",
+        "signal",
+        "request_count",
+        "response_count",
+        "pending_request_count",
+        "anomaly_count",
+        "stderr_bytes",
+        "stderr_event_count",
+        "temporary_state_removed",
+        "runtime_materials_stable",
+        "source_checkout_stable",
+        "audit_counters",
+        "retained_private_evidence"
+      ],
+      "properties": {
+        "slot": {"enum": ["session-1", "session-2"]},
+        "profile": {"enum": ["negotiation-probe", "modern-session"]},
+        "started_at": {"type": "string", "format": "date-time"},
+        "completed_at": {"type": "string", "format": "date-time"},
+        "protocol_session_status": {"const": "passed"},
+        "request": {"$ref": "#/$defs/request"},
+        "response": {"$ref": "#/$defs/response"},
+        "closure_stimulus": {"enum": ["sigterm", "sigint"]},
+        "exit_code": {"const": 0},
+        "signal": {"type": "null"},
+        "request_count": {"const": 1},
+        "response_count": {"const": 1},
+        "pending_request_count": {"const": 0},
+        "anomaly_count": {"const": 0},
+        "stderr_bytes": {"const": 0},
+        "stderr_event_count": {"const": 0},
+        "temporary_state_removed": {"const": true},
+        "runtime_materials_stable": {"const": true},
+        "source_checkout_stable": {"const": true},
+        "audit_counters": {"$ref": "#/$defs/auditCounters"},
+        "retained_private_evidence": {"$ref": "#/$defs/retainedPrivateEvidence"}
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verifier_path",
+        "verifier_sha256",
+        "result",
+        "session_count",
+        "negotiation_probe_request_count",
+        "modern_session_request_count",
+        "capture_verified_before_projection",
+        "remaining_observer_processes",
+        "remaining_fixture_processes",
+        "private_archive_owner_only",
+        "public_projection_path_free"
+      ],
+      "properties": {
+        "verifier_path": {"const": "scripts/verify_qual_206_claude_composite_observation.py"},
+        "verifier_sha256": {"const": "79fd56d43ae8b644089e205a2d8fb3b0e448232a266eb00c47693f844d7fe90d"},
+        "result": {"const": "passed"},
+        "session_count": {"const": 2},
+        "negotiation_probe_request_count": {"const": 1},
+        "modern_session_request_count": {"const": 1},
+        "capture_verified_before_projection": {"const": true},
+        "remaining_observer_processes": {"const": 0},
+        "remaining_fixture_processes": {"const": 0},
+        "private_archive_owner_only": {"const": true},
+        "public_projection_path_free": {"const": true}
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "disposable_profile",
+        "profile_root_mode",
+        "primary_configuration_mode",
+        "normal_profile_used",
+        "managed_settings_file_present",
+        "managed_mcp_file_present",
+        "managed_settings_drop_in_present",
+        "managed_preferences_domain_present",
+        "parent_environment_allowlisted",
+        "recognised_parent_credential_variables_present",
+        "mcp_child_environment",
+        "nonessential_traffic_disabled",
+        "background_tasks_disabled",
+        "tool_search_disabled",
+        "claude_ai_mcp_servers_disabled",
+        "discovery_cache_disabled",
+        "subprocess_credential_scrub_enabled",
+        "provider_egress_guard_enabled",
+        "private_client_output",
+        "raw_host_logs_published"
+      ],
+      "properties": {
+        "disposable_profile": {"const": true},
+        "profile_root_mode": {"const": "0700"},
+        "primary_configuration_mode": {"const": "0600"},
+        "normal_profile_used": {"const": false},
+        "managed_settings_file_present": {"const": false},
+        "managed_mcp_file_present": {"const": false},
+        "managed_settings_drop_in_present": {"const": false},
+        "managed_preferences_domain_present": {"const": false},
+        "parent_environment_allowlisted": {"const": true},
+        "recognised_parent_credential_variables_present": {"const": 0},
+        "mcp_child_environment": {"const": "closed-credential-free"},
+        "nonessential_traffic_disabled": {"const": true},
+        "background_tasks_disabled": {"const": true},
+        "tool_search_disabled": {"const": true},
+        "claude_ai_mcp_servers_disabled": {"const": true},
+        "discovery_cache_disabled": {"const": true},
+        "subprocess_credential_scrub_enabled": {"const": true},
+        "provider_egress_guard_enabled": {"const": true},
+        "private_client_output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bytes", "sha256", "mode", "published"],
+          "properties": {
+            "bytes": {"const": 582},
+            "sha256": {"const": "8786050455e73df9a264b90b9098d502a6003c7f97c3fc868560ace5fb735a1e"},
+            "mode": {"const": "0600"},
+            "published": {"const": false}
+          }
+        },
+        "raw_host_logs_published": {"const": false}
+      }
+    },
+    "limitations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strict_modern_transport_ready",
+        "capability_result_claimed",
+        "independent_host_capability_gate_completed",
+        "source_binding_ready",
+        "exact_five_operation_journey_exercised",
+        "model_task_requested",
+        "tool_call_observed",
+        "resource_read_observed",
+        "live_provider_called",
+        "remote_http_observed",
+        "registration_performed",
+        "activation_performed",
+        "deployment_performed",
+        "release_performed"
+      ],
+      "properties": {
+        "strict_modern_transport_ready": {"const": true},
+        "capability_result_claimed": {"const": false},
+        "independent_host_capability_gate_completed": {"const": false},
+        "source_binding_ready": {"const": false},
+        "exact_five_operation_journey_exercised": {"const": false},
+        "model_task_requested": {"const": false},
+        "tool_call_observed": {"const": false},
+        "resource_read_observed": {"const": false},
+        "live_provider_called": {"const": false},
+        "remote_http_observed": {"const": false},
+        "registration_performed": {"const": false},
+        "activation_performed": {"const": false},
+        "deployment_performed": {"const": false},
+        "release_performed": {"const": false}
+      }
+    }
+  }
+}

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -881,6 +881,22 @@ def main() -> None:
             ],
         ),
         (
+            "qual-206-claude-composite-stdio-readiness-v2.schema.json",
+            [
+                (
+                    "tests/interoperability/evidence/"
+                    "claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json",
+                    load_json(
+                        ROOT
+                        / "tests"
+                        / "interoperability"
+                        / "evidence"
+                        / "claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json"
+                    ),
+                )
+            ],
+        ),
+        (
             "qual-206-local-http-transport-preflight.schema.json",
             [
                 (

--- a/tests/contract/test_qual_206_claude_composite_stdio_readiness_v2.py
+++ b/tests/contract/test_qual_206_claude_composite_stdio_readiness_v2.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = (
+    ROOT / "schemas" / "qual-206-claude-composite-stdio-readiness-v2.schema.json"
+)
+EVIDENCE_PATH = (
+    ROOT
+    / "tests"
+    / "interoperability"
+    / "evidence"
+    / "claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json"
+)
+RUNBOOK_PATH = ROOT / "docs" / "operations" / "QUAL-206_CLAUDE_COMPOSITE_OBSERVATION.md"
+EVIDENCE_README_PATH = ROOT / "tests" / "interoperability" / "evidence" / "README.md"
+SOURCE_COMMIT = "e905c632724ecc9d13b13452fee37328e75cc2a4"
+SOURCE_TREE = "c611ba2d86dcefb541814e5cd4ab3345dd8745b6"
+SCHEMA_SHA256 = "729e8a6d5a3a2799a601a6d86588aaebef76fc6a053de254fdf2cacb77ec49aa"
+EVIDENCE_SHA256 = "a588d5cfe211f0a7f571b736cb86e8ef0105999089d59e81239364fe4b804b23"
+HISTORICAL_ARTIFACTS = {
+    "schemas/qual-206-claude-composite-stdio-readiness.schema.json": (
+        "0999efbed9c9b4267370cf9ee0b66dfe9c36824b2b6ab9d76c3af1f87bfed930"
+    ),
+    (
+        "tests/interoperability/evidence/"
+        "claude-code-2.1.241-modern-stdio-readiness-2026-08-25.json"
+    ): "eecb01a605d678a0fc2a1603e6b3e3be340890b3c9d9c9b5f1a1eb6070043639",
+}
+EXPECTED_RUNTIME_MATERIALS = {
+    "scripts/qual_206_claude_stdio_observer.mjs": (
+        "86f07637913c66aeb3df62fb3a8a44aee8c47b096b82a4cf914c4cf5f44d87ae"
+    ),
+    "scripts/qual_206_exact_five_event_collector.mjs": (
+        "be45d157c3daed81267e03be34b02eeb8fb006d8889f436ee531e315fba6bdc0"
+    ),
+    "tests/interoperability/fixtures/qual_206_strict_modern_event_server.mjs": (
+        "04e274f89dc6abbb97b445e12a38a45588bd1273dbd318c0bdadb9cac6d97a98"
+    ),
+    "tests/interoperability/fixtures/qual_206_provider_egress_guard.mjs": (
+        "f34757b6c7c555adb37a2d5fffbb164a264a689fe603e12f25703fea8d46eafe"
+    ),
+    "scripts/verify_qual_206_claude_composite_observation.py": (
+        "79fd56d43ae8b644089e205a2d8fb3b0e448232a266eb00c47693f844d7fe90d"
+    ),
+    "schemas/qual-206-claude-composite-host-event-v1.schema.json": (
+        "3fa5d43594309ce6674da8f596ef7b55405f82a38db85458a1bbfe5b02af4dc4"
+    ),
+    "schemas/qual-206-claude-composite-host-event-capture-v1.schema.json": (
+        "9e8df35db3910104019d2319643a37de0dc28d6d239c8532e28c08668d162082"
+    ),
+}
+BOUNDARY = (
+    "Accepted protected-main Claude Code 2.1.245 strict-modern STDIO "
+    "transport-readiness evidence only. In v2 automatic negotiation, Claude "
+    "completed a contract-valid MCP 2026-07-28 server/discover probe and a "
+    "separate tools/list session. No model task, tool call, resource read, "
+    "exact-five operation journey, provider, remote HTTP host, registration, "
+    "activation, deployment or release was exercised. Capability remains "
+    "unscored, and the independent-host capability and exact-five source-binding "
+    "gates remain incomplete."
+)
+PUBLIC_EVIDENCE_FORBIDDEN = re.compile(
+    r"(?:"
+    r"/Users/|/home/|/Volumes/|/private/tmp/|file://|"
+    r"[A-Za-z]:\\\\Users\\\\|"
+    r"\bsk-[A-Za-z0-9_-]{8,}|\bgh[opusr]_[A-Za-z0-9]{8,}|"
+    r"\bxox[baprs]-[A-Za-z0-9-]{8,}|\bAKIA[0-9A-Z]{16}|"
+    r"\bBearer\s+[A-Za-z0-9._~-]+|"
+    r"OPENAI_API_KEY|CODEX_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|"
+    r"CLAUDE_CODE_OAUTH_TOKEN|"
+    r"https?://(?:chatgpt\.com/c/|claude\.ai/chat/)|"
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-"
+    r"[0-9a-f]{12}\b"
+    r")",
+    re.IGNORECASE,
+)
+FORBIDDEN_FIELD_NAMES = {
+    "arguments",
+    "command_sha256",
+    "environment",
+    "headers",
+    "immediate_parent",
+    "log_path",
+    "machine_id",
+    "pid",
+    "profile_path",
+    "raw_command",
+    "raw_result",
+    "request_id_sha256",
+    "run_id",
+    "session_id",
+    "user_id",
+}
+
+
+def reject_non_standard_number(value: str) -> None:
+    raise ValueError(f"Non-standard JSON number: {value}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=reject_non_standard_number,
+    )
+    if not isinstance(value, dict):
+        raise TypeError(f"{path} must contain one JSON object")
+    return value
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def git_output(*arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise AssertionError(f"git {' '.join(arguments)} failed: {message}")
+    return result.stdout
+
+
+def git_blob(commit: str, path: str) -> bytes:
+    return git_output("show", f"{commit}:{path}")
+
+
+def nested_field_names(node: object) -> set[str]:
+    names: set[str] = set()
+    if isinstance(node, dict):
+        names.update(node)
+        for value in node.values():
+            names.update(nested_field_names(value))
+    elif isinstance(node, list):
+        for value in node:
+            names.update(nested_field_names(value))
+    return names
+
+
+def assert_contract_objects_are_closed(
+    test_case: unittest.TestCase,
+    node: object,
+    path: str = "$",
+) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            test_case.assertIs(
+                node.get("additionalProperties"),
+                False,
+                f"{path} must reject unknown properties",
+            )
+        for key, value in node.items():
+            assert_contract_objects_are_closed(test_case, value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            assert_contract_objects_are_closed(test_case, value, f"{path}[{index}]")
+
+
+class Qual206ClaudeCompositeStdioReadinessV2Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = load_json(SCHEMA_PATH)
+        cls.document = load_json(EVIDENCE_PATH)
+        cls.validator = Draft202012Validator(
+            cls.schema,
+            format_checker=FormatChecker(),
+        )
+
+    def assert_invalid(self, value: object) -> None:
+        self.assertTrue(list(self.validator.iter_errors(value)))
+
+    def test_closed_schema_accepts_exact_canonical_projection(self) -> None:
+        Draft202012Validator.check_schema(self.schema)
+        assert_contract_objects_are_closed(self, self.schema)
+        errors = sorted(
+            self.validator.iter_errors(self.document),
+            key=lambda error: list(error.absolute_path),
+        )
+        self.assertEqual(
+            [],
+            [
+                f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: "
+                f"{error.message}"
+                for error in errors
+            ],
+        )
+        expected_bytes = (
+            json.dumps(self.document, ensure_ascii=False, indent=2) + "\n"
+        ).encode()
+        self.assertEqual(EVIDENCE_PATH.read_bytes(), expected_bytes)
+        self.assertEqual(sha256_bytes(SCHEMA_PATH.read_bytes()), SCHEMA_SHA256)
+        self.assertEqual(sha256_bytes(EVIDENCE_PATH.read_bytes()), EVIDENCE_SHA256)
+        self.assertEqual(
+            self.document["schema_contract"],
+            {
+                "path": (
+                    "schemas/qual-206-claude-composite-stdio-readiness-v2.schema.json"
+                ),
+                "sha256": SCHEMA_SHA256,
+            },
+        )
+
+    def test_projection_binds_exact_protected_main_source_and_runtime(self) -> None:
+        source = self.document["source"]
+        self.assertEqual(source["commit"], SOURCE_COMMIT)
+        self.assertEqual(source["tree"], SOURCE_TREE)
+        self.assertEqual(
+            git_output("rev-parse", f"{SOURCE_COMMIT}^{{tree}}").decode().strip(),
+            SOURCE_TREE,
+        )
+        self.assertEqual(
+            git_output("merge-base", "--is-ancestor", SOURCE_COMMIT, "HEAD"),
+            b"",
+        )
+        actual_materials = {
+            item["path"]: item["sha256"]
+            for item in self.document["runtime_materials"]
+        }
+        self.assertEqual(actual_materials, EXPECTED_RUNTIME_MATERIALS)
+        for path, expected_digest in EXPECTED_RUNTIME_MATERIALS.items():
+            with self.subTest(path=path):
+                self.assertEqual(
+                    sha256_bytes(git_blob(SOURCE_COMMIT, path)),
+                    expected_digest,
+                )
+        assurance = source["assurance"]
+        self.assertTrue(all(
+            value is True
+            for key, value in assurance.items()
+            if key not in {"ci_run_id", "codeql_run_id"}
+        ))
+
+    def test_two_sessions_prove_transport_readiness_only(self) -> None:
+        probe, modern = self.document["sessions"]
+        self.assertEqual(
+            (probe["profile"], probe["request"]["method"], probe["closure_stimulus"]),
+            ("negotiation-probe", "server/discover", "sigterm"),
+        )
+        self.assertEqual(
+            (modern["profile"], modern["request"]["method"], modern["closure_stimulus"]),
+            ("modern-session", "tools/list", "sigint"),
+        )
+        for session in (probe, modern):
+            self.assertEqual(session["request"]["protocol_claim"], "2026-07-28")
+            self.assertEqual(session["response"]["outcome"], "success")
+            self.assertTrue(session["response"]["contract_valid"])
+            self.assertEqual(session["request_count"], session["response_count"])
+            self.assertEqual(session["request_count"], 1)
+            for key in (
+                "pending_request_count",
+                "anomaly_count",
+                "stderr_bytes",
+                "stderr_event_count",
+            ):
+                self.assertEqual(session[key], 0)
+            self.assertTrue(session["temporary_state_removed"])
+            self.assertTrue(session["runtime_materials_stable"])
+            self.assertTrue(session["source_checkout_stable"])
+            self.assertEqual(set(session["audit_counters"].values()), {0})
+            self.assertFalse(
+                session["retained_private_evidence"]["raw_content_published"]
+            )
+        self.assertFalse(self.document["protocol_target"]["legacy_initialize_observed"])
+        self.assertEqual(self.document["host"]["transport_readiness"], "ready")
+        self.assertEqual(self.document["host"]["capability"], "unscored")
+
+    def test_isolation_verification_and_limitations_remain_fail_closed(self) -> None:
+        verification = self.document["verification"]
+        self.assertEqual(verification["result"], "passed")
+        self.assertEqual(verification["session_count"], 2)
+        self.assertEqual(verification["remaining_observer_processes"], 0)
+        self.assertEqual(verification["remaining_fixture_processes"], 0)
+        self.assertTrue(verification["private_archive_owner_only"])
+        self.assertTrue(verification["public_projection_path_free"])
+
+        isolation = self.document["isolation"]
+        self.assertTrue(isolation["disposable_profile"])
+        self.assertFalse(isolation["normal_profile_used"])
+        self.assertEqual(isolation["recognised_parent_credential_variables_present"], 0)
+        self.assertEqual(isolation["mcp_child_environment"], "closed-credential-free")
+        self.assertFalse(isolation["raw_host_logs_published"])
+        self.assertFalse(isolation["private_client_output"]["published"])
+
+        limitations = self.document["limitations"]
+        self.assertTrue(limitations["strict_modern_transport_ready"])
+        self.assertFalse(any(
+            value
+            for key, value in limitations.items()
+            if key != "strict_modern_transport_ready"
+        ))
+        self.assertEqual(self.document["boundary"], BOUNDARY)
+
+    def test_historical_observation_remains_byte_exact_and_separate(self) -> None:
+        lineage = self.document["historical_lineage"]
+        self.assertEqual(
+            lineage["relationship"],
+            "preserved-prior-2.1.241-readiness-result-not-relabelled",
+        )
+        self.assertEqual(
+            {
+                item["path"]: item["sha256"]
+                for item in lineage["preserved_artifacts"]
+            },
+            HISTORICAL_ARTIFACTS,
+        )
+        for path, expected_digest in HISTORICAL_ARTIFACTS.items():
+            with self.subTest(path=path):
+                self.assertEqual(sha256_bytes((ROOT / path).read_bytes()), expected_digest)
+
+    def test_public_projection_is_path_free_and_minimised(self) -> None:
+        rendered = EVIDENCE_PATH.read_text(encoding="utf-8")
+        self.assertIsNone(PUBLIC_EVIDENCE_FORBIDDEN.search(rendered))
+        self.assertFalse(nested_field_names(self.document) & FORBIDDEN_FIELD_NAMES)
+        self.assertNotIn('"raw_content":', rendered)
+        self.assertNotIn('"source_checkout":', rendered)
+        self.assertNotIn('"observer_runtime":', rendered)
+        self.assertNotIn('"credential_environment":', rendered)
+
+    def test_schema_rejects_claim_widening_and_projection_tampering(self) -> None:
+        cases: list[tuple[str, dict[str, Any]]] = []
+
+        capability = copy.deepcopy(self.document)
+        capability["host"]["capability"] = "ready"
+        cases.append(("capability", capability))
+
+        provider = copy.deepcopy(self.document)
+        provider["limitations"]["live_provider_called"] = True
+        cases.append(("provider", provider))
+
+        raw = copy.deepcopy(self.document)
+        raw["sessions"][0]["retained_private_evidence"]["raw_content_published"] = True
+        cases.append(("raw", raw))
+
+        method = copy.deepcopy(self.document)
+        method["sessions"][1]["request"]["method"] = "initialize"
+        cases.append(("method", method))
+
+        extra = copy.deepcopy(self.document)
+        extra["session_id"] = "not-allowed"
+        cases.append(("extra", extra))
+
+        for label, value in cases:
+            with self.subTest(label=label):
+                self.assert_invalid(value)
+
+    def test_runbook_and_evidence_readme_state_the_accepted_boundary(self) -> None:
+        filename = EVIDENCE_PATH.name
+        for path in (RUNBOOK_PATH, EVIDENCE_README_PATH):
+            with self.subTest(path=path):
+                text = path.read_text(encoding="utf-8")
+                self.assertIn(filename, text)
+                self.assertIn("capability", text.casefold())
+                self.assertIn("2026-07-28", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -62,6 +62,23 @@ was used. The 24 August default-negotiation observation remains byte-exact and i
 not relabelled; raw logs, profile data and process identities remain private and
 local.
 
+The additive
+[`Claude Code 2.1.245 strict-modern STDIO readiness summary`](claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json)
+records a fresh observation after the macOS parent-executable binding repair reached
+protected `main` at commit `e905c632724ecc9d13b13452fee37328e75cc2a4`, tree
+`c611ba2d86dcefb541814e5cd4ab3345dd8745b6`. The exact installed binary reported
+`2.1.245 (Claude Code)` and `Connected`. The same two-session MCP `2026-07-28`
+journey passed independent replay with zero provider traffic, pending requests,
+anomalies or stderr. Repository, gateway-image and provenance assurance passed in
+[run 32868256571](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32868256571),
+and all CodeQL analyses passed in
+[run 32868252219](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32868252219).
+The public projection is path-free and preserves the 2.1.241 schema and evidence
+digests as historical lineage. It proves transport readiness only: capability,
+the exact-five journey, remote HTTP evidence, provider use, registration,
+activation, deployment and release remain incomplete or unexercised. Raw capture,
+client output, profile data and local identities remain owner-only and unpublished.
+
 The
 [`protected-main local HTTP transport preflight`](local-http-transport-preflight-2026-08-25.json)
 is a separate path-free projection from exact protected-main commit

--- a/tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json
+++ b/tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json
@@ -1,0 +1,297 @@
+{
+  "schema": "gis-ai-go.qual-206-claude-composite-stdio-readiness.v2",
+  "schema_contract": {
+    "path": "schemas/qual-206-claude-composite-stdio-readiness-v2.schema.json",
+    "sha256": "729e8a6d5a3a2799a601a6d86588aaebef76fc6a053de254fdf2cacb77ec49aa"
+  },
+  "status": "strict-modern-transport-readiness-pass-capability-unscored",
+  "observed_at": {
+    "started": "2026-08-25T16:12:36.853Z",
+    "completed": "2026-08-25T16:12:37.921Z"
+  },
+  "source": {
+    "repository": "chris-page-gov/gis-ai-go",
+    "commit": "e905c632724ecc9d13b13452fee37328e75cc2a4",
+    "tree": "c611ba2d86dcefb541814e5cd4ab3345dd8745b6",
+    "version": "0.1.0",
+    "protected_main": true,
+    "detached_checkout": true,
+    "working_tree_clean": true,
+    "local_origin_main_matched": true,
+    "assurance": {
+      "ci_run_id": 32868256571,
+      "codeql_run_id": 32868252219,
+      "repository_assurance_passed": true,
+      "gateway_image_assurance_passed": true,
+      "independent_gateway_derivation_passed": true,
+      "gateway_byte_comparison_passed": true,
+      "pages_provenance_recorded": true,
+      "gateway_provenance_recorded": true,
+      "codeql_passed": true
+    },
+    "production_registration": false,
+    "production_activation": false,
+    "public_endpoint_created": false,
+    "deployment_performed": false,
+    "release_performed": false
+  },
+  "host": {
+    "name": "Claude Code",
+    "version": "2.1.245",
+    "platform": "darwin",
+    "architecture": "arm64",
+    "binary_bytes": 376109392,
+    "binary_sha256": "9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1",
+    "binary_path_published": false,
+    "command": "mcp list",
+    "host_result": "Connected",
+    "transport_readiness": "ready",
+    "capability": "unscored",
+    "model_authentication_supplied": false,
+    "model_task_requested": false,
+    "node_runtime": {
+      "version": "v26.7.0",
+      "executable_bytes": 50320,
+      "executable_sha256": "1ef99ea25fe70c9b67e7efe768ef8ee22148d3cabc703db6131b57aeb617d040",
+      "path_published": false
+    }
+  },
+  "protocol_target": {
+    "version": "2026-07-28",
+    "source_id": "S-MCP-SPEC",
+    "client_runtime": "v2",
+    "stdio_negotiation": "auto",
+    "direct_child_sessions": 2,
+    "legacy_initialize_observed": false
+  },
+  "documentation_sources": [
+    {
+      "id": "S-CLAUDE-MCP-RUNTIME",
+      "uri": "https://code.claude.com/docs/en/mcp#MCP-client-runtimes",
+      "retrieved_on": "2026-08-25",
+      "supported_finding": "Claude Code 2.1.232 or later provides the v2 MCP runtime; STDIO modern-protocol discovery requires automatic negotiation."
+    },
+    {
+      "id": "S-CLAUDE-ENVIRONMENT",
+      "uri": "https://code.claude.com/docs/en/env-vars",
+      "retrieved_on": "2026-08-25",
+      "supported_finding": "Claude Code exposes documented controls for non-essential traffic, background tasks, tool search, claude.ai MCP servers and subprocess credential scrubbing."
+    },
+    {
+      "id": "S-MCP-SPEC",
+      "uri": "https://modelcontextprotocol.io/specification/2026-07-28",
+      "retrieved_on": "2026-08-25",
+      "supported_finding": "MCP 2026-07-28 is the strict-modern protocol target exercised by the observation."
+    }
+  ],
+  "runtime_materials": [
+    {
+      "path": "scripts/qual_206_claude_stdio_observer.mjs",
+      "sha256": "86f07637913c66aeb3df62fb3a8a44aee8c47b096b82a4cf914c4cf5f44d87ae"
+    },
+    {
+      "path": "scripts/qual_206_exact_five_event_collector.mjs",
+      "sha256": "be45d157c3daed81267e03be34b02eeb8fb006d8889f436ee531e315fba6bdc0"
+    },
+    {
+      "path": "tests/interoperability/fixtures/qual_206_strict_modern_event_server.mjs",
+      "sha256": "04e274f89dc6abbb97b445e12a38a45588bd1273dbd318c0bdadb9cac6d97a98"
+    },
+    {
+      "path": "tests/interoperability/fixtures/qual_206_provider_egress_guard.mjs",
+      "sha256": "f34757b6c7c555adb37a2d5fffbb164a264a689fe603e12f25703fea8d46eafe"
+    },
+    {
+      "path": "scripts/verify_qual_206_claude_composite_observation.py",
+      "sha256": "79fd56d43ae8b644089e205a2d8fb3b0e448232a266eb00c47693f844d7fe90d"
+    },
+    {
+      "path": "schemas/qual-206-claude-composite-host-event-v1.schema.json",
+      "sha256": "3fa5d43594309ce6674da8f596ef7b55405f82a38db85458a1bbfe5b02af4dc4"
+    },
+    {
+      "path": "schemas/qual-206-claude-composite-host-event-capture-v1.schema.json",
+      "sha256": "9e8df35db3910104019d2319643a37de0dc28d6d239c8532e28c08668d162082"
+    }
+  ],
+  "sessions": [
+    {
+      "slot": "session-1",
+      "profile": "negotiation-probe",
+      "started_at": "2026-08-25T16:12:36.853Z",
+      "completed_at": "2026-08-25T16:12:37.158Z",
+      "protocol_session_status": "passed",
+      "request": {
+        "method": "server/discover",
+        "protocol_claim": "2026-07-28",
+        "request_id_kind": "string",
+        "request_id_unique": true,
+        "frame_bytes": 441,
+        "frame_sha256": "e1b7bc8140fcdd7893dd8d52f1a035ba6379725abd98ad51e260834111adc37b"
+      },
+      "response": {
+        "request_method": "server/discover",
+        "outcome": "success",
+        "error_code": null,
+        "correlation": "matched",
+        "contract_valid": true,
+        "semantic": "discover-pass",
+        "duration_ms": 236.521708,
+        "frame_bytes": 606,
+        "frame_sha256": "ddcbbb84d2d658b089c640c85f97b6f240b5f44d90435b37c148f5d2de68e475"
+      },
+      "closure_stimulus": "sigterm",
+      "exit_code": 0,
+      "signal": null,
+      "request_count": 1,
+      "response_count": 1,
+      "pending_request_count": 0,
+      "anomaly_count": 0,
+      "stderr_bytes": 0,
+      "stderr_event_count": 0,
+      "temporary_state_removed": true,
+      "runtime_materials_stable": true,
+      "source_checkout_stable": true,
+      "audit_counters": {
+        "guarded_api_invocations": 0,
+        "provider_transport_calls": 0,
+        "aborted_provider_calls": 0,
+        "ledger_events": 0,
+        "reported_errors": 0
+      },
+      "retained_private_evidence": {
+        "manifest_bytes": 727,
+        "manifest_sha256": "78b844092982fc38314070d0e29616867731fc40326ec8ad3c0ad80c8cfc650c",
+        "event_log_bytes": 10077,
+        "event_count": 13,
+        "last_event_sha256": "0ba21221143cefa20a45d4698adfdbe0baa2c39ad0ba280cbcd7176360a42516",
+        "event_log_sha256": "1b12d9d95cca278df607ee3768d292aea2f459bd00943be248879facad438b95",
+        "raw_content_published": false
+      }
+    },
+    {
+      "slot": "session-2",
+      "profile": "modern-session",
+      "started_at": "2026-08-25T16:12:37.619Z",
+      "completed_at": "2026-08-25T16:12:37.921Z",
+      "protocol_session_status": "passed",
+      "request": {
+        "method": "tools/list",
+        "protocol_claim": "2026-07-28",
+        "request_id_kind": "integer",
+        "request_id_unique": true,
+        "frame_bytes": 412,
+        "frame_sha256": "5e1d1d023f6bdffd7b4ea45ef8c4e8e23bd0d720ff27a44989e0b7713fac20c4"
+      },
+      "response": {
+        "request_method": "tools/list",
+        "outcome": "success",
+        "error_code": null,
+        "correlation": "matched",
+        "contract_valid": true,
+        "semantic": "tools-list-pass",
+        "duration_ms": 236.087292,
+        "frame_bytes": 146625,
+        "frame_sha256": "14c103b7e0c93d3851b22d6b2a4de3d497437f438fc940dae6a2dc0bc2ecb85a"
+      },
+      "closure_stimulus": "sigint",
+      "exit_code": 0,
+      "signal": null,
+      "request_count": 1,
+      "response_count": 1,
+      "pending_request_count": 0,
+      "anomaly_count": 0,
+      "stderr_bytes": 0,
+      "stderr_event_count": 0,
+      "temporary_state_removed": true,
+      "runtime_materials_stable": true,
+      "source_checkout_stable": true,
+      "audit_counters": {
+        "guarded_api_invocations": 0,
+        "provider_transport_calls": 0,
+        "aborted_provider_calls": 0,
+        "ledger_events": 0,
+        "reported_errors": 0
+      },
+      "retained_private_evidence": {
+        "manifest_bytes": 724,
+        "manifest_sha256": "04a4519d697938bc7d71fa9aa3bd995fc3ba68d544b95d59f2d1d29f45eb7eb4",
+        "event_log_bytes": 10073,
+        "event_count": 13,
+        "last_event_sha256": "b8b0462c05f0290436d55c2d1475f22c1ed922624b7bba48da2af5a3662b33cb",
+        "event_log_sha256": "bcc68283c99f5245a829279ac0c224e7e5fc95a7dbd97f3611ef70e98e1bb78d",
+        "raw_content_published": false
+      }
+    }
+  ],
+  "verification": {
+    "verifier_path": "scripts/verify_qual_206_claude_composite_observation.py",
+    "verifier_sha256": "79fd56d43ae8b644089e205a2d8fb3b0e448232a266eb00c47693f844d7fe90d",
+    "result": "passed",
+    "session_count": 2,
+    "negotiation_probe_request_count": 1,
+    "modern_session_request_count": 1,
+    "capture_verified_before_projection": true,
+    "remaining_observer_processes": 0,
+    "remaining_fixture_processes": 0,
+    "private_archive_owner_only": true,
+    "public_projection_path_free": true
+  },
+  "isolation": {
+    "disposable_profile": true,
+    "profile_root_mode": "0700",
+    "primary_configuration_mode": "0600",
+    "normal_profile_used": false,
+    "managed_settings_file_present": false,
+    "managed_mcp_file_present": false,
+    "managed_settings_drop_in_present": false,
+    "managed_preferences_domain_present": false,
+    "parent_environment_allowlisted": true,
+    "recognised_parent_credential_variables_present": 0,
+    "mcp_child_environment": "closed-credential-free",
+    "nonessential_traffic_disabled": true,
+    "background_tasks_disabled": true,
+    "tool_search_disabled": true,
+    "claude_ai_mcp_servers_disabled": true,
+    "discovery_cache_disabled": true,
+    "subprocess_credential_scrub_enabled": true,
+    "provider_egress_guard_enabled": true,
+    "private_client_output": {
+      "bytes": 582,
+      "sha256": "8786050455e73df9a264b90b9098d502a6003c7f97c3fc868560ace5fb735a1e",
+      "mode": "0600",
+      "published": false
+    },
+    "raw_host_logs_published": false
+  },
+  "historical_lineage": {
+    "relationship": "preserved-prior-2.1.241-readiness-result-not-relabelled",
+    "preserved_artifacts": [
+      {
+        "path": "schemas/qual-206-claude-composite-stdio-readiness.schema.json",
+        "sha256": "0999efbed9c9b4267370cf9ee0b66dfe9c36824b2b6ab9d76c3af1f87bfed930"
+      },
+      {
+        "path": "tests/interoperability/evidence/claude-code-2.1.241-modern-stdio-readiness-2026-08-25.json",
+        "sha256": "eecb01a605d678a0fc2a1603e6b3e3be340890b3c9d9c9b5f1a1eb6070043639"
+      }
+    ]
+  },
+  "limitations": {
+    "strict_modern_transport_ready": true,
+    "capability_result_claimed": false,
+    "independent_host_capability_gate_completed": false,
+    "source_binding_ready": false,
+    "exact_five_operation_journey_exercised": false,
+    "model_task_requested": false,
+    "tool_call_observed": false,
+    "resource_read_observed": false,
+    "live_provider_called": false,
+    "remote_http_observed": false,
+    "registration_performed": false,
+    "activation_performed": false,
+    "deployment_performed": false,
+    "release_performed": false
+  },
+  "boundary": "Accepted protected-main Claude Code 2.1.245 strict-modern STDIO transport-readiness evidence only. In v2 automatic negotiation, Claude completed a contract-valid MCP 2026-07-28 server/discover probe and a separate tools/list session. No model task, tool call, resource read, exact-five operation journey, provider, remote HTTP host, registration, activation, deployment or release was exercised. Capability remains unscored, and the independent-host capability and exact-five source-binding gates remain incomplete."
+}


### PR DESCRIPTION
## Summary

- publish a new frozen v2 contract and path-free projection for the accepted Claude Code 2.1.245 MCP 2026-07-28 STDIO observation
- bind the observation to exact protected-main commit e905c632724ecc9d13b13452fee37328e75cc2a4, its runtime materials and retained private-capture digests
- preserve the v1 schema and Claude Code 2.1.241 readiness evidence byte-for-byte as historical lineage
- update the QUAL-206 runbooks, evidence index, progress ledger and changelog fragment

## Evidence

- the independent capture verifier accepted exactly two sessions: one server/discover probe and one tools/list session
- all provider, egress, pending-request, anomaly, error and stderr counters were zero
- the independent projection audit found no P0-P2 issues and no private path, process, run, session, credential or raw-content leakage
- 16 macOS observer lifecycle and fail-closed tests passed
- 33 focused Claude evidence contract tests passed
- the full canonical `pnpm run check` gate passed, including 222 gateway tests, 20 interoperability tests, 412 repository Python tests, 22 execution tests, 27 browser tests, deterministic release reproduction, contracts, links, secret scanning, diagrams and SBOM

## Claim boundary

This records strict-modern STDIO transport readiness for the exact Claude Code 2.1.245 binary and configuration only. It does not score model or tool capability, complete the exact-five operation journey, call a provider, prove remote HTTP hosting, register or activate the service, deploy it or release v0.2.0.

Refs #24.
