### PR TITLE
fix(qual-206): pin Claude modern MCP negotiation

### DIFF
--- a/changelog.d/QUAL-206-claude-model-negotiation.fixed.md
+++ b/changelog.d/QUAL-206-claude-model-negotiation.fixed.md
@@ -1,0 +1,3 @@
+Fix the bounded Claude Code capability launcher to select the documented v2 MCP
+runtime and automatic negotiation mode, matching the accepted strict-modern
+transport observation without changing the gateway, tool or provider boundary.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -18,6 +18,7 @@ The launcher and observer enforce all of these conditions:
 - a clean detached checkout whose `HEAD` is the exact local `origin/main` commit;
 - the accepted Claude Code `2.1.245` executable identity;
 - the pinned current model identifier `claude-sonnet-5`;
+- the documented Claude v2 MCP runtime with automatic modern/legacy-era probing;
 - one MCP server advertising only `catalogue.search` and no resources;
 - no Claude built-in tools, `dontAsk` permission mode, one tool-use turn and the
   required final text-only turn;
@@ -74,6 +75,14 @@ The preferred route uses the repository owner's normal Claude first-party login.
 Run `claude auth login` interactively if `claude auth status --json` says that the
 client is logged out. This user action is required because the harness neither
 handles nor stores login credentials.
+
+Claude Code has separate MCP runtime generations and negotiation modes. The
+capability launcher pins `MCP_SDK_GENERATION=v2` and
+`MCP_PROTOCOL_NEGOTIATION=auto`, matching the accepted strict-modern transport
+observation. This keeps `server/discover` and the final MCP `2026-07-28` session
+available on the model-task path; it is invocation-local configuration, not a
+gateway activation switch and is not forwarded into the fixture's closed child
+environment.
 
 For first-party login authentication, unset recognised credential variables before
 the run. Do not use `--bare`: the exact 2.1.245 client reports that bare mode does

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -787,7 +787,10 @@ authentication with `--bare`, so the first-party route deliberately omits that
 flag. It also omits `CLAUDE_CODE_SIMPLE=1`, because the exact client reports the
 normal macOS Keychain login as unavailable in that mode. The route retains strict
 MCP configuration, `dontAsk`, one tool-use turn plus the final text-only turn, no
-session persistence and an empty disposable workspace.
+session persistence and an empty disposable workspace. It also pins the documented
+Claude v2 MCP runtime and automatic negotiation controls used by the accepted
+strict-modern readiness observation, so the model-task path cannot silently fall
+back to a legacy `initialize` handshake when evaluating the modern surface.
 The API-key route uses `--bare` and requires an explicit per-run budget. In both
 routes, recognised credential environment variables are removed before the MCP
 child starts. An identity-bound macOS Seatbelt profile denies all network access

--- a/scripts/qual_206_claude_capability_harness.mjs
+++ b/scripts/qual_206_claude_capability_harness.mjs
@@ -129,6 +129,10 @@ const RECOGNISED_CREDENTIAL_VARIABLES = Object.freeze([
   "GOOGLE_APPLICATION_CREDENTIALS",
   "AZURE_CLIENT_SECRET",
 ]);
+const CLAUDE_CLIENT_ONLY_MCP_VARIABLES = Object.freeze([
+  "MCP_PROTOCOL_NEGOTIATION",
+  "MCP_SDK_GENERATION",
+]);
 const SAFE_PARENT_ENVIRONMENT = Object.freeze([
   "HOME",
   "LANG",
@@ -739,6 +743,8 @@ function closedClaudeEnvironment(authKind, environment, extra = {}) {
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
     CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1",
     ENABLE_CLAUDEAI_MCP_SERVERS: "false",
+    MCP_PROTOCOL_NEGOTIATION: "auto",
+    MCP_SDK_GENERATION: "v2",
     MCP_TIMEOUT: "10000",
     MCP_TOOL_TIMEOUT: "60000",
     ...extra,
@@ -860,7 +866,10 @@ function mcpConfiguration(
           "-p",
           NETWORK_SANDBOX_PROFILE,
           "/usr/bin/env",
-          ...RECOGNISED_CREDENTIAL_VARIABLES.flatMap((name) => ["-u", name]),
+          ...[
+            ...RECOGNISED_CREDENTIAL_VARIABLES,
+            ...CLAUDE_CLIENT_ONLY_MCP_VARIABLES,
+          ].flatMap((name) => ["-u", name]),
           `${CAPTURE_FLAG}=1`,
           `${NETWORK_SANDBOX_FLAG}=${NETWORK_SANDBOX}`,
           `${HOST_ATTESTATION_FLAG}=${HOST_ATTESTATION}`,

--- a/scripts/qual_206_claude_stdio_observer.mjs
+++ b/scripts/qual_206_claude_stdio_observer.mjs
@@ -72,6 +72,10 @@ const HOST_ATTESTATION = "outer-harness-spawn-executable";
 const CAPTURE_FLAG = "GIS_AI_GO_QUAL_206_EVENT_CAPTURE";
 const SERVER_FLAG = "GIS_AI_GO_QUAL_206_EXACT_FIVE_STDIO";
 const SOURCE_COMMIT_VARIABLE = "GIS_AI_GO_QUAL_206_SOURCE_COMMIT";
+const CLAUDE_CLIENT_ONLY_MCP_VARIABLES = Object.freeze([
+  "MCP_PROTOCOL_NEGOTIATION",
+  "MCP_SDK_GENERATION",
+]);
 const SERVER_AUTHORITY = "--exact-five-stdio-conformance-only";
 const READINESS_SCENARIO = "independent-host";
 const CAPABILITY_SCENARIO = "claude-host-002";
@@ -1056,6 +1060,11 @@ function startObserver(options) {
     process.env[HOST_ATTESTATION_VARIABLE] !== HOST_ATTESTATION
   )) {
     fail("capability observation requires its bounded outer controls");
+  }
+  if (capabilityMode && CLAUDE_CLIENT_ONLY_MCP_VARIABLES.some(
+    (name) => process.env[name] !== undefined,
+  )) {
+    fail("capability observer received a Claude-client-only MCP variable");
   }
   const scenario = capabilityMode ? CAPABILITY_SCENARIO : READINESS_SCENARIO;
   const rootBefore = validatePrivateDirectory(options.captureRoot, "capture root");

--- a/scripts/verify_qual_206_claude_capability.py
+++ b/scripts/verify_qual_206_claude_capability.py
@@ -127,6 +127,10 @@ RECOGNISED_CREDENTIAL_VARIABLES = (
     "GOOGLE_APPLICATION_CREDENTIALS",
     "AZURE_CLIENT_SECRET",
 )
+CLAUDE_CLIENT_ONLY_MCP_VARIABLES = (
+    "MCP_PROTOCOL_NEGOTIATION",
+    "MCP_SDK_GENERATION",
+)
 TRACKED_CAPABILITY_MATERIALS = {
     "package.json",
     "pnpm-lock.yaml",
@@ -735,7 +739,10 @@ def verify_private_configuration(
         fail("private MCP server definition is not the exact STDIO projection")
     unset_arguments = [
         value
-        for name in RECOGNISED_CREDENTIAL_VARIABLES
+        for name in (
+            *RECOGNISED_CREDENTIAL_VARIABLES,
+            *CLAUDE_CLIENT_ONLY_MCP_VARIABLES,
+        )
         for value in ("-u", name)
     ]
     args = server["args"]
@@ -749,7 +756,7 @@ def verify_private_configuration(
         "GIS_AI_GO_QUAL_206_HOST_ATTESTATION=outer-harness-spawn-executable",
     ]
     if args[: len(prefix)] != prefix:
-        fail("private MCP child does not unset the exact recognised credential set")
+        fail("private MCP child does not unset the exact closed variable set")
     tail = args[len(prefix) :]
     if len(tail) != 15:
         fail("private MCP observer command has an unexpected argument count")

--- a/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
@@ -158,6 +158,8 @@ async function main() {
     optionValue(argumentsValue, "--permission-mode") !== "dontAsk" ||
     optionValue(argumentsValue, "--max-turns") !== "1" ||
     optionValue(argumentsValue, "--tools") !== "" ||
+    process.env.MCP_PROTOCOL_NEGOTIATION !== "auto" ||
+    process.env.MCP_SDK_GENERATION !== "v2" ||
     !argumentsValue.includes("--strict-mcp-config") ||
     !argumentsValue.includes("--no-session-persistence") ||
     !argumentsValue.includes("--disable-slash-commands") ||

--- a/tests/interoperability/test_qual_206_claude_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_capability_harness.mjs
@@ -115,6 +115,8 @@ function dependencies(scenario = "positive") {
     authStatus: (_command, environment) => {
       assert.equal(environment.CLAUDE_CODE_SIMPLE, undefined);
       assert.equal(environment.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, "1");
+      assert.equal(environment.MCP_PROTOCOL_NEGOTIATION, "auto");
+      assert.equal(environment.MCP_SDK_GENERATION, "v2");
       return {
         api_provider: "firstParty",
         auth_method: "claude.ai",
@@ -259,6 +261,16 @@ macRuntimeTest(POSITIVE_TEST_NAME, async (t) => {
   for (const credential of CREDENTIALS) {
     const index = server.args.indexOf(credential);
     assert.ok(index > 0 && server.args[index - 1] === "-u", credential);
+  }
+  for (const clientOnlyVariable of [
+    "MCP_PROTOCOL_NEGOTIATION",
+    "MCP_SDK_GENERATION",
+  ]) {
+    const index = server.args.indexOf(clientOnlyVariable);
+    assert.ok(
+      index > 0 && server.args[index - 1] === "-u",
+      clientOnlyVariable,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- pin the documented Claude Code v2 MCP runtime and automatic protocol negotiation for the bounded QUAL-206 capability launcher
- keep those controls invocation-local to Claude and explicitly remove them before the MCP observer child starts
- fail closed if either Claude-client-only variable reaches the observer
- update the offline verifier, regression fixtures, operational guidance and release-note fragment

## Root cause and boundary

The capability launcher omitted the two Claude runtime controls already used by the accepted strict-modern readiness observation. The authorised first model-task observation therefore attempted a legacy `initialize` handshake and failed closed before an accepted request, response, tool call or GIS/provider call.

That unsuccessful raw capture remains private and is not projected as capability evidence. This change does not alter the gateway, advertise another tool, activate a provider, publish to the registry, deploy a service or make another model/provider call. `--max-turns 1` remains unchanged: it permits the single tool-use round trip plus the required final text-only response.

## Verification

- `node --test tests/interoperability/test_qual_206_claude_capability_harness.mjs tests/interoperability/test_qual_206_claude_stdio_observer.mjs` — 30 passed
- `uv run --locked --cache-dir .uv-cache python -m unittest tests.contract.test_qual_206_claude_capability` — 7 passed
- `pnpm run check` — passed, including 222 gateway tests, 20 interoperability tests, 419 + 22 Python tests, 27 browser tests, container assurance, two byte-identical release builds, contracts, links, secret scan, diagrams and SBOM
- independent review — no P0 or P1 findings; the one P2 child-environment finding was fixed and covered by a fail-closed observer assertion

Refs #24
