### PR TITLE
fix(qual-206): bind Claude reported turn count

### DIFF
--- a/changelog.d/QUAL-206-claude-reported-turns.fixed.md
+++ b/changelog.d/QUAL-206-claude-reported-turns.fixed.md
@@ -1,0 +1,3 @@
+Distinguish Claude Code's two-agentic-turn CLI ceiling from the three turns reported
+for the completed HOST-002 tool-use and structured-output lifecycle, and give a
+specific safe verifier error when that reported count drifts.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -22,8 +22,8 @@ The launcher and observer enforce all of these conditions:
 - one MCP server advertising only canonical operation `catalogue.search` and no
   resources, with the exact Claude permission alias
   `mcp__gis-ai-go-qual-206-host-002__catalogue_search`;
-- no Claude built-in tools, `dontAsk` permission mode and a two-turn ceiling for
-  the single tool-use round trip and its required final text-only turn;
+- no Claude built-in tools, `dontAsk` permission mode, a two-agentic-turn CLI
+  ceiling and an exact three-turn final host report;
 - exactly one call with `{"query":"INSPIRE","limit":1}` across all MCP child
   sessions;
 - no recognised credential environment variable forwarded to the MCP child and
@@ -45,10 +45,12 @@ Claude Code [documents `--max-turns`](https://code.claude.com/docs/en/cli-usage)
 as an error-producing ceiling on agentic turns.
 An exact `2.1.245` observation showed that a ceiling of one ended with
 `error_max_turns` after the valid MCP result, before Claude could emit the required
-structured final response. Two is therefore the smallest candidate ceiling
-consistent with the required two-turn result; the post-merge bounded observation
-must prove completion before any public evidence is written. The independent
-global claim still permits exactly one MCP tool call.
+structured final response. A second exact observation completed with a CLI ceiling
+of two and reported `num_turns: 3`. These are distinct Claude counters: the
+launcher records the two-agentic-turn limit, while the verifier requires the exact
+three-turn final report. The independent global claim still permits exactly one
+MCP tool call, and no public evidence is written until every field passes offline
+verification.
 
 The harness rebuilds the enumerated generated first-party runtime closure from an
 isolated archive of the accepted source and requires an exact closure match. It
@@ -208,8 +210,8 @@ separate evidence pull request.
 
 A verified pass means only that the exact Claude client and model completed one
 bounded `catalogue.search` case through the strict-modern STDIO surface and returned
-the same independently verified receipt in exactly two reported model turns: one
-tool-use turn and one final text-only turn. Continue to describe the five-operation
+the same independently verified receipt under a two-agentic-turn CLI ceiling, with
+an exact final host report of `num_turns: 3`. Continue to describe the five-operation
 journey as repository-local until a separately governed model-host observation
 exists. Remote HTTP, live provider, deployment, activation, registry and `v0.2.0`
 release gates remain separate.

--- a/schemas/qual-206-claude-capability-evidence-v1.schema.json
+++ b/schemas/qual-206-claude-capability-evidence-v1.schema.json
@@ -207,7 +207,7 @@
         "model_usage_observed": {"const": true},
         "input_tokens": {"type": "integer", "minimum": 1, "maximum": 10000000},
         "output_tokens": {"type": "integer", "minimum": 1, "maximum": 1000000},
-        "num_turns": {"const": 2},
+        "num_turns": {"type": "integer", "const": 3},
         "client_exit_code": {"const": 0}
       }
     },

--- a/scripts/verify_qual_206_claude_capability.py
+++ b/scripts/verify_qual_206_claude_capability.py
@@ -33,6 +33,7 @@ EVIDENCE_DIRECTORY = ROOT / "tests/interoperability/evidence"
 CORPUS = ROOT / "tests/interoperability/qual_206_cases.json"
 OBSERVER = ROOT / "scripts/qual_206_claude_stdio_observer.mjs"
 PINNED_MODEL = "claude-sonnet-5"
+EXPECTED_REPORTED_TURNS = 3
 CANONICAL_REPOSITORY_ORIGIN = "https://github.com/chris-page-gov/gis-ai-go.git"
 ALLOWED_REPOSITORY_ORIGINS = {
     CANONICAL_REPOSITORY_ORIGIN,
@@ -1143,6 +1144,8 @@ def verify_output(
     num_turns = output.get("num_turns")
     if any(value is None for value in aggregate_counts + model_counts):
         fail("Claude final output does not contain bounded model usage")
+    if type(num_turns) is not int or num_turns != EXPECTED_REPORTED_TURNS:
+        fail("Claude final output reported an unexpected bounded turn count")
     bounded_aggregate = [int(value) for value in aggregate_counts]
     bounded_model = [int(value) for value in model_counts]
     if (
@@ -1162,8 +1165,6 @@ def verify_output(
         or sum(bounded_aggregate[:3]) <= 0
         or sum(bounded_aggregate[:3]) > 10_000_000
         or bounded_aggregate[3] <= 0
-        or isinstance(num_turns, bool)
-        or num_turns != 2
     ):
         fail("Claude final structured output does not match the verified MCP result")
     return {

--- a/tests/contract/test_qual_206_claude_capability.py
+++ b/tests/contract/test_qual_206_claude_capability.py
@@ -244,7 +244,7 @@ await harness.runClaudeCapability({
     output = json.loads(stdout_path.read_text(encoding="utf-8"))
     output.update(
         {
-            "num_turns": 2,
+            "num_turns": 3,
             "usage": {
                 "input_tokens": 3,
                 "cache_creation_input_tokens": 5,
@@ -343,7 +343,7 @@ def public_projection() -> dict[str, object]:
             "model_usage_observed": True,
             "input_tokens": 12,
             "output_tokens": 7,
-            "num_turns": 2,
+            "num_turns": 3,
             "client_exit_code": 0,
         },
         "isolation": {
@@ -515,7 +515,7 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
             ("unverified receipt", ("result", "receipt_verification_valid"), False),
             ("model mismatch", ("result", "model_output_match"), False),
             ("zero model input", ("result", "input_tokens"), 0),
-            ("extra model turn", ("result", "num_turns"), 3),
+            ("reported-turn under-count", ("result", "num_turns"), 2),
             ("second call", ("transport", "tool_call_count"), 2),
             ("built-in tools", ("isolation", "built_in_tools_available"), True),
             ("turn ceiling drift", ("isolation", "maximum_turns"), 1),
@@ -739,7 +739,7 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
                 "subtype": "success",
                 "is_error": False,
                 "permission_denials": [],
-                "num_turns": 2,
+                "num_turns": 3,
                 "usage": {
                     "input_tokens": 3,
                     "cache_creation_input_tokens": 5,
@@ -831,9 +831,15 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
             ):
                 zero_input["modelUsage"]["claude-sonnet-5"][name] = 0
             invalid_outputs.append(("positive input usage", zero_input))
+            too_few_turns = copy.deepcopy(output)
+            too_few_turns["num_turns"] = 2
+            invalid_outputs.append(("exact reported-turn lifecycle", too_few_turns))
+            non_integer_turns = copy.deepcopy(output)
+            non_integer_turns["num_turns"] = 3.0
+            invalid_outputs.append(("integer reported-turn count", non_integer_turns))
             extra_turn = copy.deepcopy(output)
-            extra_turn["num_turns"] = 3
-            invalid_outputs.append(("exact two-turn lifecycle", extra_turn))
+            extra_turn["num_turns"] = 4
+            invalid_outputs.append(("extra reported turn", extra_turn))
             for label, invalid in invalid_outputs:
                 with self.subTest(label=label):
                     invalid_raw = json.dumps(invalid, separators=(",", ":")).encode()

--- a/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_capability_client.mjs
@@ -236,7 +236,7 @@ async function main() {
     subtype: "success",
     is_error: false,
     permission_denials: [],
-    num_turns: 2,
+    num_turns: 3,
     duration_ms: 400,
     duration_api_ms: 300,
     result: "The governed catalogue result is available in structured_output.",


### PR DESCRIPTION
## Summary

- distinguish Claude Code's `--max-turns 2` CLI ceiling from its successful final `num_turns: 3` report
- bind the observed count through the verifier, public schema and fake-host regression
- require the reported count to be a real integer and reject `3.0`, under-counts and over-counts
- correct the runbook interpretation and add a focused changelog fragment

## Why

The exact protected-main observation completed successfully with one valid `catalogue.search` call, the expected deterministic record and a verified inline receipt. Claude Code returned `subtype: success`, exit code 0 and `num_turns: 3` under the already bounded `--max-turns 2` setting.

The previous fake host and verifier incorrectly assumed those two counters were identical. The offline verifier therefore failed closed and wrote no public evidence.

## Authority boundary

This changes reporting and verification only. It does not change the launcher, two-agentic-turn CLI ceiling, permission alias, exact-one MCP global claim, advertised operation, deterministic fixture, network sandbox or zero-provider-egress boundary.

## Verification

- focused Node harness: 16/16 passed
- Claude capability Python contracts: 7/7 passed
- contract validation passed
- link validation passed
- secret scan passed
- independent review: no remaining P0–P2 findings

No live observation or public capability evidence is included in this pull request.
