### PR TITLE
test(qual-206): publish Claude HOST-002 capability evidence

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Delivery progress
 
-Last updated: 25 August 2026
+Last updated: 26 August 2026
 
 ## Current outcome
 
@@ -27,20 +27,25 @@ The supported target active set is exactly `catalogue.search`,
 - retain the merged bounded two-process observer and independent verifier for
   Claude Code automatic modern negotiation without changing the exact-sequence
   collector or scoring host capability;
-- accept the separately verified MCP `2026-07-28` Claude Code `2.1.241` and
-  `2.1.245` desktop-STDIO results as transport readiness only, with capability and
-  exact-five source binding still false;
-- complete the separately gated Claude Code `2.1.245` `HOST-002` capability
+- preserve the separately verified MCP `2026-07-28` Claude Code `2.1.241` and
+  `2.1.245` desktop-STDIO transport-readiness results without relabelling them;
+- retain the separately gated Claude Code `2.1.245` `HOST-002` capability
   harness, which advertises only `catalogue.search`, permits one exact call, checks
   the inline receipt independently, retains raw material privately and can publish
   only a path-free pass after the harness has merged to protected `main`; retain
   the standards-conformant dotted MCP wire name separately from Claude's
   underscored permission alias, reject alias collisions and allow open MCP request
   metadata while keeping attribution and exact-case evidence predicates closed;
+- accept the verifier-produced `HOST-002` projection from exact protected-main
+  commit `5837bd65a482e90238c466673318f007e305c744` as one bounded
+  model-mediated `catalogue.search` capability pass; keep exact-five model
+  capability, remote HTTP, live geospatial-provider use, registry publication,
+  activation, deployment and release false and open;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;
-- complete the remaining bounded desktop capability and remote-HTTP host evidence;
+- complete the remaining exact-five desktop capability and remote-HTTP host
+  evidence;
   and
 - continue provider-neutral preparation, but stop before public provisioning or
   spend until a provider account, numeric monthly ceiling and operational hosting
@@ -346,10 +351,10 @@ or release is claimed.
 ## Next
 
 1. Preserve the verified Claude Code `2.1.241` and `2.1.245` strict-modern transport
-   summaries, the separate historical default-negotiation record and the accepted
-   protected-main loopback HTTP projection. Complete the bounded capability pack
-   and remaining remote-HTTP host evidence without widening any transport result
-   into a capability claim.
+   summaries, the separate historical default-negotiation record, the accepted
+   one-case `HOST-002` capability projection and the protected-main loopback HTTP
+   projection. Complete the exact-five desktop capability and remaining remote-HTTP
+   host evidence without widening any narrow result.
 2. Retain the exact protected-main UBI, independent-derivation and provenance
    evidence from runs `32760872035` and `32760871684`; rebuild and repeat it after
    every later source-changing activation or release commit.
@@ -380,7 +385,9 @@ or release is claimed.
   `2025-11-25` result. The separate 25 August v2 automatic-negotiation observations
   for exact Claude Code `2.1.241` and `2.1.245` establish strict MCP `2026-07-28`
   desktop-STDIO transport readiness, but neither involved a model task or tool
-  call, and neither completes the capability pack or remote-HTTP host evidence.
+  call. The later accepted `HOST-002` projection scores one bounded
+  `catalogue.search` case only; exact-five model capability and remote-HTTP host
+  evidence remain incomplete.
   Security, accessibility, governed ingress/storage admission, retention/disposal
   and host-specific lifecycle evidence remain activation gates.
 - Direct routes and MCP transports now exist on protected `main`, but the
@@ -495,6 +502,25 @@ or release is claimed.
   that exact component and retained database, not a claim of no vulnerabilities. The
   candidate remains repository-only and blocked; no publication, provider call,
   deployment, registration, activation, tag or release is claimed;
+
+- Claude Code `2.1.245` bounded `HOST-002` capability: the verifier-produced
+  [path-free projection](tests/interoperability/evidence/claude-code-2.1.245-host-002-capability-2026-08-26.json)
+  binds exact protected-main commit
+  `5837bd65a482e90238c466673318f007e305c744`, tree
+  `d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f`, with SHA-256
+  `558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb`.
+  Exact-main
+  [run 32941380816](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380816)
+  passed repository, producer and independent gateway-image derivation, byte
+  comparison, attestation verification, Pages and gateway provenance assurance;
+  [CodeQL run 32941380576](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380576)
+  passed Actions, JavaScript/TypeScript and Python analysis. Claude Code `2.1.245`,
+  reporting model `claude-sonnet-5`, made exactly one canonical MCP `2026-07-28`
+  `catalogue.search` call and returned the same independently verified inline
+  receipt. The CLI ceiling was two agentic turns and the exact final host report
+  was `num_turns: 3`. Raw capture remains owner-only and local. Exact-five model
+  capability, remote HTTP interoperability, live geospatial-provider use, registry
+  publication, activation, deployment and release remain false and open;
 
 - Claude Code `2.1.245` strict-modern STDIO readiness: the
   [path-free source-bound summary](tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json)

--- a/changelog.d/QUAL-206-claude-host-002-capability-evidence.added.md
+++ b/changelog.d/QUAL-206-claude-host-002-capability-evidence.added.md
@@ -1,0 +1,6 @@
+- Add the verifier-produced, path-free Claude Code `2.1.245` `HOST-002` capability
+  projection from exact protected-main commit
+  `5837bd65a482e90238c466673318f007e305c744`, recording one canonical
+  `catalogue.search` MCP `2026-07-28` call while leaving exact-five model
+  capability, remote HTTP, live provider, registry publication, activation,
+  deployment and release explicitly false.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -11,6 +11,29 @@ interoperability, a live geospatial provider, registry publication, deployment o
 release. The external SSD and the separately relocated `mcp-geo` ONS cache are not
 used.
 
+## Accepted evidence
+
+The verifier-produced
+[`Claude Code 2.1.245 HOST-002 capability projection`](../../tests/interoperability/evidence/claude-code-2.1.245-host-002-capability-2026-08-26.json)
+records a pass from exact protected-main commit
+`5837bd65a482e90238c466673318f007e305c744`, tree
+`d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f`. Its SHA-256 is
+`558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb`.
+Every exact-main CI job passed in
+[run 32941380816](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380816),
+and every analysis passed in
+[CodeQL run 32941380576](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380576).
+
+Claude Code `2.1.245`, reporting model `claude-sonnet-5`, completed MCP
+`2026-07-28` case `QUAL-206-HOST-002` with exactly one canonical
+`catalogue.search` call and a valid independently checked receipt. The accepted
+projection records a two-agentic-turn CLI ceiling and exact final host
+`num_turns: 3`; the counters are not interchangeable. This is one bounded
+capability pass only. Exact-five model capability, remote HTTP interoperability,
+live geospatial-provider use, registry publication, activation, deployment and
+release remain explicitly false and open. The raw observation remains local and
+owner-only.
+
 ## Closed observation boundary
 
 The launcher and observer enforce all of these conditions:

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -11,15 +11,19 @@
   ready; a separate 23 August Claude Code legacy STDIO observation from exact
   protected-main bytes passed initialisation and tool listing, with capability
   unscored; exact Claude Code `2.1.245` now also has independently replayed
-  strict-modern STDIO transport readiness from protected `main`, with capability
-  still unscored;
+  strict-modern STDIO transport readiness from protected `main`; a later bounded
+  `HOST-002` observation from exact protected-main bytes passed one model-mediated
+  canonical `catalogue.search` call and independent receipt verification;
   deterministic `HOST-015` application recovery passes locally but remains non-live
-  and unscored; capability scoring and activation remain pending
+  and unscored; exact-five model capability, remote HTTP evidence and activation
+  remain pending
 - reviewed source base: `66507f9a6e6c0da23a8af4682268f9362d93bc06`
 - local HTTP transport evidence source: protected `main` commit
   `066a9cb22f719d22e29c95cd99857ddf694c878e`
 - latest Claude transport-readiness source: protected `main` commit
   `e905c632724ecc9d13b13452fee37328e75cc2a4`
+- accepted Claude `HOST-002` capability source: protected `main` commit
+  `5837bd65a482e90238c466673318f007e305c744`
 - historical Claude legacy transport-readiness source: protected `main` commit
   `30b575beb27ff805745a2864c1acf44392774046`
 - legacy fallback integration base: protected `main` commit
@@ -248,6 +252,7 @@ MCP registry for a conformance run.
 | Claude Code 2.1.241, strict modern and fallback seams, 24 August | Two credential-free `mcp list` checks against exact protected main `dda0eb9` | strict `2026-07-28` `not_ready`: client offered `2025-11-25` and received `-32022`; constructor-only fallback `ready`: initialisation and `tools/list` passed; capability unscored |
 | Claude Code 2.1.241, v2 automatic negotiation, 25 August | Two-session credential-free `mcp list` observation against exact protected main `c679b6f` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
 | Claude Code 2.1.245, v2 automatic negotiation, 25 August | Fresh two-session credential-free `mcp list` observation after the parent-identity repair reached exact protected main `e905c63` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
+| Claude Code 2.1.245, bounded `HOST-002`, 26 August | One model-mediated `catalogue.search` call from exact protected main `5837bd6`, with independent receipt verification | `capability_pass` for the one bounded MCP `2026-07-28` case; exact-five and remote HTTP remain open |
 | VS Code 1.134.0 | Temporary workspace and MCP registry; prove correct window attachment | `not_ready`: no GitHub token and no proved chat attachment; zero MCP traffic |
 | Official SDK client | HTTP and STDIO discovery, calls, resources and shutdown | Accepted on protected `main` |
 
@@ -677,12 +682,12 @@ constructor-only two-tool conformance seam, not the exact-five unregistered
 production assembly. No model task, tool call, resource read, live provider,
 remote HTTP host, registration, activation, deployment or release was exercised.
 
-This new record does not change either historical result. The 20 August
+This record does not change either historical result. The 20 August
 modern-only attempt remains `not_ready` because it received `-32022`, and the
-uncommitted fallback observation remains exploratory. Complete a separately
-authorised, bounded model task before scoring Claude capability, and complete the
-remaining independent desktop and remote HTTP evidence before claiming the full
-independent-host gate.
+uncommitted fallback observation remains exploratory. The later accepted
+`HOST-002` projection scores only its separately authorised bounded
+`catalogue.search` case. Complete the remaining exact-five desktop and remote HTTP
+evidence before claiming the full independent-host gate.
 
 This fallback is local-only. Do not attach it to the existing ChatGPT tunnel,
 change that tunnel's profile, publish its address, activate a production tool or
@@ -745,8 +750,8 @@ raw content, local identities or paths.
 This establishes strict-modern desktop STDIO transport readiness for the exact
 observed client and configuration. It does not score a tool call, complete the
 exact-five operation journey or exercise a model, provider, remote HTTP host,
-registration, activation, deployment or release. Run the separately bounded
-capability pack before claiming independent-host capability.
+registration, activation, deployment or release. The later bounded `HOST-002`
+capability pass is a separate record and does not widen this readiness result.
 
 ### Claude Code 2.1.245 protected-main readiness
 
@@ -767,10 +772,9 @@ no observer or fixture remained. The path-free
 binds the exact source and runtime materials to retained private-capture digests.
 The earlier `2.1.241` schema and readiness record remain byte-exact lineage.
 
-This is transport readiness for that exact client and configuration, not a model or
-tool capability pass. No model task, tool call, resource read, exact-five journey,
-provider, remote HTTP host, registration, activation, deployment or release was
-exercised. The next independent-host step remains the bounded capability pack.
+This remains the transport-readiness record for that exact client and
+configuration; it is not retroactively relabelled. The separately bounded
+`HOST-002` capability projection below records the later model-mediated result.
 
 ### Claude Code 2.1.245 bounded capability pack
 
@@ -815,9 +819,25 @@ paths remain in an owner-only private directory. The offline verifier can publis
 only a path-free pass projection, in a separate evidence pull request. A failure
 remains private and cannot produce public capability evidence.
 
+The accepted verifier-produced
+[`Claude Code 2.1.245 HOST-002 capability projection`](../../tests/interoperability/evidence/claude-code-2.1.245-host-002-capability-2026-08-26.json)
+binds exact protected-main commit
+`5837bd65a482e90238c466673318f007e305c744`, tree
+`d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f`. Its SHA-256 is
+`558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb`.
+Exact-main
+[CI run 32941380816](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380816)
+and
+[CodeQL run 32941380576](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380576)
+passed. Claude Code `2.1.245`, reporting model `claude-sonnet-5`, made exactly one
+canonical `catalogue.search` call over MCP `2026-07-28` and returned the same
+independently verified receipt. The CLI ceiling was two agentic turns and the exact
+final host report was `num_turns: 3`; these are different counters. Raw capture
+remains local and owner-only.
+
 See the
 [Claude HOST-002 capability runbook](QUAL-206_CLAUDE_CAPABILITY.md) for the exact
-boundary and procedure. A pass closes only the single model-mediated
+boundary and procedure. The accepted pass closes only the single model-mediated
 `catalogue.search` case. It does not establish exact-five model capability, remote
 HTTP interoperability, live-provider readiness, registration, activation,
 deployment or release.

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -897,6 +897,22 @@ def main() -> None:
             ],
         ),
         (
+            "qual-206-claude-capability-evidence-v1.schema.json",
+            [
+                (
+                    "tests/interoperability/evidence/"
+                    "claude-code-2.1.245-host-002-capability-2026-08-26.json",
+                    load_json(
+                        ROOT
+                        / "tests"
+                        / "interoperability"
+                        / "evidence"
+                        / "claude-code-2.1.245-host-002-capability-2026-08-26.json"
+                    ),
+                )
+            ],
+        ),
+        (
             "qual-206-local-http-transport-preflight.schema.json",
             [
                 (

--- a/tests/contract/test_qual_206_claude_capability.py
+++ b/tests/contract/test_qual_206_claude_capability.py
@@ -25,6 +25,13 @@ import verify_qual_206_claude_capability as verifier  # noqa: E402
 PUBLIC_SCHEMA_PATH = (
     ROOT / "schemas/qual-206-claude-capability-evidence-v1.schema.json"
 )
+PUBLIC_EVIDENCE_PATH = (
+    ROOT
+    / "tests"
+    / "interoperability"
+    / "evidence"
+    / "claude-code-2.1.245-host-002-capability-2026-08-26.json"
+)
 PRIVATE_SCHEMA_PATH = (
     ROOT / "schemas/qual-206-claude-capability-private-run-v1.schema.json"
 )
@@ -36,6 +43,9 @@ COMMIT = "b" * 40
 TREE = "c" * 40
 RECEIPT = f"gis-ai-go:evidence-receipt:sha256:{'d' * 64}"
 TRACKED = sorted(verifier.TRACKED_CAPABILITY_MATERIALS)
+PUBLIC_SOURCE_COMMIT = "5837bd65a482e90238c466673318f007e305c744"
+PUBLIC_SOURCE_TREE = "d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f"
+PUBLIC_EVIDENCE_SHA256 = "558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb"
 BOUNDARY = (
     "One bounded Claude Code 2.1.245 model-mediated catalogue.search observation "
     "for QUAL-206-HOST-002 over local MCP 2026-07-28 STDIO. This does not "
@@ -58,12 +68,74 @@ RECOGNISED_CREDENTIAL_VARIABLES = (
     "GOOGLE_APPLICATION_CREDENTIALS",
     "AZURE_CLIENT_SECRET",
 )
+PUBLIC_EVIDENCE_FORBIDDEN = re.compile(
+    r"(?:"
+    r"/Users/|/home/|/Volumes/|/private/tmp/|file://|"
+    r"[A-Za-z]:\\\\Users\\\\|"
+    r"\bsk-[A-Za-z0-9_-]{8,}|\bgh[opusr]_[A-Za-z0-9]{8,}|"
+    r"\bxox[baprs]-[A-Za-z0-9-]{8,}|\bAKIA[0-9A-Z]{16}|"
+    r"\bBearer\s+[A-Za-z0-9._~-]+|"
+    r"OPENAI_API_KEY|CODEX_API_KEY|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|"
+    r"CLAUDE_CODE_OAUTH_TOKEN|"
+    r"https?://(?:chatgpt\.com/c/|claude\.ai/chat/)|"
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-"
+    r"[0-9a-f]{12}\b"
+    r")",
+    re.IGNORECASE,
+)
+FORBIDDEN_PUBLIC_FIELD_NAMES = {
+    "arguments",
+    "credential",
+    "environment",
+    "local_path",
+    "mcp_config",
+    "pid",
+    "process_id",
+    "prompt",
+    "prompt_text",
+    "raw_content",
+    "response_body",
+    "settings",
+    "subscription_type",
+    "user_identity",
+}
 
 
 def validator(path: Path) -> Draft202012Validator:
     schema = json.loads(path.read_text(encoding="utf-8"))
     Draft202012Validator.check_schema(schema)
     return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def git_output(*arguments: str) -> str:
+    return subprocess.check_output(
+        [
+            "git",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            *arguments,
+        ],
+        cwd=ROOT,
+        text=True,
+    ).strip()
+
+
+def nested_field_names(value: Any) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {
+            name
+            for child in value.values()
+            for name in nested_field_names(child)
+        }
+    if isinstance(value, list):
+        return {name for child in value for name in nested_field_names(child)}
+    return set()
 
 
 def fake_host_validator(
@@ -920,13 +992,70 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
         after = sorted((ROOT / "tests/interoperability/evidence").iterdir())
         self.assertEqual(after, before)
 
-    def test_no_public_observation_is_added_by_the_harness_implementation(self) -> None:
+    def test_public_evidence_is_exactly_registered_and_minimised(self) -> None:
         matches = sorted(
             (ROOT / "tests/interoperability/evidence").glob(
                 "claude-code-2.1.245-host-002-capability-*.json"
             )
         )
-        self.assertEqual(matches, [])
+        self.assertEqual(matches, [PUBLIC_EVIDENCE_PATH])
+
+        raw = PUBLIC_EVIDENCE_PATH.read_bytes()
+        document = json.loads(raw)
+        self.assertEqual(sha256_bytes(raw), PUBLIC_EVIDENCE_SHA256)
+        self.assertEqual(list(validator(PUBLIC_SCHEMA_PATH).iter_errors(document)), [])
+
+        self.assertEqual(document["source"]["commit"], PUBLIC_SOURCE_COMMIT)
+        self.assertEqual(document["source"]["tree"], PUBLIC_SOURCE_TREE)
+        self.assertEqual(
+            git_output("rev-parse", f"{PUBLIC_SOURCE_COMMIT}^{{tree}}"),
+            PUBLIC_SOURCE_TREE,
+        )
+        ancestry = subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "merge-base",
+                "--is-ancestor",
+                PUBLIC_SOURCE_COMMIT,
+                "HEAD",
+            ],
+            cwd=ROOT,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.assertEqual(ancestry.returncode, 0)
+
+        self.assertEqual(
+            document["claims"],
+            {
+                "host_002_catalogue_search": True,
+                "exact_five_model_capability": False,
+                "remote_http_interoperability": False,
+                "live_geospatial_provider": False,
+                "registry_publication": False,
+                "activation": False,
+                "deployment": False,
+                "release": False,
+            },
+        )
+        self.assertEqual(document["transport"]["tool_call_count"], 1)
+        self.assertEqual(document["transport"]["protocol"], "2026-07-28")
+        self.assertEqual(document["result"]["classification"], "capability_pass")
+        self.assertTrue(document["result"]["receipt_verification_valid"])
+        self.assertEqual(document["result"]["num_turns"], 3)
+        self.assertEqual(document["isolation"]["maximum_turns"], 2)
+        self.assertFalse(document["isolation"]["built_in_tools_available"])
+        self.assertFalse(document["isolation"]["mcp_subtree_network_access_allowed"])
+        self.assertFalse(document["private_capture"]["published"])
+
+        rendered = raw.decode("utf-8")
+        self.assertIsNone(PUBLIC_EVIDENCE_FORBIDDEN.search(rendered))
+        self.assertFalse(nested_field_names(document) & FORBIDDEN_PUBLIC_FIELD_NAMES)
 
 
 if __name__ == "__main__":

--- a/tests/interoperability/README.md
+++ b/tests/interoperability/README.md
@@ -130,8 +130,20 @@ It constrains the server to `catalogue.search`, no resources and no
 geospatial-provider egress; requires exactly one `QUAL-206-HOST-002` call;
 independently verifies the returned inline receipt; and requires Claude's final
 structured output to match that observed result. These tests prove the harness
-behaviour, not Claude capability. No live capability projection is added by the
-implementation change. See the
+behaviour, not Claude capability. The implementation change itself added no live
+capability projection. A later independent verifier produced the accepted,
+path-free
+[Claude Code 2.1.245 HOST-002 projection](evidence/claude-code-2.1.245-host-002-capability-2026-08-26.json)
+from exact protected-main commit
+`5837bd65a482e90238c466673318f007e305c744`, tree
+`d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f`, with SHA-256
+`558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb`.
+It records one model-mediated canonical `catalogue.search` call through MCP
+`2026-07-28`, using Claude Code `2.1.245` and reported model
+`claude-sonnet-5`, under a CLI ceiling of two and exact final host
+`num_turns: 3`. It does not establish exact-five model capability, remote HTTP
+interoperability, a live geospatial provider, registry publication, activation,
+deployment or release. See the
 [capability runbook](../../docs/operations/QUAL-206_CLAUDE_CAPABILITY.md).
 
 See the [QUAL-206 interoperability runbook](../../docs/operations/QUAL-206_INTEROPERABILITY.md)

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -79,6 +79,26 @@ the exact-five journey, remote HTTP evidence, provider use, registration,
 activation, deployment and release remain incomplete or unexercised. Raw capture,
 client output, profile data and local identities remain owner-only and unpublished.
 
+The separate
+[`Claude Code 2.1.245 HOST-002 capability projection`](claude-code-2.1.245-host-002-capability-2026-08-26.json)
+is a verifier-produced, path-free pass from exact protected-main commit
+`5837bd65a482e90238c466673318f007e305c744`, tree
+`d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f`, with projection SHA-256
+`558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb`.
+Every exact-main CI job passed in
+[run 32941380816](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380816),
+and every analysis passed in
+[CodeQL run 32941380576](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32941380576).
+Claude Code `2.1.245`, reporting model `claude-sonnet-5`, completed MCP
+`2026-07-28` case `QUAL-206-HOST-002` with exactly one canonical
+`catalogue.search` call and a valid independently checked receipt. The CLI ceiling
+was two agentic turns while the exact final host report was `num_turns: 3`; these
+are distinct counters. This closes only that one bounded capability case. The
+projection explicitly keeps exact-five model capability, remote HTTP
+interoperability, live geospatial-provider use, registry publication, activation,
+deployment and release false. Raw Claude and MCP capture remains owner-only and
+local.
+
 The
 [`protected-main local HTTP transport preflight`](local-http-transport-preflight-2026-08-25.json)
 is a separate path-free projection from exact protected-main commit

--- a/tests/interoperability/evidence/claude-code-2.1.245-host-002-capability-2026-08-26.json
+++ b/tests/interoperability/evidence/claude-code-2.1.245-host-002-capability-2026-08-26.json
@@ -1,0 +1,131 @@
+{
+  "schema": "gis-ai-go.qual-206-claude-capability-evidence.v1",
+  "status": "capability_pass",
+  "observed_at": "2026-08-26T07:11:24.404Z",
+  "source": {
+    "repository": "chris-page-gov/gis-ai-go",
+    "repository_origin": "https://github.com/chris-page-gov/gis-ai-go.git",
+    "commit": "5837bd65a482e90238c466673318f007e305c744",
+    "tree": "d68d0cdb12fd555fbb41da0d6d4aba23a69ef44f",
+    "version": "0.1.0",
+    "local_origin_main_match": true,
+    "protected_main_verification": "external-publication-gate",
+    "production_activation": false
+  },
+  "host": {
+    "name": "Claude Code",
+    "version": "2.1.245",
+    "executable_bytes": 376109392,
+    "executable_sha256": "9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1",
+    "model_requested": "claude-sonnet-5",
+    "auth_kind": "first-party-login",
+    "auth_preflight": {
+      "logged_in": true,
+      "api_provider": "firstParty",
+      "auth_method": "claude.ai",
+      "subscription_type_observed": true
+    },
+    "model_provider_usage_observed": true,
+    "guarded_provider_api_invocations": 0
+  },
+  "case": {
+    "id": "QUAL-206-HOST-002",
+    "capability": "catalogue_search",
+    "corpus_sha256": "23ac9bc1a76d524bd0e250b11b9ba321b09e66bd5921f1463f50c150001cd389",
+    "prompt_sha256": "e0f33896a8980656f503bd32f5b99caea1783df8f5c0e82f258676eaa82a46f2",
+    "required_tool": "catalogue.search",
+    "prompt_text_repeated_in_projection": false
+  },
+  "transport": {
+    "protocol": "2026-07-28",
+    "kind": "operating-system-stdio-pipes",
+    "session_count": 2,
+    "request_count": 3,
+    "response_count": 3,
+    "tool_call_count": 1,
+    "only_catalogue_search_advertised": true,
+    "resources_advertised": 0,
+    "provider_egress_guard_calls": 0
+  },
+  "result": {
+    "classification": "capability_pass",
+    "capability": "passed",
+    "record_id": "hmlr:dataset:inspire-index-polygons",
+    "title": "Index polygons spatial data (INSPIRE)",
+    "receipt_id": "gis-ai-go:evidence-receipt:sha256:65c13a14a1f7e0a8c6a2b80c8cce01da1049495203a07c4a9c8e4eb34d4cf867",
+    "receipt_verification_valid": true,
+    "model_output_match": true,
+    "model_reported": "claude-sonnet-5",
+    "model_usage_observed": true,
+    "input_tokens": 7631,
+    "output_tokens": 409,
+    "num_turns": 3,
+    "client_exit_code": 0
+  },
+  "isolation": {
+    "built_in_tools_available": false,
+    "allowed_mcp_tool_count": 1,
+    "claude_permission_alias": "mcp__gis-ai-go-qual-206-host-002__catalogue_search",
+    "permission_mode": "dontAsk",
+    "session_persistence": false,
+    "maximum_turns": 2,
+    "mcp_subtree_network_access_allowed": false,
+    "mcp_subtree_network_sandbox": "macos-seatbelt-deny-network",
+    "mcp_child_recognised_credentials_forwarded": false,
+    "raw_host_output_published": false
+  },
+  "runtime_binding": {
+    "tracked_source_material_count": 16,
+    "generated_first_party_closure": {
+      "bytes": 2266018,
+      "file_count": 278,
+      "manifest_sha256": "cd89eddbb721f17df8ff47f29c513c227ecd3416bc48f2305ff9063736366f57",
+      "reference_manifest_sha256": "cd89eddbb721f17df8ff47f29c513c227ecd3416bc48f2305ff9063736366f57",
+      "reference_matches_current": true
+    },
+    "installed_dependency_closure": {
+      "bytes": 137176452,
+      "entry_count": 5396,
+      "manifest_sha256": "e11b94b3f3d62988651daace0a57d5e240945dd3732e0fabb6958202270bd497"
+    },
+    "node_runtime": {
+      "bytes": 50320,
+      "sha256": "1ef99ea25fe70c9b67e7efe768ef8ee22148d3cabc703db6131b57aeb617d040",
+      "version": "26.7.0"
+    },
+    "network_sandbox": {
+      "bytes": 102560,
+      "profile_sha256": "0a5222386587bf836d30a070bd759c0194f999bf5503ba76c6c0f8cb84b19db2",
+      "sha256": "8290e4be7387a0df83cd1559e86afd880464f269450573d012795761fe298f16"
+    },
+    "network_sandbox_probe": {
+      "fsync_pass": true,
+      "loopback_denied": true,
+      "probe_script_sha256": "c6540fbbb22b0c3b965a6ce5dceb81eb2064e99ceb324c122db31ad6f0a8f426"
+    },
+    "complete_first_party_generated_closure_binding": false,
+    "third_party_runtime_binding": "installed-closure-digest-plus-pnpm-lockfile",
+    "complete_runtime_source_binding": false,
+    "dependency_materials_stable": true,
+    "runtime_materials_stable": true,
+    "source_checkout_stable": true
+  },
+  "claims": {
+    "host_002_catalogue_search": true,
+    "exact_five_model_capability": false,
+    "remote_http_interoperability": false,
+    "live_geospatial_provider": false,
+    "registry_publication": false,
+    "activation": false,
+    "deployment": false,
+    "release": false
+  },
+  "private_capture": {
+    "retained": true,
+    "published": false,
+    "manifest_sha256": "6ea8fd87c0bc77f4c7d209adfff62f6f0988116849e4e40f4eeafd1eeb724da3",
+    "stdout_sha256": "af8c906c6532cee5167fda3a37efd83172bb259311519e766d64475a6b798fee",
+    "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "boundary": "One bounded Claude Code 2.1.245 model-mediated catalogue.search observation for QUAL-206-HOST-002 over local MCP 2026-07-28 STDIO. This does not prove exact-five model capability, remote HTTP interoperability, a live geospatial provider, registry publication, activation, deployment or release."
+}


### PR DESCRIPTION
## Summary

- publish the verifier-produced, path-free Claude Code 2.1.245 HOST-002 capability projection from exact protected-main commit 5837bd65a482e90238c466673318f007e305c744
- register and test the immutable evidence instance, source/tree ancestry, minimisation boundary and closed negative claims
- update the authoritative interoperability, capability and progress records without relabelling earlier transport-readiness evidence

## Verified result

Claude Code 2.1.245, reporting model claude-sonnet-5, made exactly one canonical catalogue.search call over MCP 2026-07-28 and returned the same independently verified inline receipt. The launcher used a two-agentic-turn ceiling; the exact final host report was num_turns 3.

The source commit passed exact-main CI run 32941380816 and CodeQL run 32941380576. The public projection SHA-256 is 558a2a5a337dc2c601b982c11e644390e68c858342b0fe28f9b40bf68d740ebb.

## Boundary

This closes only the bounded HOST-002 catalogue.search case. Exact-five model capability, remote HTTP interoperability, live geospatial-provider use, registry publication, activation, deployment and release remain false and open. Raw Claude and MCP capture remains owner-only and local.

## Checks

- seven QUAL-206 Claude capability contract tests
- contract validation: 84 schemas and 106 records
- link validation: 460 local links, 183 research hashes and 2 ledger snapshots
- secret and machine-path scan: 866 text files
- git diff check
- independent P0-P2 review: no findings
