### PR TITLE
ci: add fail-closed impact routing shadow

### DIFF
--- a/.github/ci/verification-impact-map.v1.json
+++ b/.github/ci/verification-impact-map.v1.json
@@ -149,6 +149,9 @@
       "id": "governed-okf-publication",
       "description": "Canonical OKF inputs affect the Explorer and gateway catalogue.",
       "patterns": [
+        "docs/research/2026-08-19/research-pack/data/providers.json",
+        "docs/research/2026-08-19/research-pack/data/sources.json",
+        "docs/research/2026-08-19/research-pack/data/workflows.json",
         "docs/source-ledger/**",
         "okf/**",
         "providers/**",

--- a/.github/ci/verification-impact-map.v1.json
+++ b/.github/ci/verification-impact-map.v1.json
@@ -1,0 +1,263 @@
+{
+  "schema": "gis-ai-go.ci-impact-map.v1",
+  "mode": "shadow",
+  "unknown_path_policy": "full",
+  "push_main_policy": "full_exact_commit",
+  "always_run": [
+    "assurance",
+    "ci_impact_shadow"
+  ],
+  "lanes": [
+    {
+      "id": "gateway_attestation_verification",
+      "description": "Replays and cross-checks the protected-main gateway evidence.",
+      "events": [
+        "push_main"
+      ],
+      "depends_on": [
+        "gateway_image",
+        "gateway_independent_image",
+        "repository_assurance"
+      ]
+    },
+    {
+      "id": "gateway_image",
+      "description": "Builds, scans and verifies the primary gateway image evidence.",
+      "events": [
+        "pull_request",
+        "push_main"
+      ],
+      "depends_on": []
+    },
+    {
+      "id": "gateway_independent_image",
+      "description": "Builds the independent protected-main gateway derivation.",
+      "events": [
+        "push_main"
+      ],
+      "depends_on": []
+    },
+    {
+      "id": "gateway-provenance",
+      "description": "Attests verified gateway image subjects on protected main.",
+      "events": [
+        "push_main"
+      ],
+      "depends_on": [
+        "gateway_attestation_verification",
+        "gateway_image",
+        "gateway_independent_image",
+        "repository_assurance"
+      ]
+    },
+    {
+      "id": "provenance",
+      "description": "Attests an immutable Pages source archive on protected main.",
+      "events": [
+        "push_main"
+      ],
+      "depends_on": [
+        "repository_assurance"
+      ]
+    },
+    {
+      "id": "repository_assurance",
+      "description": "Runs the complete locked repository assurance gate.",
+      "events": [
+        "pull_request",
+        "push_main"
+      ],
+      "depends_on": []
+    }
+  ],
+  "full_lanes": [
+    "gateway-provenance",
+    "gateway_attestation_verification",
+    "gateway_image",
+    "gateway_independent_image",
+    "provenance",
+    "repository_assurance"
+  ],
+  "rules": [
+    {
+      "id": "global-assurance-control",
+      "description": "Toolchain, workflow and planner changes require every lane.",
+      "patterns": [
+        ".dockerignore",
+        ".github/**",
+        ".nvmrc",
+        "VERSION",
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "pyproject.toml",
+        "scripts/plan_ci_impact.py",
+        "tests/contract/test_ci_impact_plan.py",
+        "tsconfig.base.json",
+        "uv.lock"
+      ],
+      "lanes": [
+        "gateway-provenance",
+        "gateway_attestation_verification",
+        "gateway_image",
+        "gateway_independent_image",
+        "provenance",
+        "repository_assurance"
+      ],
+      "force_full": true
+    },
+    {
+      "id": "gateway-assurance-tooling",
+      "description": "Gateway tooling changes affect image assurance.",
+      "patterns": [
+        "deploy/gateway/**",
+        "infra/**",
+        "scripts/check_gateway_*.py",
+        "scripts/gateway_*.py",
+        "scripts/generate_gateway_image_sbom.py",
+        "scripts/node_runtime_advisory.py",
+        "scripts/package_gateway_oci.py",
+        "scripts/run_gateway_image_assurance.py",
+        "scripts/scan_gateway_image.py",
+        "scripts/verify_gateway_*.py",
+        "tests/contract/test_gateway_*.py"
+      ],
+      "lanes": [
+        "gateway-provenance",
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "gateway-build-context",
+      "description": "Runtime source and contracts enter the governed gateway image.",
+      "patterns": [
+        "LICENSE",
+        "THIRD_PARTY.md",
+        "apps/mcp-gateway/**",
+        "packages/**",
+        "profiles/**",
+        "schemas/**"
+      ],
+      "lanes": [
+        "gateway-provenance",
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "governed-okf-publication",
+      "description": "Canonical OKF inputs affect the Explorer and gateway catalogue.",
+      "patterns": [
+        "docs/source-ledger/**",
+        "okf/**",
+        "providers/**",
+        "scripts/build_okf.py"
+      ],
+      "lanes": [
+        "gateway-provenance",
+        "provenance",
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "public-explorer-publication",
+      "description": "Explorer source, browser checks and Pages packaging affect the static product.",
+      "patterns": [
+        "apps/public-explorer/**",
+        "scripts/check_release_reproducibility.py",
+        "scripts/package_pages.py",
+        "scripts/stage_pages_payload.py",
+        "scripts/verify_pages_archive.py",
+        "tests/accessibility/**"
+      ],
+      "lanes": [
+        "provenance",
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "qual-206-evidence",
+      "description": "QUAL-206 harness, fixture and evidence changes require repository assurance.",
+      "patterns": [
+        "changelog.d/QUAL-206-*",
+        "docs/operations/QUAL-206_*",
+        "evaluation/qual-206-*",
+        "scripts/compile_qual_206_*.py",
+        "scripts/qual_206_*",
+        "scripts/verify_qual_206_*.py",
+        "tests/contract/test_qual_206_*.py",
+        "tests/interoperability/**"
+      ],
+      "lanes": [
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "documentation-and-governance",
+      "description": "Documentation changes retain source, link and secret assurance.",
+      "patterns": [
+        "AGENTS.md",
+        "CHANGELOG.md",
+        "CODE_OF_CONDUCT.md",
+        "CONTEXT.md",
+        "CONTRIBUTING.md",
+        "GOVERNANCE.md",
+        "PROGRESS.md",
+        "README.md",
+        "RELEASE_NOTES/**",
+        "SECURITY.md",
+        "architecture/**",
+        "changelog.d/**",
+        "docs/**"
+      ],
+      "lanes": [
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "repository-runtime-and-policy",
+      "description": "Execution, policy and workflow source uses the complete repository gate.",
+      "patterns": [
+        "deploy/**",
+        "evaluation/**",
+        "policies/**",
+        "services/**",
+        "workflows/**"
+      ],
+      "lanes": [
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "repository-tests-and-tooling",
+      "description": "Repository tests and non-image tooling retain the complete repository gate.",
+      "patterns": [
+        "scripts/**",
+        "tests/**"
+      ],
+      "lanes": [
+        "repository_assurance"
+      ],
+      "force_full": false
+    },
+    {
+      "id": "repository-control-files",
+      "description": "Repository control files retain the complete repository gate.",
+      "patterns": [
+        ".editorconfig",
+        ".gitattributes",
+        ".gitignore"
+      ],
+      "lanes": [
+        "repository_assurance"
+      ],
+      "force_full": false
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,72 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:
+  ci_impact_shadow:
+    name: CI impact plan (shadow)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      force_full: ${{ steps.plan.outputs.force_full }}
+      plan_sha256: ${{ steps.plan.outputs.plan_sha256 }}
+      selected_lanes: ${{ steps.plan.outputs.selected_lanes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Check out impact-planning source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Produce fail-closed shadow impact plan
+        id: plan
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) base_sha="$PR_BASE_SHA"; impact_event='pull_request' ;;
+            push) base_sha="$PUSH_BASE_SHA"; impact_event='push_main' ;;
+            *) echo 'Unsupported CI impact event' >&2; exit 1 ;;
+          esac
+          python3 scripts/plan_ci_impact.py \
+            --base "$base_sha" \
+            --head "$GITHUB_SHA" \
+            --event "$impact_event" \
+            --map .github/ci/verification-impact-map.v1.json \
+            --output artifacts/ci/impact-plan.json
+          plan_sha256="$(sha256sum artifacts/ci/impact-plan.json | cut -d ' ' -f 1)"
+          force_full="$(jq -r '.force_full' artifacts/ci/impact-plan.json)"
+          selected_lanes="$(jq -c '.selected_lanes' artifacts/ci/impact-plan.json)"
+          printf 'plan_sha256=%s\n' "$plan_sha256" >> "$GITHUB_OUTPUT"
+          printf 'force_full=%s\n' "$force_full" >> "$GITHUB_OUTPUT"
+          printf 'selected_lanes=%s\n' "$selected_lanes" >> "$GITHUB_OUTPUT"
+          {
+            printf '### CI impact plan (shadow)\n\n'
+            printf 'All current assurance jobs still run; this plan cannot skip a check.\n\n'
+            printf -- '- Plan SHA-256: `%s`\n' "$plan_sha256"
+            printf -- '- Force full: `%s`\n' "$force_full"
+            printf -- '- Selected lanes:\n'
+            jq -r '.selected_lanes[] | "  - `" + . + "`"' \
+              artifacts/ci/impact-plan.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload shadow impact plan
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-impact-plan-${{ github.sha }}
+          path: artifacts/ci/impact-plan.json
+          if-no-files-found: error
+          retention-days: 30
+
   repository_assurance:
     name: Repository assurance
     runs-on: ubuntu-24.04
@@ -122,7 +185,6 @@ jobs:
 
   gateway_image:
     name: Gateway image assurance
-    needs: repository_assurance
     runs-on: ubuntu-24.04
     timeout-minutes: 50
     outputs:
@@ -193,6 +255,7 @@ jobs:
     name: assurance
     if: always()
     needs:
+      - ci_impact_shadow
       - repository_assurance
       - gateway_image
     runs-on: ubuntu-24.04
@@ -201,11 +264,14 @@ jobs:
     steps:
       - name: Require all assurance producers to succeed
         env:
+          CI_IMPACT_SHADOW_RESULT: ${{ needs.ci_impact_shadow.result }}
           GATEWAY_IMAGE_RESULT: ${{ needs.gateway_image.result }}
           REPOSITORY_ASSURANCE_RESULT: ${{ needs.repository_assurance.result }}
         run: |
-          if [[ "$REPOSITORY_ASSURANCE_RESULT" != 'success' ]] || \
+          if [[ "$CI_IMPACT_SHADOW_RESULT" != 'success' ]] || \
+             [[ "$REPOSITORY_ASSURANCE_RESULT" != 'success' ]] || \
              [[ "$GATEWAY_IMAGE_RESULT" != 'success' ]]; then
+            printf 'CI impact plan (shadow): %s\n' "$CI_IMPACT_SHADOW_RESULT" >&2
             printf 'Repository assurance: %s\n' "$REPOSITORY_ASSURANCE_RESULT" >&2
             printf 'Gateway image assurance: %s\n' "$GATEWAY_IMAGE_RESULT" >&2
             exit 1
@@ -272,7 +338,6 @@ jobs:
   gateway_independent_image:
     name: Independent gateway image derivation
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    needs: repository_assurance
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:

--- a/changelog.d/CI-IMPACT.changed.md
+++ b/changelog.d/CI-IMPACT.changed.md
@@ -1,0 +1,4 @@
+- Run the complete repository and gateway assurance producers in parallel, cancel
+  superseded pull-request runs, and add a tested fail-closed CI impact planner in
+  report-only shadow mode. No existing check is skipped and the stable `assurance`
+  gate remains unchanged.

--- a/docs/implementation/CI_IMPACT_ROUTING.md
+++ b/docs/implementation/CI_IMPACT_ROUTING.md
@@ -52,6 +52,7 @@ Representative current decisions are:
 | --- | --- | --- |
 | QUAL-206 harness or fixture | Repository assurance | All existing checks run |
 | QUAL-206 schema | Repository and gateway derivation chain | All existing checks run |
+| Locked OKF research input | Repository and gateway derivation chain | All existing checks run |
 | Documentation | Repository assurance | All existing checks run |
 | Workflow, lock or toolchain | Full assurance | All existing checks run |
 | Unknown path | Full assurance | All existing checks run |
@@ -77,6 +78,24 @@ following:
 
 The next optimisation decision should use retained shadow plans and full-run
 outcomes, not assumptions about filenames alone.
+
+The planner and map in a pull-request head are untrusted while that pull request
+can change them. Shadow reporting may execute that candidate safely because it
+cannot skip verification. Before enforcement, the workflow must instead execute
+the planner and map from the trusted pull-request base, compare that result with
+the candidate head, and select full assurance if either result is missing, fails
+or disagrees. Workflow, planner, map and routing-test changes must themselves
+select full assurance under the base policy. A revised policy becomes eligible
+only after it has merged under full checks and passed exact-main verification; it
+must never govern its own pull request. Workflow ownership must also be protected
+through CODEOWNERS or an equivalent repository ruleset.
+
+The OKF source lock is part of the dependency contract. Its three research-pack
+JSON inputs are not ordinary documentation: `scripts/build_okf.py` consumes them
+to create the deterministic projection used by Explorer and the gateway image.
+Contract tests therefore require every path in `okf/source-lock.json` to select
+both repository and gateway-image assurance, including rename handling and a
+mutation test which removes a mapping entry.
 
 ## Expected time effect
 

--- a/docs/implementation/CI_IMPACT_ROUTING.md
+++ b/docs/implementation/CI_IMPACT_ROUTING.md
@@ -1,0 +1,93 @@
+# CI impact routing
+
+Status: shadow evaluation; no assurance check is skipped.
+
+## Safe first slice
+
+The complete repository gate, primary gateway-image gate and protected-main
+independent gateway derivation still run for every event on which they previously
+ran. Their producers now start independently instead of waiting for repository
+assurance. The stable required `assurance` job still fails unless:
+
+- the repository gate succeeds;
+- the primary gateway-image gate succeeds; and
+- the shadow impact planner succeeds.
+
+Protected-main Pages and gateway provenance keep their existing downstream evidence
+requirements. The independent gateway derivation has no producer input, so it also
+starts independently on protected main. No required-check name changes.
+
+Superseded runs for the same pull request are cancelled. Push runs use the unique
+GitHub run identity as their concurrency key, so this policy neither cancels nor
+coalesces protected-main runs.
+
+## Shadow planner contract
+
+The versioned map at
+`.github/ci/verification-impact-map.v1.json` declares selectable lanes, their
+dependencies and repository-path rules. `scripts/plan_ci_impact.py` reads the exact
+event-base-to-head Git change inventory, filters recommendations to lanes that run
+for that pull-request or protected-main event, and emits canonical JSON. The output
+records:
+
+- both exact commits and the map SHA-256;
+- every changed path and matching rule;
+- dependency-expanded lane decisions;
+- unmatched paths; and
+- whether a full plan was selected.
+
+The planner is fail closed. An invalid map, missing commit, malformed or unsafe
+path, unknown Git status, empty change set or unmatched path selects full assurance
+or stops the stable gate. Rules cannot enable skipping because the workflow does
+not consume lane outputs in a job condition. The plan is uploaded only as a
+30-day diagnostic artefact.
+
+Every protected-main push selects all lanes, regardless of its paths. The current
+Pages and gateway artefacts bind the exact source commit, and `main` remains
+releasable, so path routing cannot omit that evidence chain.
+
+Representative current decisions are:
+
+| Change | Shadow recommendation | Current execution |
+| --- | --- | --- |
+| QUAL-206 harness or fixture | Repository assurance | All existing checks run |
+| QUAL-206 schema | Repository and gateway derivation chain | All existing checks run |
+| Documentation | Repository assurance | All existing checks run |
+| Workflow, lock or toolchain | Full assurance | All existing checks run |
+| Unknown path | Full assurance | All existing checks run |
+| Any protected-main push | Full exact-commit assurance | All existing checks run |
+
+Gateway runtime and contract paths expand through the independent derivation,
+cross-verification and provenance dependencies. Canonical OKF changes additionally
+select Pages provenance because they affect both published products.
+
+## Promotion gate
+
+Do not use the plan to skip a check until shadow evidence demonstrates all of the
+following:
+
+1. representative documentation, QUAL-206, Explorer, OKF, gateway, execution,
+   schema, workflow, dependency and release changes are covered;
+2. every unmatched or ambiguous path selects full assurance;
+3. recommended lanes have no false negative against the complete checks;
+4. dependency-map and workflow-contract mutations select full assurance;
+5. protected-main and release transitions retain complete evidence and provenance;
+   and
+6. branch protection continues to require the stable fail-closed `assurance` job.
+
+The next optimisation decision should use retained shadow plans and full-run
+outcomes, not assumptions about filenames alone.
+
+## Expected time effect
+
+Recent full runs show roughly 4 to 5 minutes of repository work and roughly 7
+minutes of primary gateway-image work in a previously serial pull-request path.
+Running those producers together should reduce an unchanged successful pull-request
+critical path by about 4 to 5 minutes. Starting the independent derivation at the
+same time should reduce protected-main completion by a similar order, subject to
+runner allocation and network variance. Pull-request cancellation additionally
+avoids completing obsolete runs; its saving is the remaining duration of each
+superseded run.
+
+Shadow planning itself adds one small checkout and a dependency-free Python pass.
+It does not yet save runner minutes because skipping remains disabled.

--- a/docs/implementation/DELIVERY_AND_RELEASE.md
+++ b/docs/implementation/DELIVERY_AND_RELEASE.md
@@ -21,6 +21,13 @@ tests, source/link/research integrity, secret scanning, diagrams and SBOM genera
 Feature work adds affected browser, accessibility, protocol, policy, provider and
 deployment tests to the same required gate or a separately required stable check.
 
+Independent assurance producers may run in parallel, but the stable `assurance`
+aggregator must fail closed unless every required producer succeeds. The current
+[CI impact planner](CI_IMPACT_ROUTING.md) is shadow-only: it records a versioned,
+dependency-expanded recommendation while every existing check still runs. Unknown
+paths select full assurance, and no planner output may control job execution until
+the documented promotion gate is separately accepted.
+
 Pinned dependencies and GitHub Actions remain mandatory. A dependency change must
 update lock files, regenerate the SBOM, record the reason and pass the relevant
 same-pattern tests.

--- a/scripts/plan_ci_impact.py
+++ b/scripts/plan_ci_impact.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""Produce a deterministic, fail-closed CI impact plan without skipping checks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MAP = Path(".github/ci/verification-impact-map.v1.json")
+MAP_SCHEMA = "gis-ai-go.ci-impact-map.v1"
+PLAN_SCHEMA = "gis-ai-go.ci-impact-plan.v1"
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+LANE_ID = re.compile(r"^[a-z][a-z0-9_-]*$")
+RULE_ID = re.compile(r"^[a-z][a-z0-9-]*$")
+MAX_MAP_BYTES = 1024 * 1024
+MAX_CHANGED_PATHS = 20_000
+MAX_DIFF_BYTES = 64 * 1024 * 1024
+MAX_PATH_BYTES = 4_096
+ALLOWED_EVENTS = frozenset({"pull_request", "push_main"})
+
+
+class ImpactPlanError(ValueError):
+    """Raised when an impact plan cannot be produced safely."""
+
+
+@dataclass(frozen=True)
+class Lane:
+    lane_id: str
+    description: str
+    events: tuple[str, ...]
+    depends_on: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    description: str
+    patterns: tuple[str, ...]
+    lanes: tuple[str, ...]
+    force_full: bool
+    matchers: tuple[re.Pattern[str], ...]
+
+
+@dataclass(frozen=True)
+class ImpactMap:
+    digest: str
+    always_run: tuple[str, ...]
+    lanes: tuple[Lane, ...]
+    full_lanes: tuple[str, ...]
+    push_main_policy: str
+    rules: tuple[Rule, ...]
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ImpactPlanError(f"impact map contains duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_json_constant(value: str) -> object:
+    raise ImpactPlanError(f"impact map contains non-standard JSON constant: {value}")
+
+
+def _closed_object(value: object, keys: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ImpactPlanError(f"{label} must be an object")
+    observed = set(value)
+    if observed != keys:
+        missing = sorted(keys - observed)
+        extra = sorted(observed - keys)
+        raise ImpactPlanError(f"{label} keys are not closed; missing={missing}, extra={extra}")
+    return value
+
+
+def _string(value: object, label: str, *, maximum: int = 240) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise ImpactPlanError(f"{label} must be a non-empty string of at most {maximum} characters")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ImpactPlanError(f"{label} contains a control character")
+    return value
+
+
+def _string_list(value: object, label: str, *, maximum: int = 256) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value or len(value) > maximum:
+        raise ImpactPlanError(f"{label} must be a non-empty bounded array")
+    items = tuple(_string(item, f"{label} item", maximum=MAX_PATH_BYTES) for item in value)
+    if len(items) != len(set(items)):
+        raise ImpactPlanError(f"{label} contains a duplicate")
+    if items != tuple(sorted(items)):
+        raise ImpactPlanError(f"{label} must be sorted")
+    return items
+
+
+def _validate_repository_path(value: str, label: str = "changed path") -> str:
+    encoded = value.encode("utf-8")
+    if not encoded or len(encoded) > MAX_PATH_BYTES:
+        raise ImpactPlanError(f"{label} has an invalid byte length")
+    if value.startswith("/") or value.endswith("/") or "\\" in value:
+        raise ImpactPlanError(f"{label} is not a canonical repository-relative path")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ImpactPlanError(f"{label} contains a control character")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ImpactPlanError(f"{label} contains an unsafe path component")
+    return value
+
+
+def _validate_pattern(value: str) -> str:
+    _validate_repository_path(value, "impact pattern")
+    if any(character in value for character in "?[]{}") or "***" in value:
+        raise ImpactPlanError(f"impact pattern uses unsupported syntax: {value}")
+    for part in value.split("/"):
+        if "**" in part and part != "**":
+            raise ImpactPlanError(f"recursive wildcard must occupy one path component: {value}")
+    return value
+
+
+def _compile_pattern(pattern: str) -> re.Pattern[str]:
+    fragments: list[str] = ["^"]
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            fragments.append("(?:.*/)?")
+            index += 3
+        elif pattern.startswith("**", index):
+            fragments.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            fragments.append("[^/]*")
+            index += 1
+        else:
+            fragments.append(re.escape(pattern[index]))
+            index += 1
+    fragments.append("$")
+    return re.compile("".join(fragments))
+
+
+def _validate_dependency_graph(lanes: tuple[Lane, ...]) -> None:
+    by_id = {lane.lane_id: lane for lane in lanes}
+    for lane in lanes:
+        for dependency in lane.depends_on:
+            if dependency not in by_id:
+                raise ImpactPlanError(
+                    f"lane {lane.lane_id} has unknown dependency {dependency}"
+                )
+            if dependency == lane.lane_id:
+                raise ImpactPlanError(f"lane {lane.lane_id} depends on itself")
+            if not set(lane.events).issubset(by_id[dependency].events):
+                raise ImpactPlanError(
+                    f"lane {lane.lane_id} dependency {dependency} is not available "
+                    "for every consumer event"
+                )
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(lane_id: str) -> None:
+        if lane_id in visiting:
+            raise ImpactPlanError("lane dependency graph contains a cycle")
+        if lane_id in visited:
+            return
+        visiting.add(lane_id)
+        for dependency in by_id[lane_id].depends_on:
+            visit(dependency)
+        visiting.remove(lane_id)
+        visited.add(lane_id)
+
+    for lane_id in sorted(by_id):
+        visit(lane_id)
+
+
+def _read_bounded_regular_file(path: Path) -> bytes:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise ImpactPlanError(f"impact map is missing: {path}") from error
+    if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+        raise ImpactPlanError("impact map must be a regular file, not a link")
+    if metadata.st_size > MAX_MAP_BYTES:
+        raise ImpactPlanError("impact map exceeds the byte limit")
+    return path.read_bytes()
+
+
+def load_impact_map(path: Path) -> ImpactMap:
+    raw = _read_bounded_regular_file(path)
+    try:
+        document = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_unique_json_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ImpactPlanError("impact map is not valid UTF-8 JSON") from error
+    root = _closed_object(
+        document,
+        {
+            "schema",
+            "mode",
+            "unknown_path_policy",
+            "push_main_policy",
+            "always_run",
+            "lanes",
+            "full_lanes",
+            "rules",
+        },
+        "impact map",
+    )
+    if root["schema"] != MAP_SCHEMA:
+        raise ImpactPlanError(f"unsupported impact map schema: {root['schema']!r}")
+    if root["mode"] != "shadow":
+        raise ImpactPlanError("the first impact-map version must remain in shadow mode")
+    if root["unknown_path_policy"] != "full":
+        raise ImpactPlanError("unknown paths must select full assurance")
+    if root["push_main_policy"] != "full_exact_commit":
+        raise ImpactPlanError("protected-main changes must select exact-commit full assurance")
+
+    always_run = _string_list(root["always_run"], "always_run", maximum=32)
+    if any(LANE_ID.fullmatch(item) is None for item in always_run):
+        raise ImpactPlanError("always_run contains an invalid job identifier")
+
+    lane_values = root["lanes"]
+    if not isinstance(lane_values, list) or not lane_values or len(lane_values) > 32:
+        raise ImpactPlanError("lanes must be a non-empty bounded array")
+    lanes: list[Lane] = []
+    for index, value in enumerate(lane_values):
+        lane = _closed_object(
+            value,
+            {"id", "description", "events", "depends_on"},
+            f"lane {index}",
+        )
+        lane_id = _string(lane["id"], f"lane {index} id", maximum=80)
+        if LANE_ID.fullmatch(lane_id) is None:
+            raise ImpactPlanError(f"invalid lane identifier: {lane_id}")
+        description = _string(lane["description"], f"lane {lane_id} description")
+        events = _string_list(lane["events"], f"lane {lane_id} events", maximum=4)
+        if not set(events).issubset(ALLOWED_EVENTS):
+            raise ImpactPlanError(f"lane {lane_id} contains an unsupported event")
+        dependencies_value = lane["depends_on"]
+        if not isinstance(dependencies_value, list) or len(dependencies_value) > 32:
+            raise ImpactPlanError(f"lane {lane_id} dependencies must be a bounded array")
+        dependencies = tuple(
+            _string(item, f"lane {lane_id} dependency", maximum=80)
+            for item in dependencies_value
+        )
+        if len(dependencies) != len(set(dependencies)) or dependencies != tuple(
+            sorted(dependencies)
+        ):
+            raise ImpactPlanError(f"lane {lane_id} dependencies must be unique and sorted")
+        if any(LANE_ID.fullmatch(item) is None for item in dependencies):
+            raise ImpactPlanError(f"lane {lane_id} contains an invalid dependency")
+        lanes.append(Lane(lane_id, description, events, dependencies))
+
+    lane_tuple = tuple(sorted(lanes, key=lambda item: item.lane_id))
+    lane_ids = tuple(lane.lane_id for lane in lane_tuple)
+    if len(lane_ids) != len(set(lane_ids)):
+        raise ImpactPlanError("lane identifiers must be unique")
+    _validate_dependency_graph(lane_tuple)
+
+    full_lanes = _string_list(root["full_lanes"], "full_lanes", maximum=32)
+    if full_lanes != lane_ids:
+        raise ImpactPlanError("full_lanes must contain every lane exactly once")
+
+    rule_values = root["rules"]
+    if not isinstance(rule_values, list) or not rule_values or len(rule_values) > 256:
+        raise ImpactPlanError("rules must be a non-empty bounded array")
+    rules: list[Rule] = []
+    for index, value in enumerate(rule_values):
+        rule = _closed_object(
+            value,
+            {"id", "description", "patterns", "lanes", "force_full"},
+            f"rule {index}",
+        )
+        rule_id = _string(rule["id"], f"rule {index} id", maximum=80)
+        if RULE_ID.fullmatch(rule_id) is None:
+            raise ImpactPlanError(f"invalid rule identifier: {rule_id}")
+        description = _string(rule["description"], f"rule {rule_id} description")
+        patterns = _string_list(rule["patterns"], f"rule {rule_id} patterns")
+        patterns = tuple(_validate_pattern(pattern) for pattern in patterns)
+        selected_lanes = _string_list(rule["lanes"], f"rule {rule_id} lanes", maximum=32)
+        if not set(selected_lanes).issubset(lane_ids):
+            raise ImpactPlanError(f"rule {rule_id} selects an unknown lane")
+        force_full = rule["force_full"]
+        if not isinstance(force_full, bool):
+            raise ImpactPlanError(f"rule {rule_id} force_full must be a boolean")
+        if force_full and selected_lanes != full_lanes:
+            raise ImpactPlanError(f"force-full rule {rule_id} must select every lane")
+        rules.append(
+            Rule(
+                rule_id,
+                description,
+                patterns,
+                selected_lanes,
+                force_full,
+                tuple(_compile_pattern(pattern) for pattern in patterns),
+            )
+        )
+
+    rule_ids = tuple(rule.rule_id for rule in rules)
+    if len(rule_ids) != len(set(rule_ids)):
+        raise ImpactPlanError("rule identifiers must be unique")
+    return ImpactMap(
+        digest=hashlib.sha256(raw).hexdigest(),
+        always_run=always_run,
+        lanes=lane_tuple,
+        full_lanes=full_lanes,
+        push_main_policy=root["push_main_policy"],
+        rules=tuple(rules),
+    )
+
+
+def _validate_commit(value: str, label: str) -> str:
+    if COMMIT.fullmatch(value) is None or value == "0" * 40:
+        raise ImpactPlanError(f"{label} must be a non-zero full lowercase Git commit")
+    return value
+
+
+def _expand_dependencies(impact_map: ImpactMap, selected: set[str]) -> tuple[str, ...]:
+    by_id = {lane.lane_id: lane for lane in impact_map.lanes}
+    pending = list(selected)
+    while pending:
+        lane_id = pending.pop()
+        for dependency in by_id[lane_id].depends_on:
+            if dependency not in selected:
+                selected.add(dependency)
+                pending.append(dependency)
+    return tuple(sorted(selected))
+
+
+def plan_for_paths(
+    impact_map: ImpactMap,
+    paths: Sequence[str],
+    *,
+    base_commit: str,
+    head_commit: str,
+    event: str,
+) -> dict[str, object]:
+    base_commit = _validate_commit(base_commit, "base commit")
+    head_commit = _validate_commit(head_commit, "head commit")
+    if event not in ALLOWED_EVENTS:
+        raise ImpactPlanError(f"unsupported planning event: {event}")
+    if len(paths) > MAX_CHANGED_PATHS:
+        raise ImpactPlanError("changed-path count exceeds the planner limit")
+    changed_paths = tuple(sorted({_validate_repository_path(path) for path in paths}))
+    applicable_lanes = tuple(
+        lane.lane_id for lane in impact_map.lanes if event in lane.events
+    )
+
+    matched_rule_ids: set[str] = set()
+    selected: set[str] = set()
+    unmatched: list[str] = []
+    matches: list[dict[str, object]] = []
+    force_full_rules: set[str] = set()
+    for path in changed_paths:
+        path_rules: list[str] = []
+        for rule in impact_map.rules:
+            if any(matcher.fullmatch(path) is not None for matcher in rule.matchers):
+                path_rules.append(rule.rule_id)
+                matched_rule_ids.add(rule.rule_id)
+                selected.update(rule.lanes)
+                if rule.force_full:
+                    force_full_rules.add(rule.rule_id)
+        if not path_rules:
+            unmatched.append(path)
+        matches.append({"path": path, "rule_ids": sorted(path_rules)})
+
+    if not changed_paths:
+        reason = "empty-change-set"
+        force_full = True
+    elif unmatched:
+        reason = "unmatched-path"
+        force_full = True
+    elif force_full_rules:
+        reason = "force-full-rule"
+        force_full = True
+    else:
+        reason = "matched-rules"
+        force_full = False
+
+    if event == "push_main" and changed_paths:
+        reason = "protected-main-exact-commit"
+        force_full = True
+
+    expanded_lanes = _expand_dependencies(impact_map, selected)
+    selected_lanes = tuple(
+        lane_id
+        for lane_id in (impact_map.full_lanes if force_full else expanded_lanes)
+        if lane_id in applicable_lanes
+    )
+    if not force_full and not selected_lanes:
+        reason = "no-applicable-lane"
+        force_full = True
+        selected_lanes = applicable_lanes
+    lane_decisions = {
+        lane.lane_id: lane.lane_id in selected_lanes for lane in impact_map.lanes
+    }
+    return {
+        "schema": PLAN_SCHEMA,
+        "mode": "shadow",
+        "enforced": False,
+        "event": event,
+        "reason": reason,
+        "force_full": force_full,
+        "base_commit": base_commit,
+        "head_commit": head_commit,
+        "map_sha256": impact_map.digest,
+        "changed_path_count": len(changed_paths),
+        "changed_paths": list(changed_paths),
+        "matches": matches,
+        "matched_rule_ids": sorted(matched_rule_ids),
+        "force_full_rule_ids": sorted(force_full_rules),
+        "unmatched_paths": unmatched,
+        "always_run": list(impact_map.always_run),
+        "applicable_lanes": list(applicable_lanes),
+        "selected_lanes": list(selected_lanes),
+        "lane_decisions": lane_decisions,
+    }
+
+
+def _run_git(root: Path, arguments: Sequence[str]) -> bytes:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise ImpactPlanError(f"Git command failed closed: git {' '.join(arguments[:2])}")
+    return result.stdout
+
+
+def changed_paths_between(root: Path, base_commit: str, head_commit: str) -> tuple[str, ...]:
+    base_commit = _validate_commit(base_commit, "base commit")
+    head_commit = _validate_commit(head_commit, "head commit")
+    for commit in (base_commit, head_commit):
+        _run_git(root, ("cat-file", "-e", f"{commit}^{{commit}}"))
+    checked_out = _run_git(root, ("rev-parse", "HEAD")).decode("ascii").strip()
+    if checked_out != head_commit:
+        raise ImpactPlanError("head commit does not match the checked-out worktree")
+
+    raw = _run_git(
+        root,
+        (
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames=50%",
+            base_commit,
+            head_commit,
+            "--",
+        ),
+    )
+    if len(raw) > MAX_DIFF_BYTES:
+        raise ImpactPlanError("Git change inventory exceeds the planner byte limit")
+    tokens = raw.split(b"\0")
+    if tokens and tokens[-1] == b"":
+        tokens.pop()
+    paths: list[str] = []
+    index = 0
+    while index < len(tokens):
+        try:
+            status_text = tokens[index].decode("ascii")
+        except UnicodeDecodeError as error:
+            raise ImpactPlanError("Git change status is not ASCII") from error
+        index += 1
+        status = status_text[:1]
+        path_count = 2 if status in {"C", "R"} else 1
+        if status not in {"A", "C", "D", "M", "R", "T"}:
+            raise ImpactPlanError(f"unsupported Git change status: {status_text}")
+        if index + path_count > len(tokens):
+            raise ImpactPlanError("Git change inventory is truncated")
+        for raw_path in tokens[index : index + path_count]:
+            try:
+                path = raw_path.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ImpactPlanError("Git changed path is not UTF-8") from error
+            paths.append(_validate_repository_path(path))
+        index += path_count
+        if len(paths) > MAX_CHANGED_PATHS:
+            raise ImpactPlanError("changed-path count exceeds the planner limit")
+    return tuple(sorted(set(paths)))
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _repository_file(root: Path, relative: Path, label: str) -> Path:
+    if relative.is_absolute():
+        raise ImpactPlanError(f"{label} must be repository relative")
+    logical = _validate_repository_path(relative.as_posix(), label)
+    target = root / logical
+    resolved_root = root.resolve()
+    resolved_target = target.resolve(strict=False)
+    if not resolved_target.is_relative_to(resolved_root):
+        raise ImpactPlanError(f"{label} escapes the repository")
+    return target
+
+
+def write_new_output(root: Path, relative: Path, payload: bytes) -> Path:
+    target = _repository_file(root, relative, "output path")
+    relative_parent = target.parent.relative_to(root)
+    current = root
+    for component in relative_parent.parts:
+        current = current / component
+        if current.exists() or current.is_symlink():
+            metadata = current.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise ImpactPlanError("output parent must be a real directory")
+        else:
+            current.mkdir(mode=0o755)
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(target, flags, 0o600)
+    except FileExistsError as error:
+        raise ImpactPlanError("output path already exists") from error
+    with os.fdopen(descriptor, "wb") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+    return target
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Plan CI impact in fail-closed shadow mode without skipping checks."
+    )
+    parser.add_argument("--base", required=True, help="full event base commit")
+    parser.add_argument("--head", required=True, help="full checked-out head commit")
+    parser.add_argument(
+        "--event",
+        required=True,
+        choices=sorted(ALLOWED_EVENTS),
+        help="normalised workflow event",
+    )
+    parser.add_argument(
+        "--map",
+        type=Path,
+        default=DEFAULT_MAP,
+        help="repository-relative versioned impact map",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="new repository-relative machine-readable plan path",
+    )
+    arguments = parser.parse_args(argv)
+
+    try:
+        map_path = _repository_file(ROOT, arguments.map, "impact map path")
+        impact_map = load_impact_map(map_path)
+        paths = changed_paths_between(ROOT, arguments.base, arguments.head)
+        plan = plan_for_paths(
+            impact_map,
+            paths,
+            base_commit=arguments.base,
+            head_commit=arguments.head,
+            event=arguments.event,
+        )
+        payload = canonical_json_bytes(plan)
+        write_new_output(ROOT, arguments.output, payload)
+    except (ImpactPlanError, OSError) as error:
+        raise SystemExit(f"CI impact planning failed closed: {error}") from error
+    print(payload.decode("utf-8"), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/contract/test_ci_impact_plan.py
+++ b/tests/contract/test_ci_impact_plan.py
@@ -24,8 +24,19 @@ from plan_ci_impact import (  # noqa: E402
 
 
 MAP_PATH = ROOT / ".github" / "ci" / "verification-impact-map.v1.json"
+SOURCE_LOCK_PATH = ROOT / "okf" / "source-lock.json"
 BASE = "1" * 40
 HEAD = "2" * 40
+REQUIRED_OKF_PR_LANES = {"gateway_image", "repository_assurance"}
+RESEARCH_OKF_INPUTS = (
+    "docs/research/2026-08-19/research-pack/data/providers.json",
+    "docs/research/2026-08-19/research-pack/data/sources.json",
+    "docs/research/2026-08-19/research-pack/data/workflows.json",
+)
+LOCKED_OKF_INPUTS = tuple(
+    item["path"]
+    for item in json.loads(SOURCE_LOCK_PATH.read_text(encoding="utf-8"))["inputs"]
+)
 
 
 class CiImpactPlanTests(unittest.TestCase):
@@ -41,6 +52,20 @@ class CiImpactPlanTests(unittest.TestCase):
             head_commit=HEAD,
             event="pull_request",
         )
+
+    def assert_locked_okf_inputs_select_image_assurance(self, impact_map: object) -> None:
+        for path in LOCKED_OKF_INPUTS:
+            plan = plan_for_paths(
+                impact_map,
+                [path],
+                base_commit=BASE,
+                head_commit=HEAD,
+                event="pull_request",
+            )
+            self.assertTrue(
+                REQUIRED_OKF_PR_LANES.issubset(set(plan["selected_lanes"])),
+                f"locked OKF input {path!r} did not select repository and image assurance",
+            )
 
     def test_qual_harness_change_selects_repository_assurance_only(self) -> None:
         plan = self.plan("scripts/qual_206_claude_capability_harness.mjs")
@@ -69,6 +94,62 @@ class CiImpactPlanTests(unittest.TestCase):
         self.assertFalse(plan["force_full"])
         self.assertEqual(plan["selected_lanes"], ["repository_assurance"])
         self.assertEqual(plan["matched_rule_ids"], ["documentation-and-governance"])
+
+    def test_locked_research_inputs_select_okf_image_assurance(self) -> None:
+        for path in RESEARCH_OKF_INPUTS:
+            with self.subTest(path=path):
+                plan = self.plan(path)
+                self.assertFalse(plan["force_full"])
+                self.assertEqual(
+                    plan["selected_lanes"],
+                    ["gateway_image", "repository_assurance"],
+                )
+                self.assertEqual(
+                    plan["matched_rule_ids"],
+                    ["documentation-and-governance", "governed-okf-publication"],
+                )
+
+    def test_every_locked_okf_input_selects_repository_and_image_assurance(self) -> None:
+        self.assert_locked_okf_inputs_select_image_assurance(self.impact_map)
+
+    def test_nearby_unlocked_research_document_remains_repository_only(self) -> None:
+        plan = self.plan(
+            "docs/research/2026-08-19/research-pack/data/decisions.json"
+        )
+        self.assertFalse(plan["force_full"])
+        self.assertEqual(plan["selected_lanes"], ["repository_assurance"])
+        self.assertEqual(plan["matched_rule_ids"], ["documentation-and-governance"])
+
+    def test_locked_research_inputs_force_full_exact_commit_on_main(self) -> None:
+        for path in RESEARCH_OKF_INPUTS:
+            with self.subTest(path=path):
+                plan = plan_for_paths(
+                    self.impact_map,
+                    [path],
+                    base_commit=BASE,
+                    head_commit=HEAD,
+                    event="push_main",
+                )
+                self.assertTrue(plan["force_full"])
+                self.assertEqual(plan["reason"], "protected-main-exact-commit")
+                self.assertEqual(
+                    plan["selected_lanes"], list(self.impact_map.full_lanes)
+                )
+
+    def test_source_lock_coverage_fails_if_a_locked_mapping_is_removed(self) -> None:
+        document = json.loads(MAP_PATH.read_text(encoding="utf-8"))
+        rule = next(
+            item
+            for item in document["rules"]
+            if item["id"] == "governed-okf-publication"
+        )
+        rule["patterns"].remove(RESEARCH_OKF_INPUTS[0])
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            mutated_map = load_impact_map(path)
+            with self.assertRaises(AssertionError):
+                self.assert_locked_okf_inputs_select_image_assurance(mutated_map)
 
     def test_global_workflow_change_selects_every_lane(self) -> None:
         plan = self.plan(".github/workflows/ci.yml")
@@ -229,6 +310,47 @@ class CiImpactPlanTests(unittest.TestCase):
                 changed_paths_between(root, base, head),
                 ("docs/new.md", "docs/old.md"),
             )
+
+    def test_locked_input_rename_evaluates_old_and_new_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(("git", "init", "-q"), cwd=root, check=True)
+            subprocess.run(
+                ("git", "config", "user.email", "ci-impact@example.invalid"),
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ("git", "config", "user.name", "CI impact test"),
+                cwd=root,
+                check=True,
+            )
+            old = root / RESEARCH_OKF_INPUTS[0]
+            old.parent.mkdir(parents=True)
+            old.write_text("{}\n", encoding="utf-8")
+            subprocess.run(("git", "add", RESEARCH_OKF_INPUTS[0]), cwd=root, check=True)
+            subprocess.run(("git", "commit", "-qm", "first"), cwd=root, check=True)
+            base = subprocess.check_output(("git", "rev-parse", "HEAD"), cwd=root).decode(
+                "ascii"
+            ).strip()
+            new_path = "docs/research/2026-08-19/research-pack/data/decisions.json"
+            subprocess.run(
+                ("git", "mv", RESEARCH_OKF_INPUTS[0], new_path), cwd=root, check=True
+            )
+            subprocess.run(("git", "commit", "-qm", "rename"), cwd=root, check=True)
+            head = subprocess.check_output(("git", "rev-parse", "HEAD"), cwd=root).decode(
+                "ascii"
+            ).strip()
+            changed_paths = changed_paths_between(root, base, head)
+            self.assertEqual(changed_paths, (new_path, RESEARCH_OKF_INPUTS[0]))
+            plan = plan_for_paths(
+                self.impact_map,
+                changed_paths,
+                base_commit=base,
+                head_commit=head,
+                event="pull_request",
+            )
+            self.assertTrue(REQUIRED_OKF_PR_LANES.issubset(set(plan["selected_lanes"])))
 
     def test_output_is_new_and_repository_relative(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/contract/test_ci_impact_plan.py
+++ b/tests/contract/test_ci_impact_plan.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from plan_ci_impact import (  # noqa: E402
+    ImpactPlanError,
+    canonical_json_bytes,
+    changed_paths_between,
+    load_impact_map,
+    plan_for_paths,
+    write_new_output,
+)
+
+
+MAP_PATH = ROOT / ".github" / "ci" / "verification-impact-map.v1.json"
+BASE = "1" * 40
+HEAD = "2" * 40
+
+
+class CiImpactPlanTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.impact_map = load_impact_map(MAP_PATH)
+
+    def plan(self, *paths: str) -> dict[str, object]:
+        return plan_for_paths(
+            self.impact_map,
+            paths,
+            base_commit=BASE,
+            head_commit=HEAD,
+            event="pull_request",
+        )
+
+    def test_qual_harness_change_selects_repository_assurance_only(self) -> None:
+        plan = self.plan("scripts/qual_206_claude_capability_harness.mjs")
+        self.assertFalse(plan["force_full"])
+        self.assertEqual(plan["reason"], "matched-rules")
+        self.assertEqual(plan["selected_lanes"], ["repository_assurance"])
+        self.assertEqual(
+            plan["matched_rule_ids"],
+            ["qual-206-evidence", "repository-tests-and-tooling"],
+        )
+
+    def test_qual_schema_also_selects_the_gateway_derivation_chain(self) -> None:
+        plan = self.plan("schemas/qual-206-claude-capability-evidence-v1.schema.json")
+        self.assertFalse(plan["force_full"])
+        self.assertEqual(
+            plan["selected_lanes"],
+            [
+                "gateway_image",
+                "repository_assurance",
+            ],
+        )
+        self.assertEqual(plan["matched_rule_ids"], ["gateway-build-context"])
+
+    def test_documentation_change_selects_repository_assurance_only(self) -> None:
+        plan = self.plan("docs/implementation/ROADMAP.md")
+        self.assertFalse(plan["force_full"])
+        self.assertEqual(plan["selected_lanes"], ["repository_assurance"])
+        self.assertEqual(plan["matched_rule_ids"], ["documentation-and-governance"])
+
+    def test_global_workflow_change_selects_every_lane(self) -> None:
+        plan = self.plan(".github/workflows/ci.yml")
+        self.assertTrue(plan["force_full"])
+        self.assertEqual(plan["reason"], "force-full-rule")
+        self.assertEqual(
+            plan["selected_lanes"], ["gateway_image", "repository_assurance"]
+        )
+        self.assertEqual(plan["force_full_rule_ids"], ["global-assurance-control"])
+
+    def test_unknown_path_fails_closed_to_every_lane(self) -> None:
+        plan = self.plan("future-component/source/new-runtime.ts")
+        self.assertTrue(plan["force_full"])
+        self.assertEqual(plan["reason"], "unmatched-path")
+        self.assertEqual(plan["unmatched_paths"], ["future-component/source/new-runtime.ts"])
+        self.assertEqual(
+            plan["selected_lanes"], ["gateway_image", "repository_assurance"]
+        )
+
+    def test_empty_change_set_fails_closed_to_every_lane(self) -> None:
+        plan = self.plan()
+        self.assertTrue(plan["force_full"])
+        self.assertEqual(plan["reason"], "empty-change-set")
+        self.assertEqual(
+            plan["selected_lanes"], ["gateway_image", "repository_assurance"]
+        )
+
+    def test_gateway_dependency_closure_is_expanded_deterministically(self) -> None:
+        plan = self.plan("apps/mcp-gateway/src/server.ts")
+        self.assertEqual(
+            plan["selected_lanes"],
+            [
+                "gateway_image",
+                "repository_assurance",
+            ],
+        )
+        self.assertEqual(
+            canonical_json_bytes(plan),
+            canonical_json_bytes(self.plan("apps/mcp-gateway/src/server.ts")),
+        )
+
+    def test_push_main_gateway_plan_expands_the_provenance_chain(self) -> None:
+        plan = plan_for_paths(
+            self.impact_map,
+            ["apps/mcp-gateway/src/server.ts"],
+            base_commit=BASE,
+            head_commit=HEAD,
+            event="push_main",
+        )
+        self.assertEqual(
+            plan["selected_lanes"],
+            [
+                "gateway-provenance",
+                "gateway_attestation_verification",
+                "gateway_image",
+                "gateway_independent_image",
+                "provenance",
+                "repository_assurance",
+            ],
+        )
+        self.assertEqual(plan["reason"], "protected-main-exact-commit")
+        self.assertTrue(plan["force_full"])
+
+    def test_push_main_documentation_plan_retains_full_exact_commit_evidence(self) -> None:
+        plan = plan_for_paths(
+            self.impact_map,
+            ["docs/implementation/ROADMAP.md"],
+            base_commit=BASE,
+            head_commit=HEAD,
+            event="push_main",
+        )
+        self.assertEqual(plan["reason"], "protected-main-exact-commit")
+        self.assertEqual(plan["selected_lanes"], list(self.impact_map.full_lanes))
+
+    def test_unsafe_changed_path_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ImpactPlanError, "unsafe path component"):
+            self.plan("../outside")
+        with self.assertRaisesRegex(ImpactPlanError, "control character"):
+            self.plan("docs/forged\nheading.md")
+
+    def test_map_rejects_a_non_full_unknown_path_policy(self) -> None:
+        document = json.loads(MAP_PATH.read_text(encoding="utf-8"))
+        document["unknown_path_policy"] = "none"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(ImpactPlanError, "must select full assurance"):
+                load_impact_map(path)
+
+    def test_map_rejects_duplicate_keys_and_non_standard_constants(self) -> None:
+        source = MAP_PATH.read_text(encoding="utf-8")
+        invalid_documents = (
+            (
+                source.replace(
+                    '"mode": "shadow",',
+                    '"mode": "shadow",\n  "mode": "shadow",',
+                    1,
+                ),
+                "duplicate JSON key",
+            ),
+            (
+                source.replace('"mode": "shadow"', '"mode": NaN', 1),
+                "non-standard JSON constant",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            for index, (content, message) in enumerate(invalid_documents):
+                with self.subTest(message=message):
+                    path = Path(directory) / f"invalid-{index}.json"
+                    path.write_text(content, encoding="utf-8")
+                    with self.assertRaisesRegex(ImpactPlanError, message):
+                        load_impact_map(path)
+
+    def test_map_rejects_an_event_incompatible_dependency(self) -> None:
+        document = json.loads(MAP_PATH.read_text(encoding="utf-8"))
+        lane = next(
+            item
+            for item in document["lanes"]
+            if item["id"] == "gateway_attestation_verification"
+        )
+        lane["events"] = ["pull_request", "push_main"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(ImpactPlanError, "not available"):
+                load_impact_map(path)
+
+    def test_git_rename_inventory_includes_old_and_new_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(("git", "init", "-q"), cwd=root, check=True)
+            subprocess.run(
+                ("git", "config", "user.email", "ci-impact@example.invalid"),
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ("git", "config", "user.name", "CI impact test"),
+                cwd=root,
+                check=True,
+            )
+            old = root / "docs" / "old.md"
+            old.parent.mkdir()
+            old.write_text("bounded\n", encoding="utf-8")
+            subprocess.run(("git", "add", "docs/old.md"), cwd=root, check=True)
+            subprocess.run(("git", "commit", "-qm", "first"), cwd=root, check=True)
+            base = subprocess.check_output(("git", "rev-parse", "HEAD"), cwd=root).decode(
+                "ascii"
+            ).strip()
+            subprocess.run(
+                ("git", "mv", "docs/old.md", "docs/new.md"), cwd=root, check=True
+            )
+            subprocess.run(("git", "commit", "-qm", "rename"), cwd=root, check=True)
+            head = subprocess.check_output(("git", "rev-parse", "HEAD"), cwd=root).decode(
+                "ascii"
+            ).strip()
+            self.assertEqual(
+                changed_paths_between(root, base, head),
+                ("docs/new.md", "docs/old.md"),
+            )
+
+    def test_output_is_new_and_repository_relative(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = write_new_output(root, Path("artifacts/ci/plan.json"), b"{}\n")
+            self.assertEqual(target.read_bytes(), b"{}\n")
+            with self.assertRaisesRegex(ImpactPlanError, "already exists"):
+                write_new_output(root, Path("artifacts/ci/plan.json"), b"{}\n")
+            with self.assertRaisesRegex(ImpactPlanError, "repository relative"):
+                write_new_output(root, Path("/tmp/plan.json"), b"{}\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -76,7 +76,51 @@ class PagesWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("contents: write", CI_WORKFLOW + PAGES_WORKFLOW)
 
+    def test_ci_cancels_only_superseded_pull_request_runs(self) -> None:
+        concurrency = CI_WORKFLOW.split("\nconcurrency:\n", 1)[1].split(
+            "\npermissions: {}", 1
+        )[0]
+        self.assertIn(
+            "group: ci-${{ github.workflow }}-"
+            "${{ github.event.pull_request.number || github.run_id }}",
+            concurrency,
+        )
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            concurrency,
+        )
+        self.assertNotIn("github.ref", concurrency)
+
+    def test_ci_impact_map_job_identifiers_cannot_drift_from_the_workflow(self) -> None:
+        impact_map = json.loads(
+            (ROOT / ".github/ci/verification-impact-map.v1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        mapped_lanes = {lane["id"] for lane in impact_map["lanes"]}
+        always_run = set(impact_map["always_run"])
+        jobs = CI_WORKFLOW.split("\njobs:\n", 1)[1]
+        workflow_jobs = set(
+            re.findall(r"^  ([a-z][a-z0-9_-]*):$", jobs, re.MULTILINE)
+        )
+        self.assertEqual(
+            mapped_lanes,
+            {
+                "gateway-provenance",
+                "gateway_attestation_verification",
+                "gateway_image",
+                "gateway_independent_image",
+                "provenance",
+                "repository_assurance",
+            },
+        )
+        self.assertEqual(always_run, {"assurance", "ci_impact_shadow"})
+        self.assertEqual(workflow_jobs, mapped_lanes | always_run)
+
     def test_ci_exposes_one_stable_assurance_gate_for_both_producers(self) -> None:
+        impact = CI_WORKFLOW.split("\n  ci_impact_shadow:\n", 1)[1].split(
+            "\n  repository_assurance:\n", 1
+        )[0]
         repository = CI_WORKFLOW.split("\n  repository_assurance:\n", 1)[1].split(
             "\n  gateway_image:\n", 1
         )[0]
@@ -88,18 +132,35 @@ class PagesWorkflowTests(unittest.TestCase):
         )[0]
 
         self.assertEqual(CI_WORKFLOW.count("\n  assurance:\n"), 1)
+        self.assertIn("name: CI impact plan (shadow)", impact)
+        self.assertIn("fetch-depth: 0", impact)
+        self.assertIn("scripts/plan_ci_impact.py", impact)
+        self.assertIn("impact_event='pull_request'", impact)
+        self.assertIn("impact_event='push_main'", impact)
+        self.assertIn('--event "$impact_event"', impact)
+        impact_map = (
+            ROOT / ".github/ci/verification-impact-map.v1.json"
+        ).read_text(encoding="utf-8")
+        self.assertIn('"mode": "shadow"', impact_map)
+        self.assertIn("All current assurance jobs still run", impact)
+        self.assertNotIn("needs.ci_impact_shadow.outputs", CI_WORKFLOW)
         self.assertIn("name: Repository assurance", repository)
         self.assertIn("timeout-minutes: 20", repository)
         self.assertIn("name: Gateway image assurance", gateway)
-        self.assertIn("needs: repository_assurance", gateway)
+        self.assertNotIn("needs: repository_assurance", gateway)
         self.assertIn("timeout-minutes: 50", gateway)
         self.assertNotIn("\n  gateway-image:\n", CI_WORKFLOW)
 
         self.assertIn("name: assurance", assurance)
         self.assertIn("if: always()", assurance)
         self.assertIn("permissions: {}", assurance)
+        self.assertIn("- ci_impact_shadow", assurance)
         self.assertIn("- repository_assurance", assurance)
         self.assertIn("- gateway_image", assurance)
+        self.assertIn(
+            "CI_IMPACT_SHADOW_RESULT: ${{ needs.ci_impact_shadow.result }}",
+            assurance,
+        )
         self.assertIn(
             "REPOSITORY_ASSURANCE_RESULT: ${{ needs.repository_assurance.result }}",
             assurance,
@@ -110,9 +171,14 @@ class PagesWorkflowTests(unittest.TestCase):
         self.assertIn(
             '[[ "$REPOSITORY_ASSURANCE_RESULT" != \'success\' ]]', assurance
         )
+        self.assertIn('[[ "$CI_IMPACT_SHADOW_RESULT" != \'success\' ]]', assurance)
         self.assertIn('[[ "$GATEWAY_IMAGE_RESULT" != \'success\' ]]', assurance)
         self.assertIn("exit 1", assurance)
 
+        self.assertLess(
+            CI_WORKFLOW.index("\n  ci_impact_shadow:\n"),
+            CI_WORKFLOW.index("\n  repository_assurance:\n"),
+        )
         self.assertLess(
             CI_WORKFLOW.index("\n  repository_assurance:\n"),
             CI_WORKFLOW.index("\n  gateway_image:\n"),
@@ -194,7 +260,7 @@ class PagesWorkflowTests(unittest.TestCase):
         independent = CI_WORKFLOW.split(
             "\n  gateway_independent_image:\n", 1
         )[1].split("\n  gateway_attestation_verification:\n", 1)[0]
-        self.assertIn("needs: repository_assurance", independent)
+        self.assertNotIn("needs: repository_assurance", independent)
         self.assertIn("timeout-minutes: 30", independent)
         self.assertIn("permissions:\n      contents: read", independent)
         self.assertNotIn("actions: read", independent)


### PR DESCRIPTION
## Outcome

Introduce the safe first optimisation slice for GIS AI GO verification without weakening any current gate.

## Changes

- run repository assurance, primary gateway-image assurance and protected-main independent image derivation as independent producers rather than serialising them behind repository assurance
- cancel only superseded runs for the same pull request; protected-main runs retain unique concurrency identities
- add a versioned, dependency-aware and fail-closed change-impact planner in report-only shadow mode
- upload the canonical shadow plan for measurement while preventing planner outputs from controlling job execution
- bind every input in the OKF source lock, including the three research-pack JSON inputs, to repository and gateway-image assurance
- retain the stable required assurance check and every existing producer, attestation and provenance gate

Unknown paths, unsafe changes, toolchain or workflow changes and every protected-main push select full assurance. No check is skipped in this pull request.

## Why

Recent QUAL-206-only changes repeatedly paid for a clean gateway image on both the pull request and protected main even though no gateway build input changed. The useful Claude observation took 18 seconds; the existing PR #77 repository gate took 4 minutes 44 seconds and its unrelated gateway image took 7 minutes 41 seconds on the critical path.

Parallel producers should save about 4 to 5 minutes of elapsed time per successful pull request and a similar amount on protected main. Shadow evidence will be retained before selective pull-request execution is promoted.

## Checks

- 43 focused planner and workflow contract tests, including locked-input rename and mapping-removal mutations
- contract validation: 84 schemas and 106 records
- link validation: 461 local links, 183 research hashes and 2 ledger snapshots
- secret and machine-path scan: 824 text files
- all 823 repository paths mapped with no unmatched path in the pre-rebase audit
- workflow YAML parse and clean diff check
- two independent P0–P2 reviews: no findings

The latest uploaded shadow plan is report-only, matches all eight pull-request paths, contains no unmatched path and selects full pull-request assurance because the change modifies CI policy itself. Its recorded map SHA-256 matches the reviewed file.

## Promotion boundary

Selective execution remains disabled. Promotion requires representative shadow plans, no false negatives against complete checks, full selection for unknown or ambiguous paths, and full exact-commit main and release assurance.

Before enforcement, planning must execute from the trusted pull-request base. The candidate head is comparison input only; a missing result, failure or disagreement selects full assurance. A policy change becomes eligible only after it has merged under full checks and passed exact-main verification, so it can never govern its own pull request.
