### PR TITLE
fix(qual-206): accept extensible Claude request metadata

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -33,7 +33,10 @@ The supported target active set is exactly `catalogue.search`,
 - complete the separately gated Claude Code `2.1.245` `HOST-002` capability
   harness, which advertises only `catalogue.search`, permits one exact call, checks
   the inline receipt independently, retains raw material privately and can publish
-  only a path-free pass after the harness has merged to protected `main`;
+  only a path-free pass after the harness has merged to protected `main`; retain
+  the standards-conformant dotted MCP wire name separately from Claude's
+  underscored permission alias, reject alias collisions and allow open MCP request
+  metadata while keeping attribution and exact-case evidence predicates closed;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;

--- a/changelog.d/QUAL-206-claude-permission-alias.fixed.md
+++ b/changelog.d/QUAL-206-claude-permission-alias.fixed.md
@@ -1,3 +1,6 @@
 Fix the bounded Claude Code capability launcher to allow the exact sanitised
 permission alias for canonical `catalogue.search`, and regression-check the CLI
 and settings allowlists while retaining the one-tool-use-round-trip boundary.
+Keep the dotted MCP `2026-07-28` wire name distinct from Claude's underscored
+permission alias, reject alias collisions and accept additional standards-compliant
+request metadata without weakening the exact capability evidence predicate.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -92,7 +92,25 @@ allowlists the exact host-facing alias
 `mcp__gis-ai-go-qual-206-host-002__catalogue_search`, while the MCP wire request,
 observer contract and evidence continue to use the canonical `catalogue.search`
 name. The regression fixture checks both the command-line and settings allowlists
-so these two namespaces cannot silently diverge again.
+so these two namespaces cannot silently diverge again. The alias builder applies
+the current MCP tool-name guidance—1 to 128 ASCII letters, digits, underscores,
+hyphens and dots—and rejects any canonical-name collision after Claude's observed
+dot-to-underscore transformation. `catalogue.search` therefore remains the public
+protocol name; `catalogue_search` is not a replacement API.
+
+MCP request `_meta` is an open extension object. The observer requires the core
+`io.modelcontextprotocol/protocolVersion` and
+`io.modelcontextprotocol/clientCapabilities` fields and permits additional client
+metadata whose keys follow the standard prefix-and-name grammar, instead of
+treating the object as a closed record. The optional
+`io.modelcontextprotocol/clientInfo` is checked separately as an observation
+attribution predicate; it is not trusted as a security identity, which remains
+bound to the independently measured Claude executable. This first-and-only call
+still requires exact top-level parameters and rejects `requestState` or
+`inputResponses`, because the observer never issues an `input_required` result.
+See the official
+[tool-name guidance](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+and [`_meta` rules](https://modelcontextprotocol.io/specification/2026-07-28/basic#_meta).
 
 For first-party login authentication, unset recognised credential variables before
 the run. Do not use `--bare`: the exact 2.1.245 client reports that bare mode does

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -793,7 +793,15 @@ strict-modern readiness observation, so the model-task path cannot silently fall
 back to a legacy `initialize` handshake when evaluating the modern surface.
 The launcher maps canonical `catalogue.search` to Claude's permission-facing
 `mcp__gis-ai-go-qual-206-host-002__catalogue_search` alias and regression-checks
-that exact allowlist without changing the MCP wire operation.
+that exact allowlist without changing the MCP wire operation. The canonical name
+conforms to the MCP `2026-07-28` tool-name guidance; the alias builder rejects
+out-of-guidance canonical names and dot-to-underscore collisions. The observer
+also treats request `_meta` as the standard's open extension object: it requires
+the two core protocol fields, allows syntactically valid additional client
+metadata, and keeps the optional self-reported client information separate from
+executable attestation. The exact first-call evidence predicate rejects
+multi-round-trip `requestState` and `inputResponses` parameters because this
+observer never produces an `input_required` result.
 The API-key route uses `--bare` and requires an explicit per-run budget. In both
 routes, recognised credential environment variables are removed before the MCP
 child starts. An identity-bound macOS Seatbelt profile denies all network access

--- a/schemas/qual-206-claude-capability-evidence-v1.schema.json
+++ b/schemas/qual-206-claude-capability-evidence-v1.schema.json
@@ -217,6 +217,7 @@
       "required": [
         "built_in_tools_available",
         "allowed_mcp_tool_count",
+        "claude_permission_alias",
         "permission_mode",
         "session_persistence",
         "maximum_turns",
@@ -228,6 +229,9 @@
       "properties": {
         "built_in_tools_available": {"const": false},
         "allowed_mcp_tool_count": {"const": 1},
+        "claude_permission_alias": {
+          "const": "mcp__gis-ai-go-qual-206-host-002__catalogue_search"
+        },
         "permission_mode": {"const": "dontAsk"},
         "session_persistence": {"const": false},
         "maximum_turns": {"const": 1},

--- a/scripts/qual_206_claude_capability_harness.mjs
+++ b/scripts/qual_206_claude_capability_harness.mjs
@@ -45,10 +45,9 @@ const HOST_ATTESTATION_FLAG = "GIS_AI_GO_QUAL_206_HOST_ATTESTATION";
 const ENABLE_FLAG = "GIS_AI_GO_QUAL_206_CLAUDE_CAPABILITY";
 const CASE_ID = "QUAL-206-HOST-002";
 const SERVER_NAME = "gis-ai-go-qual-206-host-002";
-// Claude Code 2.1.245 normalises the canonical MCP operation separator on its
-// permission surface.
-// The observer continues to advertise and enforce the wire name `catalogue.search`.
-const CLAUDE_PERMISSION_TOOL_NAME = `mcp__${SERVER_NAME}__catalogue_search`;
+const CANONICAL_CAPABILITY_TOOL_NAME = "catalogue.search";
+const MCP_TOOL_NAME = /^[A-Za-z0-9_.-]{1,128}$/u;
+const CLAUDE_PERMISSION_SEGMENT_CHARACTER = /[^A-Za-z0-9_-]/gu;
 const PINNED_MODEL = "claude-sonnet-5";
 const NETWORK_SANDBOX = "macos-seatbelt-deny-network";
 const HOST_ATTESTATION = "outer-harness-spawn-executable";
@@ -175,6 +174,43 @@ const SYSTEM_PROMPT =
 function fail(message) {
   throw new Error(message);
 }
+
+export function buildClaudePermissionAliasMap(serverName, canonicalToolNames) {
+  if (
+    typeof serverName !== "string" || !/^[A-Za-z0-9_-]{1,128}$/u.test(serverName) ||
+    !Array.isArray(canonicalToolNames) || canonicalToolNames.length < 1
+  ) {
+    fail("Claude permission alias inputs are invalid");
+  }
+  const aliasEntries = [];
+  const canonicalNames = new Set();
+  const canonicalByAlias = new Map();
+  for (const canonicalName of canonicalToolNames) {
+    if (typeof canonicalName !== "string" || !MCP_TOOL_NAME.test(canonicalName)) {
+      fail("canonical tool name does not follow MCP 2026-07-28 naming guidance");
+    }
+    if (canonicalNames.has(canonicalName)) {
+      fail("canonical Claude permission tool name is duplicated");
+    }
+    // Claude Code 2.1.245 empirically replaces the MCP dot separator with an
+    // underscore on its permission surface. The MCP wire name remains unchanged.
+    const segment = canonicalName.replace(CLAUDE_PERMISSION_SEGMENT_CHARACTER, "_");
+    const alias = `mcp__${serverName}__${segment}`;
+    const existing = canonicalByAlias.get(alias);
+    if (existing !== undefined) {
+      fail(`Claude permission alias collision between ${existing} and ${canonicalName}`);
+    }
+    canonicalNames.add(canonicalName);
+    canonicalByAlias.set(alias, canonicalName);
+    aliasEntries.push([canonicalName, alias]);
+  }
+  return Object.freeze(Object.fromEntries(aliasEntries));
+}
+
+const CLAUDE_PERMISSION_TOOL_NAME = buildClaudePermissionAliasMap(
+  SERVER_NAME,
+  [CANONICAL_CAPABILITY_TOOL_NAME],
+)[CANONICAL_CAPABILITY_TOOL_NAME];
 
 function sha256Bytes(value) {
   return createHash("sha256").update(value).digest("hex");

--- a/scripts/qual_206_claude_stdio_observer.mjs
+++ b/scripts/qual_206_claude_stdio_observer.mjs
@@ -109,6 +109,8 @@ const SHA256 = /^[0-9a-f]{64}$/u;
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const CLIENT_LABEL = /^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/u;
+const META_PREFIX_LABEL = /^[A-Za-z](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/u;
+const META_NAME = /^(?:[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)?$/u;
 const EXACT_OPERATIONS = Object.freeze([
   "catalogue.search",
   "catalogue.describe",
@@ -216,6 +218,16 @@ function exactKeys(value, expected) {
     Object.keys(value).sort(),
     [...expected].sort(),
   );
+}
+
+function validMetaKey(value) {
+  if (typeof value !== "string") return false;
+  const parts = value.split("/");
+  if (parts.length === 1) return META_NAME.test(value);
+  if (parts.length !== 2 || parts[0].length === 0 || !META_NAME.test(parts[1])) {
+    return false;
+  }
+  return parts[0].split(".").every((label) => META_PREFIX_LABEL.test(label));
 }
 
 function sha256Bytes(value) {
@@ -766,17 +778,19 @@ function validResponseShape(message) {
   );
 }
 
-function capabilityMetaValid(value) {
-  const clientInfo = value?.["io.modelcontextprotocol/clientInfo"];
+function capabilityProtocolMetaValid(value) {
   return plainRecord(value) &&
-    exactKeys(value, [
-      "io.modelcontextprotocol/clientCapabilities",
-      "io.modelcontextprotocol/clientInfo",
-      "io.modelcontextprotocol/protocolVersion",
-    ]) &&
+    Object.keys(value).every((key) => validMetaKey(key)) &&
+    Object.hasOwn(value, "io.modelcontextprotocol/clientCapabilities") &&
+    Object.hasOwn(value, "io.modelcontextprotocol/protocolVersion") &&
     value["io.modelcontextprotocol/protocolVersion"] === PROTOCOL_TARGET &&
-    plainRecord(value["io.modelcontextprotocol/clientCapabilities"]) &&
-    exactKeys(clientInfo, ["name", "version"]) &&
+    plainRecord(value["io.modelcontextprotocol/clientCapabilities"]);
+}
+
+function capabilityClientAttributionValid(value) {
+  const clientInfo = value?.["io.modelcontextprotocol/clientInfo"];
+  return plainRecord(clientInfo) && Object.hasOwn(clientInfo, "name") &&
+    Object.hasOwn(clientInfo, "version") &&
     typeof clientInfo.name === "string" && clientInfo.name.length >= 1 &&
     clientInfo.name.length <= 128 && typeof clientInfo.version === "string" &&
     clientInfo.version.length >= 1 && clientInfo.version.length <= 64;
@@ -784,20 +798,24 @@ function capabilityMetaValid(value) {
 
 export function capabilitySearchRequest(message) {
   const argumentsValue = message?.params?.arguments;
-  const valid = message?.method === "tools/call" &&
+  const protocolValid = capabilityProtocolMetaValid(message?.params?._meta);
+  const clientAttributionValid = capabilityClientAttributionValid(message?.params?._meta);
+  const evidenceRequestValid = message?.method === "tools/call" &&
     exactKeys(message.params, ["_meta", "arguments", "name"]) &&
     message.params.name === "catalogue.search" &&
     exactKeys(argumentsValue, ["limit", "query"]) &&
-    argumentsValue.query === "INSPIRE" && argumentsValue.limit === 1 &&
-    capabilityMetaValid(message.params._meta);
+    argumentsValue.query === "INSPIRE" && argumentsValue.limit === 1;
   const encoded = Buffer.from(
     canonicalJson(plainRecord(argumentsValue) ? argumentsValue : null),
     "utf8",
   );
   return Object.freeze({
     bytes: encoded.length,
+    client_attribution_valid: clientAttributionValid,
+    evidence_request_valid: evidenceRequestValid,
+    protocol_valid: protocolValid,
     sha256: sha256Bytes(encoded),
-    valid,
+    valid: protocolValid && clientAttributionValid && evidenceRequestValid,
   });
 }
 
@@ -1339,7 +1357,12 @@ function startObserver(options) {
       if (method === "tools/call") {
         const request = capabilitySearchRequest(message);
         if (!request.valid) {
-          captureFatal("capability-request-invalid", base);
+          const classification = !request.protocol_valid
+            ? "capability-protocol-metadata-invalid"
+            : !request.client_attribution_valid
+              ? "capability-client-attribution-invalid"
+              : "capability-evidence-request-invalid";
+          captureFatal(classification, base);
           return;
         }
         if (capabilityRequest !== null) {

--- a/scripts/verify_qual_206_claude_capability.py
+++ b/scripts/verify_qual_206_claude_capability.py
@@ -1298,6 +1298,7 @@ def verify_and_project(
         "isolation": {
             "built_in_tools_available": False,
             "allowed_mcp_tool_count": 1,
+            "claude_permission_alias": manifest["execution"]["allowed_mcp_tool"],
             "permission_mode": "dontAsk",
             "session_persistence": False,
             "maximum_turns": 1,

--- a/tests/contract/test_qual_206_claude_capability.py
+++ b/tests/contract/test_qual_206_claude_capability.py
@@ -349,6 +349,9 @@ def public_projection() -> dict[str, object]:
         "isolation": {
             "built_in_tools_available": False,
             "allowed_mcp_tool_count": 1,
+            "claude_permission_alias": (
+                "mcp__gis-ai-go-qual-206-host-002__catalogue_search"
+            ),
             "permission_mode": "dontAsk",
             "session_persistence": False,
             "maximum_turns": 1,
@@ -494,8 +497,8 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
             )
         }
         expected = {
-            "tests": 14,
-            "pass": 14 if sys.platform == "darwin" else 2,
+            "tests": 16,
+            "pass": 16 if sys.platform == "darwin" else 4,
             "fail": 0,
             "skipped": 0 if sys.platform == "darwin" else 12,
         }
@@ -515,6 +518,11 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
             ("extra model turn", ("result", "num_turns"), 3),
             ("second call", ("transport", "tool_call_count"), 2),
             ("built-in tools", ("isolation", "built_in_tools_available"), True),
+            (
+                "permission alias drift",
+                ("isolation", "claude_permission_alias"),
+                "mcp__gis-ai-go-qual-206-host-002__catalogue.search",
+            ),
             (
                 "network access inflation",
                 ("isolation", "mcp_subtree_network_access_allowed"),

--- a/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
@@ -48,7 +48,9 @@ function meta(extra = {}) {
       "io.modelcontextprotocol/clientInfo": {
         name: "qual-206-fake-claude",
         version: "2.1.245",
+        title: "QUAL-206 fake Claude",
       },
+      "com.anthropic/toolUseId": "qual-206-bounded-test",
     },
   };
 }

--- a/tests/interoperability/test_qual_206_claude_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_capability_harness.mjs
@@ -15,11 +15,15 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 import {
+  buildClaudePermissionAliasMap,
   expectedNetworkSandboxProbeEvidence,
   parseClaudeCapabilityArguments,
   runClaudeCapability,
   verifyNetworkSandboxCompatibility,
 } from "../../scripts/qual_206_claude_capability_harness.mjs";
+import {
+  capabilitySearchRequest,
+} from "../../scripts/qual_206_claude_stdio_observer.mjs";
 import {
   dependencyLinkTargetAllowed,
   measureGeneratedRuntimeClosure,
@@ -180,6 +184,117 @@ test("production arguments distinguish first-party login from API spend", () => 
   assert.throws(() => parseClaudeCapabilityArguments(base, {}), /refusing/u);
 });
 
+test("Claude permission aliases preserve canonical MCP names and reject collisions", () => {
+  assert.deepEqual(
+    buildClaudePermissionAliasMap("gis-ai-go", ["catalogue.search", "data.query"]),
+    {
+      "catalogue.search": "mcp__gis-ai-go__catalogue_search",
+      "data.query": "mcp__gis-ai-go__data_query",
+    },
+  );
+  assert.throws(
+    () => buildClaudePermissionAliasMap(
+      "gis-ai-go",
+      ["catalogue.search", "catalogue_search"],
+    ),
+    /permission alias collision/u,
+  );
+  assert.throws(
+    () => buildClaudePermissionAliasMap("gis-ai-go", ["catalogue/search"]),
+    /MCP 2026-07-28 naming guidance/u,
+  );
+  const prototypeName = buildClaudePermissionAliasMap("gis-ai-go", ["__proto__"]);
+  assert.equal(Object.hasOwn(prototypeName, "__proto__"), true);
+  assert.equal(prototypeName["__proto__"], "mcp__gis-ai-go____proto__");
+});
+
+test("Claude capability calls accept bounded extension metadata", () => {
+  const request = capabilitySearchRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "catalogue.search",
+      arguments: { query: "INSPIRE", limit: 1 },
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {
+          name: "Claude Code",
+          version: "2.1.245",
+          title: "Claude Code",
+        },
+        "com.anthropic/toolUseId": "bounded-test-value",
+      },
+    },
+  });
+  assert.equal(request.valid, true);
+  assert.equal(request.protocol_valid, true);
+  assert.equal(request.client_attribution_valid, true);
+  assert.equal(request.evidence_request_valid, true);
+  assert.equal(
+    capabilitySearchRequest({
+      method: "tools/call",
+      params: {
+        name: "catalogue.search",
+        arguments: { query: "INSPIRE", limit: 1 },
+        _meta: {
+          "io.modelcontextprotocol/clientCapabilities": {},
+          "io.modelcontextprotocol/clientInfo": { name: "Claude Code", version: "2.1.245" },
+        },
+      },
+    }).valid,
+    false,
+  );
+  const unattributed = capabilitySearchRequest({
+    method: "tools/call",
+    params: {
+      name: "catalogue.search",
+      arguments: { query: "INSPIRE", limit: 1 },
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+      },
+    },
+  });
+  assert.equal(unattributed.protocol_valid, true);
+  assert.equal(unattributed.client_attribution_valid, false);
+  assert.equal(unattributed.valid, false);
+
+  const invalidMetaKey = capabilitySearchRequest({
+    method: "tools/call",
+    params: {
+      name: "catalogue.search",
+      arguments: { query: "INSPIRE", limit: 1 },
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": { name: "Claude Code", version: "2.1.245" },
+        "not a valid meta key": "rejected",
+      },
+    },
+  });
+  assert.equal(invalidMetaKey.protocol_valid, false);
+  assert.equal(invalidMetaKey.valid, false);
+
+  const unexpectedParams = capabilitySearchRequest({
+    method: "tools/call",
+    params: {
+      name: "catalogue.search",
+      arguments: { query: "INSPIRE", limit: 1 },
+      requestState: "unbound-state",
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": { name: "Claude Code", version: "2.1.245" },
+      },
+    },
+  });
+  assert.equal(unexpectedParams.protocol_valid, true);
+  assert.equal(unexpectedParams.evidence_request_valid, false);
+  assert.equal(unexpectedParams.valid, false);
+});
+
 test("dependency links stay inside measured dependencies or exact workspaces", () => {
   const root = "/private/tmp/gis-ai-go-dependency-link-rule";
   assert.equal(
@@ -331,8 +446,8 @@ macRuntimeTest("a valid call in a later MCP session is rejected by the global cl
 });
 
 for (const [scenario, anomaly] of [
-  ["wrong-query", "capability-request-invalid"],
-  ["wrong-operation", "capability-request-invalid"],
+  ["wrong-query", "capability-evidence-request-invalid"],
+  ["wrong-operation", "capability-evidence-request-invalid"],
 ]) {
   macRuntimeTest(`${scenario} cannot create a valid capability observation`, async (t) => {
     const root = privateRoot(t);


### PR DESCRIPTION
## Summary

- keep the MCP `2026-07-28` canonical wire name `catalogue.search` distinct from Claude Code's empirically sanitised permission alias `catalogue_search`
- validate canonical MCP tool names, reject duplicate names and fail closed on any permission-alias collision
- accept syntactically valid extension metadata while retaining the exact first-and-only `tools/call` evidence predicate
- bind the Claude permission alias into the closed public evidence schema and offline projection

## Root cause

PR #73 corrected Claude Code's permission-facing name, but the next bounded observation exposed a second interoperability boundary. Claude sent the canonical dotted operation on the wire and added valid request metadata beyond the observer's previous closed three-key `_meta` record. The observer therefore rejected a standards-conformant call.

The MCP `2026-07-28` specification permits tool names containing ASCII letters, digits, underscores, hyphens and dots, with a recommended length of 1 to 128 characters. It also defines `_meta` as an extensible object whose keys must follow the prefix-and-name grammar. The fix follows those separate contracts:

- canonical MCP name: `catalogue.search`
- Claude permission alias: `mcp__gis-ai-go-qual-206-host-002__catalogue_search`

References:

- https://modelcontextprotocol.io/specification/2026-07-28/server/tools#tool-names
- https://modelcontextprotocol.io/specification/2026-07-28/basic/index#meta

## Assurance boundary

- additional `_meta` fields are accepted only when every key follows the MCP grammar
- protocol-required metadata and the exact target revision remain mandatory
- self-reported `clientInfo` is evidence attribution, not security identity; executable measurement remains the identity control
- top-level call parameters remain exact; `requestState`, `inputResponses` and unknown fields are rejected because this observer never issues an `input_required` result
- the fake end-to-end client carries valid vendor and display metadata so the repaired path is exercised through the observer, deterministic fixture and independent verifier
- no live Claude, geospatial provider, activation, deployment or public evidence publication occurs in this pull request

## Verification

- `pnpm run check`
- focused Claude harness: 16/16
- Claude capability Python contracts: 7/7
- two independent reviews found no remaining P0, P1 or P2 issue

The full gate passed TypeScript, 222 gateway tests, interoperability, 419 Python tests, 27 browser tests, the network-none execution container, reproducible release builds, contract/link/secret validation, diagram rendering and SBOM generation.
