### PR TITLE
fix(qual-206): align Claude permission alias

### DIFF
--- a/changelog.d/QUAL-206-claude-permission-alias.fixed.md
+++ b/changelog.d/QUAL-206-claude-permission-alias.fixed.md
@@ -1,0 +1,3 @@
+Fix the bounded Claude Code capability launcher to allow the exact sanitised
+permission alias for canonical `catalogue.search`, and regression-check the CLI
+and settings allowlists while retaining the one-tool-use-round-trip boundary.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -19,7 +19,9 @@ The launcher and observer enforce all of these conditions:
 - the accepted Claude Code `2.1.245` executable identity;
 - the pinned current model identifier `claude-sonnet-5`;
 - the documented Claude v2 MCP runtime with automatic modern/legacy-era probing;
-- one MCP server advertising only `catalogue.search` and no resources;
+- one MCP server advertising only canonical operation `catalogue.search` and no
+  resources, with the exact Claude permission alias
+  `mcp__gis-ai-go-qual-206-host-002__catalogue_search`;
 - no Claude built-in tools, `dontAsk` permission mode, one tool-use turn and the
   required final text-only turn;
 - exactly one call with `{"query":"INSPIRE","limit":1}` across all MCP child
@@ -83,6 +85,14 @@ observation. This keeps `server/discover` and the final MCP `2026-07-28` session
 available on the model-task path; it is invocation-local configuration, not a
 gateway activation switch and is not forwarded into the fixture's closed child
 environment.
+
+Claude Code `2.1.245` normalises the dot in the advertised `catalogue.search`
+operation to an underscore on its permission surface. The launcher therefore
+allowlists the exact host-facing alias
+`mcp__gis-ai-go-qual-206-host-002__catalogue_search`, while the MCP wire request,
+observer contract and evidence continue to use the canonical `catalogue.search`
+name. The regression fixture checks both the command-line and settings allowlists
+so these two namespaces cannot silently diverge again.
 
 For first-party login authentication, unset recognised credential variables before
 the run. Do not use `--bare`: the exact 2.1.245 client reports that bare mode does

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -791,6 +791,9 @@ session persistence and an empty disposable workspace. It also pins the document
 Claude v2 MCP runtime and automatic negotiation controls used by the accepted
 strict-modern readiness observation, so the model-task path cannot silently fall
 back to a legacy `initialize` handshake when evaluating the modern surface.
+The launcher maps canonical `catalogue.search` to Claude's permission-facing
+`mcp__gis-ai-go-qual-206-host-002__catalogue_search` alias and regression-checks
+that exact allowlist without changing the MCP wire operation.
 The API-key route uses `--bare` and requires an explicit per-run budget. In both
 routes, recognised credential environment variables are removed before the MCP
 child starts. An identity-bound macOS Seatbelt profile denies all network access

--- a/schemas/qual-206-claude-capability-private-run-v1.schema.json
+++ b/schemas/qual-206-claude-capability-private-run-v1.schema.json
@@ -222,7 +222,7 @@
         "output_schema_sha256": {"$ref": "#/$defs/sha256"},
         "built_in_tools_available": {"const": false},
         "allowed_mcp_tool": {
-          "const": "mcp__gis-ai-go-qual-206-host-002__catalogue.search"
+          "const": "mcp__gis-ai-go-qual-206-host-002__catalogue_search"
         },
         "permission_mode": {"const": "dontAsk"},
         "session_persistence": {"const": false},

--- a/scripts/qual_206_claude_capability_harness.mjs
+++ b/scripts/qual_206_claude_capability_harness.mjs
@@ -45,7 +45,10 @@ const HOST_ATTESTATION_FLAG = "GIS_AI_GO_QUAL_206_HOST_ATTESTATION";
 const ENABLE_FLAG = "GIS_AI_GO_QUAL_206_CLAUDE_CAPABILITY";
 const CASE_ID = "QUAL-206-HOST-002";
 const SERVER_NAME = "gis-ai-go-qual-206-host-002";
-const TOOL_NAME = `mcp__${SERVER_NAME}__catalogue.search`;
+// Claude Code 2.1.245 normalises the canonical MCP operation separator on its
+// permission surface.
+// The observer continues to advertise and enforce the wire name `catalogue.search`.
+const CLAUDE_PERMISSION_TOOL_NAME = `mcp__${SERVER_NAME}__catalogue_search`;
 const PINNED_MODEL = "claude-sonnet-5";
 const NETWORK_SANDBOX = "macos-seatbelt-deny-network";
 const HOST_ATTESTATION = "outer-harness-spawn-executable";
@@ -826,7 +829,7 @@ function claudeArguments(options, mcpPath, settingsPath) {
     "--tools",
     "",
     "--allowedTools",
-    TOOL_NAME,
+    CLAUDE_PERMISSION_TOOL_NAME,
     "--permission-mode",
     "dontAsk",
     "--disable-slash-commands",
@@ -902,7 +905,7 @@ function emptySettings() {
     enableAllProjectMcpServers: false,
     enabledMcpjsonServers: Object.freeze([SERVER_NAME]),
     permissions: Object.freeze({
-      allow: Object.freeze([TOOL_NAME]),
+      allow: Object.freeze([CLAUDE_PERMISSION_TOOL_NAME]),
       deny: Object.freeze([]),
       defaultMode: "dontAsk",
     }),
@@ -1335,7 +1338,7 @@ export async function runClaudeCapability(
       stderr: result.stderr,
       output_schema_sha256: sha256Bytes(Buffer.from(canonicalJson(OUTPUT_SCHEMA), "utf8")),
       built_in_tools_available: false,
-      allowed_mcp_tool: TOOL_NAME,
+      allowed_mcp_tool: CLAUDE_PERMISSION_TOOL_NAME,
       permission_mode: "dontAsk",
       session_persistence: false,
       maximum_turns: 1,

--- a/scripts/verify_qual_206_claude_capability.py
+++ b/scripts/verify_qual_206_claude_capability.py
@@ -716,7 +716,7 @@ def verify_private_configuration(
         "enableAllProjectMcpServers": False,
         "enabledMcpjsonServers": ["gis-ai-go-qual-206-host-002"],
         "permissions": {
-            "allow": ["mcp__gis-ai-go-qual-206-host-002__catalogue.search"],
+            "allow": ["mcp__gis-ai-go-qual-206-host-002__catalogue_search"],
             "deny": [],
             "defaultMode": "dontAsk",
         },

--- a/tests/contract/test_qual_206_claude_capability.py
+++ b/tests/contract/test_qual_206_claude_capability.py
@@ -607,7 +607,7 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
                 "stderr": {"bytes": 0, "limit_exceeded": False, "sha256": SHA},
                 "output_schema_sha256": SHA,
                 "built_in_tools_available": False,
-                "allowed_mcp_tool": "mcp__gis-ai-go-qual-206-host-002__catalogue.search",
+                "allowed_mcp_tool": "mcp__gis-ai-go-qual-206-host-002__catalogue_search",
                 "permission_mode": "dontAsk",
                 "session_persistence": False,
                 "maximum_turns": 1,

--- a/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
@@ -6,6 +6,8 @@ import { readFileSync } from "node:fs";
 const EXPECTED_PROMPT =
   "Search the public catalogue for INSPIRE and return the first record with its " +
   "inline evidence receipt.\n";
+const EXPECTED_PERMISSION_TOOL =
+  "mcp__gis-ai-go-qual-206-host-002__catalogue_search";
 const SCENARIO = process.env.QUAL_206_FAKE_CLAUDE_SCENARIO ?? "positive";
 
 function fail(message) {
@@ -153,11 +155,17 @@ async function discover(request) {
 async function main() {
   const argumentsValue = process.argv.slice(2);
   const mcpPath = optionValue(argumentsValue, "--mcp-config");
+  const settingsPath = optionValue(argumentsValue, "--settings");
+  const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
   if (
     optionValue(argumentsValue, "--output-format") !== "json" ||
     optionValue(argumentsValue, "--permission-mode") !== "dontAsk" ||
     optionValue(argumentsValue, "--max-turns") !== "1" ||
     optionValue(argumentsValue, "--tools") !== "" ||
+    optionValue(argumentsValue, "--allowedTools") !== EXPECTED_PERMISSION_TOOL ||
+    settings.permissions?.defaultMode !== "dontAsk" ||
+    JSON.stringify(settings.permissions?.allow) !==
+      JSON.stringify([EXPECTED_PERMISSION_TOOL]) ||
     process.env.MCP_PROTOCOL_NEGOTIATION !== "auto" ||
     process.env.MCP_SDK_GENERATION !== "v2" ||
     !argumentsValue.includes("--strict-mcp-config") ||

--- a/tests/interoperability/test_qual_206_claude_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_capability_harness.mjs
@@ -222,7 +222,7 @@ macRuntimeTest(POSITIVE_TEST_NAME, async (t) => {
   assert.equal(manifest.execution.harness_classification, null);
   assert.equal(manifest.execution.built_in_tools_available, false);
   assert.equal(manifest.execution.allowed_mcp_tool,
-    "mcp__gis-ai-go-qual-206-host-002__catalogue.search");
+    "mcp__gis-ai-go-qual-206-host-002__catalogue_search");
   assert.equal(manifest.host.auth_preflight.auth_method, "claude.ai");
   assert.equal(manifest.host.api_budget_usd, null);
   assert.deepEqual(readdirSync(join(root, "observer")).sort(), [


### PR DESCRIPTION
## Summary

- align the Claude Code `2.1.245` permission allowlist with its observed sanitised
  `catalogue_search` host alias
- retain canonical `catalogue.search` throughout MCP discovery, wire traffic and
  evidence
- make the fake Claude client verify both the CLI and settings permission rules
- update the private schema, offline verifier, runbooks and changelog fragment

## Evidence

The single authorised protected-main observation completed modern negotiation and
tool discovery. Claude selected the intended tool as
`mcp__gis-ai-go-qual-206-host-002__catalogue_search`, but the dotted permission rule
did not match, so `dontAsk` denied it before any `tools/call` reached the observer.
No geospatial-provider call occurred. The failed raw capture remains owner-only and
is not published by this pull request.

`--max-turns 1` remains unchanged because it bounds one tool-use round trip; the
observer independently enforces one exact call across every MCP child session.

## Verification

- `pnpm run check`
- focused Claude harness regression: 14 passed
- capability verifier contract tests: 7 passed
- contract, link and secret validation
- two independent reviews: no P0-P2 findings

## Boundary

This fixes the observation harness only. It does not claim a successful Claude
capability result and does not activate, register, deploy or release the candidate.
