### PR TITLE
fix(qual-206): preserve Claude keychain login

### DIFF
--- a/changelog.d/QUAL-206-claude-keychain.fixed.md
+++ b/changelog.d/QUAL-206-claude-keychain.fixed.md
@@ -1,0 +1,3 @@
+Fix the Claude Code 2.1.245 first-party capability preflight so the hardened
+launcher can read the owner's normal macOS Keychain login without weakening the
+MCP network sandbox, tool boundary or credential scrubbing.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -80,7 +80,9 @@ the run. Do not use `--bare`: the exact 2.1.245 client reports that bare mode do
 not read first-party login or keychain authentication. The harness therefore uses
 the normal login profile while excluding user and project settings, disabling
 built-in tools and failing unmatched permission requests closed. The private
-preflight checks the authentication method, but no subscription value is published
+preflight checks the authentication method. It also deliberately omits
+`CLAUDE_CODE_SIMPLE=1`: the exact 2.1.245 client treats that mode as logged out even
+when its normal macOS Keychain login is valid. No subscription value is published
 and this observation makes no billing or remaining-allocation claim.
 
 The alternative API-key route requires `ANTHROPIC_API_KEY` and an owner-supplied

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -784,8 +784,10 @@ title and independently verified inline receipt in a closed structured response.
 The launcher supports the normal Claude first-party login and a separately bounded
 API-key route. Claude Code 2.1.245 does not use first-party or keychain
 authentication with `--bare`, so the first-party route deliberately omits that
-flag while retaining strict MCP configuration, `dontAsk`, one tool-use turn plus
-the final text-only turn, no session persistence and an empty disposable workspace.
+flag. It also omits `CLAUDE_CODE_SIMPLE=1`, because the exact client reports the
+normal macOS Keychain login as unavailable in that mode. The route retains strict
+MCP configuration, `dontAsk`, one tool-use turn plus the final text-only turn, no
+session persistence and an empty disposable workspace.
 The API-key route uses `--bare` and requires an explicit per-run budget. In both
 routes, recognised credential environment variables are removed before the MCP
 child starts. An identity-bound macOS Seatbelt profile denies all network access

--- a/scripts/qual_206_claude_capability_harness.mjs
+++ b/scripts/qual_206_claude_capability_harness.mjs
@@ -738,7 +738,6 @@ function closedClaudeEnvironment(authKind, environment, extra = {}) {
     CLAUDE_CODE_DISABLE_CRON: "1",
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
     CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1",
-    CLAUDE_CODE_SIMPLE: "1",
     ENABLE_CLAUDEAI_MCP_SERVERS: "false",
     MCP_TIMEOUT: "10000",
     MCP_TOOL_TIMEOUT: "60000",

--- a/tests/interoperability/test_qual_206_claude_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_capability_harness.mjs
@@ -112,12 +112,16 @@ function dependencies(scenario = "positive") {
       ...nodeIdentity(),
       version: process.versions.node,
     }),
-    authStatus: () => ({
-      api_provider: "firstParty",
-      auth_method: "claude.ai",
-      logged_in: true,
-      subscription_type: "test-profile",
-    }),
+    authStatus: (_command, environment) => {
+      assert.equal(environment.CLAUDE_CODE_SIMPLE, undefined);
+      assert.equal(environment.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, "1");
+      return {
+        api_provider: "firstParty",
+        auth_method: "claude.ai",
+        logged_in: true,
+        subscription_type: "test-profile",
+      };
+    },
     command: [realpathSync(process.execPath), FAKE],
     environment: closedEnvironment(),
     extraEnvironment: { QUAL_206_FAKE_CLAUDE_SCENARIO: scenario },


### PR DESCRIPTION
## Summary

- remove `CLAUDE_CODE_SIMPLE=1` from the bounded Claude capability environment because Claude Code 2.1.245 reports a valid macOS Keychain login as logged out in that mode
- retain credential scrubbing, non-essential-traffic suppression, the identity-bound network sandbox, exact tool boundary, `dontAsk`, empty settings sources and no session persistence
- add a regression that rejects reintroduction of the incompatible flag and document the exact first-party-login behaviour

## Evidence

- the initial protected-main observation stopped at authentication preflight before the model client was spawned and produced no private run files or capability claim
- the corrected hardened authentication environment reports the existing first-party login correctly
- focused macOS capability suite: 14 passed
- complete `pnpm run check`: passed
- independent focused review: no P0-P2 findings

## Boundary

This pull request contains no live capability evidence and makes no provider, activation, registry, deployment or release claim. A single bounded observation may be retried only after this fix merges and its exact protected-main checks pass.
