### PR TITLE
ci: harden impact routing shadow v2

### DIFF
--- a/.github/ci/verification-impact-map.v2.json
+++ b/.github/ci/verification-impact-map.v2.json
@@ -1,5 +1,5 @@
 {
-  "schema": "gis-ai-go.ci-impact-map.v1",
+  "schema": "gis-ai-go.ci-impact-map.v2",
   "mode": "shadow",
   "unknown_path_policy": "full",
   "push_main_policy": "full_exact_commit",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,16 @@ jobs:
     timeout-minutes: 5
     outputs:
       force_full: ${{ steps.plan.outputs.force_full }}
+      gateway_image_required: ${{ steps.plan.outputs.gateway_image_required || steps.fail_full.outputs.gateway_image_required }}
       plan_sha256: ${{ steps.plan.outputs.plan_sha256 }}
       selected_lanes: ${{ steps.plan.outputs.selected_lanes }}
     permissions:
       contents: read
     steps:
+      - name: Default gateway image routing to fail-full
+        id: fail_full
+        run: printf 'gateway_image_required=true\n' >> "$GITHUB_OUTPUT"
+
       - name: Check out impact-planning source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -44,20 +49,32 @@ jobs:
           python3 scripts/plan_ci_impact.py \
             --base "$base_sha" \
             --head "$GITHUB_SHA" \
+            --repository-root "$GITHUB_WORKSPACE" \
             --event "$impact_event" \
-            --map .github/ci/verification-impact-map.v1.json \
+            --map .github/ci/verification-impact-map.v2.json \
             --output artifacts/ci/impact-plan.json
           plan_sha256="$(sha256sum artifacts/ci/impact-plan.json | cut -d ' ' -f 1)"
           force_full="$(jq -r '.force_full' artifacts/ci/impact-plan.json)"
+          gateway_image_required="$(
+            jq -er '
+              if .gateway_image_required == true then "true"
+              elif .gateway_image_required == false then "false"
+              else error("gateway_image_required must be a boolean")
+              end
+            ' artifacts/ci/impact-plan.json
+          )"
           selected_lanes="$(jq -c '.selected_lanes' artifacts/ci/impact-plan.json)"
           printf 'plan_sha256=%s\n' "$plan_sha256" >> "$GITHUB_OUTPUT"
           printf 'force_full=%s\n' "$force_full" >> "$GITHUB_OUTPUT"
+          printf 'gateway_image_required=%s\n' "$gateway_image_required" >> "$GITHUB_OUTPUT"
           printf 'selected_lanes=%s\n' "$selected_lanes" >> "$GITHUB_OUTPUT"
           {
             printf '### CI impact plan (shadow)\n\n'
             printf 'All current assurance jobs still run; this plan cannot skip a check.\n\n'
             printf -- '- Plan SHA-256: `%s`\n' "$plan_sha256"
             printf -- '- Force full: `%s`\n' "$force_full"
+            printf -- '- Gateway image required (candidate-head shadow): `%s`\n' \
+              "$gateway_image_required"
             printf -- '- Selected lanes:\n'
             jq -r '.selected_lanes[] | "  - `" + . + "`"' \
               artifacts/ci/impact-plan.json

--- a/changelog.d/CI-IMPACT-V2.changed.md
+++ b/changelog.d/CI-IMPACT-V2.changed.md
@@ -1,0 +1,6 @@
+- Upgrade the fail-closed CI impact planner to a shadow-only v2 contract with an
+  explicit repository root, a canonical Boolean gateway-image decision and a
+  workflow output that defaults to full image assurance on missing or malformed
+  candidate result; bind routing coverage to every tracked repository path and every
+  tracked gateway build-context input while retaining full assurance for unknown,
+  empty, global and protected-main changes. Every existing assurance job still runs.

--- a/docs/implementation/CI_IMPACT_ROUTING.md
+++ b/docs/implementation/CI_IMPACT_ROUTING.md
@@ -24,7 +24,7 @@ coalesces protected-main runs.
 ## Shadow planner contract
 
 The versioned map at
-`.github/ci/verification-impact-map.v1.json` declares selectable lanes, their
+`.github/ci/verification-impact-map.v2.json` declares selectable lanes, their
 dependencies and repository-path rules. `scripts/plan_ci_impact.py` reads the exact
 event-base-to-head Git change inventory, filters recommendations to lanes that run
 for that pull-request or protected-main event, and emits canonical JSON. The output
@@ -34,7 +34,23 @@ records:
 - every changed path and matching rule;
 - dependency-expanded lane decisions;
 - unmatched paths; and
-- whether a full plan was selected.
+- whether a full plan was selected; and
+- the closed Boolean `gateway_image_required` decision.
+
+The Boolean remains a Boolean in the canonical plan. Only the workflow output
+boundary converts it to the exact string `true` or `false`. Before candidate-head
+planning starts, the workflow publishes `true` as its fail-full default. It replaces
+that default only after the candidate plan exists and `jq` has proved the field is
+exactly a JSON Boolean. A missing planner result, missing field or any other scalar
+therefore cannot become a skip recommendation.
+
+The planner accepts an explicit `--repository-root`. Its script bytes can therefore
+come from a separately checked-out policy source while the Git inventory, map and
+new output remain bounded to the named worktree. The root must be a real directory
+and the exact Git top level; nested directories and symbolic-link aliases fail
+closed. This interface is preparation for trusted-base evaluation. The current
+workflow still runs the planner and map from the candidate head, so its output is
+diagnostic only and does not control any job.
 
 The planner is fail closed. An invalid map, missing commit, malformed or unsafe
 path, unknown Git status, empty change set or unmatched path selects full assurance
@@ -96,6 +112,29 @@ to create the deterministic projection used by Explorer and the gateway image.
 Contract tests therefore require every path in `okf/source-lock.json` to select
 both repository and gateway-image assurance, including rename handling and a
 mutation test which removes a mapping entry.
+
+The v2 contract test evaluates every path tracked at its introduction: all 832 had
+an explicit rule, and each of the 235 tracked files admitted to the gateway build
+context required gateway-image assurance. The assertions retain those baseline
+lower bounds and automatically evaluate newly tracked paths, so an unmapped new path
+or an image-context omission fails before routing can be promoted.
+
+## Trusted agreement stage
+
+The next routing pull request may add a separately reviewed trusted-base/candidate
+agreement, but v2 does not claim that boundary is present. That later workflow must:
+
+1. obtain the planner and map from the pull request's trusted base commit without
+   executing candidate-controlled preparation;
+2. evaluate the same exact base-to-candidate inventory with both policies;
+3. accept `false` only when both closed outputs are exactly `false`;
+4. use `true` for missing, malformed, failed or disagreeing results; and
+5. keep workflow, planner, map and routing-test changes on full assurance under the
+   trusted base policy.
+
+Until that agreement is implemented and separately accepted, the workflow does not
+use `gateway_image_required` in a job condition. The stable aggregator still
+requires the planner, repository and gateway-image producers to succeed.
 
 ## Expected time effect
 

--- a/scripts/plan_ci_impact.py
+++ b/scripts/plan_ci_impact.py
@@ -16,9 +16,10 @@ from typing import Any, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_MAP = Path(".github/ci/verification-impact-map.v1.json")
-MAP_SCHEMA = "gis-ai-go.ci-impact-map.v1"
-PLAN_SCHEMA = "gis-ai-go.ci-impact-plan.v1"
+DEFAULT_MAP = Path(".github/ci/verification-impact-map.v2.json")
+MAP_SCHEMA = "gis-ai-go.ci-impact-map.v2"
+PLAN_SCHEMA = "gis-ai-go.ci-impact-plan.v2"
+GATEWAY_IMAGE_LANE = "gateway_image"
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
 LANE_ID = re.compile(r"^[a-z][a-z0-9_-]*$")
 RULE_ID = re.compile(r"^[a-z][a-z0-9-]*$")
@@ -221,7 +222,7 @@ def load_impact_map(path: Path) -> ImpactMap:
     if root["schema"] != MAP_SCHEMA:
         raise ImpactPlanError(f"unsupported impact map schema: {root['schema']!r}")
     if root["mode"] != "shadow":
-        raise ImpactPlanError("the first impact-map version must remain in shadow mode")
+        raise ImpactPlanError("the impact map must remain in shadow mode until separately promoted")
     if root["unknown_path_policy"] != "full":
         raise ImpactPlanError("unknown paths must select full assurance")
     if root["push_main_policy"] != "full_exact_commit":
@@ -268,6 +269,15 @@ def load_impact_map(path: Path) -> ImpactMap:
     if len(lane_ids) != len(set(lane_ids)):
         raise ImpactPlanError("lane identifiers must be unique")
     _validate_dependency_graph(lane_tuple)
+    gateway_image_lane = next(
+        (lane for lane in lane_tuple if lane.lane_id == GATEWAY_IMAGE_LANE), None
+    )
+    if gateway_image_lane is None:
+        raise ImpactPlanError("the gateway_image lane is required")
+    if set(gateway_image_lane.events) != ALLOWED_EVENTS:
+        raise ImpactPlanError(
+            "the gateway_image lane must be available for pull requests and protected main"
+        )
 
     full_lanes = _string_list(root["full_lanes"], "full_lanes", maximum=32)
     if full_lanes != lane_ids:
@@ -406,6 +416,7 @@ def plan_for_paths(
     lane_decisions = {
         lane.lane_id: lane.lane_id in selected_lanes for lane in impact_map.lanes
     }
+    gateway_image_required = GATEWAY_IMAGE_LANE in selected_lanes
     return {
         "schema": PLAN_SCHEMA,
         "mode": "shadow",
@@ -426,6 +437,7 @@ def plan_for_paths(
         "applicable_lanes": list(applicable_lanes),
         "selected_lanes": list(selected_lanes),
         "lane_decisions": lane_decisions,
+        "gateway_image_required": gateway_image_required,
     }
 
 
@@ -518,6 +530,29 @@ def _repository_file(root: Path, relative: Path, label: str) -> Path:
     return target
 
 
+def resolve_repository_root(path: Path) -> Path:
+    """Resolve one explicit, real Git worktree root for planning."""
+
+    logical = Path(os.path.abspath(path))
+    try:
+        metadata = logical.lstat()
+    except FileNotFoundError as error:
+        raise ImpactPlanError("repository root is missing") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ImpactPlanError("repository root must be a real directory, not a link")
+    root = logical.resolve()
+    if root != logical:
+        raise ImpactPlanError("repository root must not use a symbolic-link alias")
+    try:
+        raw_top_level = _run_git(root, ("rev-parse", "--show-toplevel"))
+        top_level = Path(raw_top_level.decode("utf-8").strip()).resolve()
+    except (UnicodeDecodeError, OSError) as error:
+        raise ImpactPlanError("repository root could not be resolved as UTF-8") from error
+    if top_level != root:
+        raise ImpactPlanError("repository root must be the exact Git worktree root")
+    return root
+
+
 def write_new_output(root: Path, relative: Path, payload: bytes) -> Path:
     target = _repository_file(root, relative, "output path")
     relative_parent = target.parent.relative_to(root)
@@ -551,6 +586,12 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--base", required=True, help="full event base commit")
     parser.add_argument("--head", required=True, help="full checked-out head commit")
     parser.add_argument(
+        "--repository-root",
+        type=Path,
+        default=ROOT,
+        help="explicit Git worktree root whose base-to-head change is planned",
+    )
+    parser.add_argument(
         "--event",
         required=True,
         choices=sorted(ALLOWED_EVENTS),
@@ -571,9 +612,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     arguments = parser.parse_args(argv)
 
     try:
-        map_path = _repository_file(ROOT, arguments.map, "impact map path")
+        repository_root = resolve_repository_root(arguments.repository_root)
+        map_path = _repository_file(repository_root, arguments.map, "impact map path")
         impact_map = load_impact_map(map_path)
-        paths = changed_paths_between(ROOT, arguments.base, arguments.head)
+        paths = changed_paths_between(repository_root, arguments.base, arguments.head)
         plan = plan_for_paths(
             impact_map,
             paths,
@@ -582,7 +624,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             event=arguments.event,
         )
         payload = canonical_json_bytes(plan)
-        write_new_output(ROOT, arguments.output, payload)
+        write_new_output(repository_root, arguments.output, payload)
     except (ImpactPlanError, OSError) as error:
         raise SystemExit(f"CI impact planning failed closed: {error}") from error
     print(payload.decode("utf-8"), end="")

--- a/tests/contract/test_ci_impact_plan.py
+++ b/tests/contract/test_ci_impact_plan.py
@@ -19,11 +19,14 @@ from plan_ci_impact import (  # noqa: E402
     changed_paths_between,
     load_impact_map,
     plan_for_paths,
+    resolve_repository_root,
     write_new_output,
 )
+from gateway_image import CONTEXT_FILES, CONTEXT_ROOTS  # noqa: E402
 
 
-MAP_PATH = ROOT / ".github" / "ci" / "verification-impact-map.v1.json"
+MAP_RELATIVE_PATH = Path(".github/ci/verification-impact-map.v2.json")
+MAP_PATH = ROOT / MAP_RELATIVE_PATH
 SOURCE_LOCK_PATH = ROOT / "okf" / "source-lock.json"
 BASE = "1" * 40
 HEAD = "2" * 40
@@ -36,6 +39,19 @@ RESEARCH_OKF_INPUTS = (
 LOCKED_OKF_INPUTS = tuple(
     item["path"]
     for item in json.loads(SOURCE_LOCK_PATH.read_text(encoding="utf-8"))["inputs"]
+)
+TRACKED_PATHS = tuple(
+    path.decode("utf-8")
+    for path in subprocess.check_output(
+        ("git", "ls-files", "--cached", "-z"), cwd=ROOT
+    ).split(b"\0")
+    if path
+)
+GATEWAY_CONTEXT_PATHS = tuple(
+    path
+    for path in TRACKED_PATHS
+    if path in CONTEXT_FILES
+    or any(path == root or path.startswith(f"{root}/") for root in CONTEXT_ROOTS)
 )
 
 
@@ -67,9 +83,70 @@ class CiImpactPlanTests(unittest.TestCase):
                 f"locked OKF input {path!r} did not select repository and image assurance",
             )
 
+    def test_plan_v2_is_closed_and_uses_a_boolean_gateway_scalar(self) -> None:
+        plan = self.plan("docs/implementation/ROADMAP.md")
+        self.assertEqual(
+            set(plan),
+            {
+                "always_run",
+                "applicable_lanes",
+                "base_commit",
+                "changed_path_count",
+                "changed_paths",
+                "enforced",
+                "event",
+                "force_full",
+                "force_full_rule_ids",
+                "gateway_image_required",
+                "head_commit",
+                "lane_decisions",
+                "map_sha256",
+                "matched_rule_ids",
+                "matches",
+                "mode",
+                "reason",
+                "schema",
+                "selected_lanes",
+                "unmatched_paths",
+            },
+        )
+        self.assertEqual(plan["schema"], "gis-ai-go.ci-impact-plan.v2")
+        self.assertEqual(plan["mode"], "shadow")
+        self.assertIs(plan["enforced"], False)
+        self.assertIs(type(plan["gateway_image_required"]), bool)
+        self.assertIs(plan["gateway_image_required"], False)
+        self.assertEqual(
+            plan["lane_decisions"],
+            {
+                "gateway-provenance": False,
+                "gateway_attestation_verification": False,
+                "gateway_image": False,
+                "gateway_independent_image": False,
+                "provenance": False,
+                "repository_assurance": True,
+            },
+        )
+        self.assertIn(b'"gateway_image_required":false', canonical_json_bytes(plan))
+
+    def test_every_current_tracked_path_has_an_explicit_fail_closed_route(self) -> None:
+        self.assertGreaterEqual(len(TRACKED_PATHS), 832)
+        for path in TRACKED_PATHS:
+            with self.subTest(path=path):
+                self.assertEqual(self.plan(path)["unmatched_paths"], [])
+
+    def test_every_current_gateway_context_path_requires_image_assurance(self) -> None:
+        self.assertGreaterEqual(len(GATEWAY_CONTEXT_PATHS), 235)
+        omitted: list[str] = []
+        for path in GATEWAY_CONTEXT_PATHS:
+            plan = self.plan(path)
+            if plan["gateway_image_required"] is not True:
+                omitted.append(path)
+        self.assertEqual(omitted, [])
+
     def test_qual_harness_change_selects_repository_assurance_only(self) -> None:
         plan = self.plan("scripts/qual_206_claude_capability_harness.mjs")
         self.assertFalse(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], False)
         self.assertEqual(plan["reason"], "matched-rules")
         self.assertEqual(plan["selected_lanes"], ["repository_assurance"])
         self.assertEqual(
@@ -80,6 +157,7 @@ class CiImpactPlanTests(unittest.TestCase):
     def test_qual_schema_also_selects_the_gateway_derivation_chain(self) -> None:
         plan = self.plan("schemas/qual-206-claude-capability-evidence-v1.schema.json")
         self.assertFalse(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], True)
         self.assertEqual(
             plan["selected_lanes"],
             [
@@ -92,6 +170,7 @@ class CiImpactPlanTests(unittest.TestCase):
     def test_documentation_change_selects_repository_assurance_only(self) -> None:
         plan = self.plan("docs/implementation/ROADMAP.md")
         self.assertFalse(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], False)
         self.assertEqual(plan["selected_lanes"], ["repository_assurance"])
         self.assertEqual(plan["matched_rule_ids"], ["documentation-and-governance"])
 
@@ -154,6 +233,7 @@ class CiImpactPlanTests(unittest.TestCase):
     def test_global_workflow_change_selects_every_lane(self) -> None:
         plan = self.plan(".github/workflows/ci.yml")
         self.assertTrue(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], True)
         self.assertEqual(plan["reason"], "force-full-rule")
         self.assertEqual(
             plan["selected_lanes"], ["gateway_image", "repository_assurance"]
@@ -163,6 +243,7 @@ class CiImpactPlanTests(unittest.TestCase):
     def test_unknown_path_fails_closed_to_every_lane(self) -> None:
         plan = self.plan("future-component/source/new-runtime.ts")
         self.assertTrue(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], True)
         self.assertEqual(plan["reason"], "unmatched-path")
         self.assertEqual(plan["unmatched_paths"], ["future-component/source/new-runtime.ts"])
         self.assertEqual(
@@ -172,6 +253,7 @@ class CiImpactPlanTests(unittest.TestCase):
     def test_empty_change_set_fails_closed_to_every_lane(self) -> None:
         plan = self.plan()
         self.assertTrue(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], True)
         self.assertEqual(plan["reason"], "empty-change-set")
         self.assertEqual(
             plan["selected_lanes"], ["gateway_image", "repository_assurance"]
@@ -212,6 +294,7 @@ class CiImpactPlanTests(unittest.TestCase):
         )
         self.assertEqual(plan["reason"], "protected-main-exact-commit")
         self.assertTrue(plan["force_full"])
+        self.assertIs(plan["gateway_image_required"], True)
 
     def test_push_main_documentation_plan_retains_full_exact_commit_evidence(self) -> None:
         plan = plan_for_paths(
@@ -237,6 +320,20 @@ class CiImpactPlanTests(unittest.TestCase):
             path = Path(directory) / "map.json"
             path.write_text(json.dumps(document), encoding="utf-8")
             with self.assertRaisesRegex(ImpactPlanError, "must select full assurance"):
+                load_impact_map(path)
+
+    def test_map_requires_gateway_image_for_both_planning_events(self) -> None:
+        document = json.loads(MAP_PATH.read_text(encoding="utf-8"))
+        lane = next(
+            item for item in document["lanes"] if item["id"] == "gateway_image"
+        )
+        lane["events"] = ["push_main"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "map.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(
+                ImpactPlanError, "must be available for pull requests"
+            ):
                 load_impact_map(path)
 
     def test_map_rejects_duplicate_keys_and_non_standard_constants(self) -> None:
@@ -351,6 +448,86 @@ class CiImpactPlanTests(unittest.TestCase):
                 event="pull_request",
             )
             self.assertTrue(REQUIRED_OKF_PR_LANES.issubset(set(plan["selected_lanes"])))
+
+    def test_cli_plans_an_explicit_repository_root_independent_of_script_location(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            subprocess.run(("git", "init", "-q"), cwd=root, check=True)
+            subprocess.run(
+                ("git", "config", "user.email", "ci-impact@example.invalid"),
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ("git", "config", "user.name", "CI impact test"),
+                cwd=root,
+                check=True,
+            )
+            map_path = root / MAP_RELATIVE_PATH
+            map_path.parent.mkdir(parents=True)
+            map_path.write_bytes(MAP_PATH.read_bytes())
+            document = root / "docs" / "example.md"
+            document.parent.mkdir()
+            document.write_text("first\n", encoding="utf-8")
+            subprocess.run(("git", "add", "."), cwd=root, check=True)
+            subprocess.run(("git", "commit", "-qm", "base"), cwd=root, check=True)
+            base = subprocess.check_output(("git", "rev-parse", "HEAD"), cwd=root).decode(
+                "ascii"
+            ).strip()
+            document.write_text("second\n", encoding="utf-8")
+            subprocess.run(("git", "add", "docs/example.md"), cwd=root, check=True)
+            subprocess.run(("git", "commit", "-qm", "head"), cwd=root, check=True)
+            head = subprocess.check_output(("git", "rev-parse", "HEAD"), cwd=root).decode(
+                "ascii"
+            ).strip()
+
+            result = subprocess.run(
+                (
+                    sys.executable,
+                    str(SCRIPTS / "plan_ci_impact.py"),
+                    "--base",
+                    base,
+                    "--head",
+                    head,
+                    "--repository-root",
+                    str(root),
+                    "--event",
+                    "pull_request",
+                    "--map",
+                    MAP_RELATIVE_PATH.as_posix(),
+                    "--output",
+                    "artifacts/ci/impact-plan.json",
+                ),
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+            )
+            plan = json.loads(result.stdout)
+            self.assertEqual(plan["changed_paths"], ["docs/example.md"])
+            self.assertIs(plan["gateway_image_required"], False)
+            self.assertEqual(
+                (root / "artifacts/ci/impact-plan.json").read_bytes(),
+                canonical_json_bytes(plan),
+            )
+
+    def test_repository_root_rejects_nested_and_linked_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            subprocess.run(("git", "init", "-q"), cwd=root, check=True)
+            nested = root / "nested"
+            nested.mkdir()
+            self.assertEqual(resolve_repository_root(root), root)
+            with self.assertRaisesRegex(ImpactPlanError, "exact Git worktree root"):
+                resolve_repository_root(nested)
+            linked = root.parent / f"{root.name}-linked"
+            linked.symlink_to(root, target_is_directory=True)
+            try:
+                with self.assertRaisesRegex(ImpactPlanError, "real directory"):
+                    resolve_repository_root(linked)
+            finally:
+                linked.unlink()
 
     def test_output_is_new_and_repository_relative(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/contract/test_pages_workflows.py
+++ b/tests/contract/test_pages_workflows.py
@@ -93,7 +93,7 @@ class PagesWorkflowTests(unittest.TestCase):
 
     def test_ci_impact_map_job_identifiers_cannot_drift_from_the_workflow(self) -> None:
         impact_map = json.loads(
-            (ROOT / ".github/ci/verification-impact-map.v1.json").read_text(
+            (ROOT / ".github/ci/verification-impact-map.v2.json").read_text(
                 encoding="utf-8"
             )
         )
@@ -135,11 +135,12 @@ class PagesWorkflowTests(unittest.TestCase):
         self.assertIn("name: CI impact plan (shadow)", impact)
         self.assertIn("fetch-depth: 0", impact)
         self.assertIn("scripts/plan_ci_impact.py", impact)
+        self.assertIn('--repository-root "$GITHUB_WORKSPACE"', impact)
         self.assertIn("impact_event='pull_request'", impact)
         self.assertIn("impact_event='push_main'", impact)
         self.assertIn('--event "$impact_event"', impact)
         impact_map = (
-            ROOT / ".github/ci/verification-impact-map.v1.json"
+            ROOT / ".github/ci/verification-impact-map.v2.json"
         ).read_text(encoding="utf-8")
         self.assertIn('"mode": "shadow"', impact_map)
         self.assertIn("All current assurance jobs still run", impact)
@@ -187,6 +188,41 @@ class PagesWorkflowTests(unittest.TestCase):
             CI_WORKFLOW.index("\n  gateway_image:\n"),
             CI_WORKFLOW.index("\n  assurance:\n"),
         )
+
+    def test_ci_gateway_image_scalar_is_closed_fail_full_shadow_output(self) -> None:
+        impact = CI_WORKFLOW.split("\n  ci_impact_shadow:\n", 1)[1].split(
+            "\n  repository_assurance:\n", 1
+        )[0]
+        default_name = "- name: Default gateway image routing to fail-full"
+        checkout_name = "- name: Check out impact-planning source"
+        plan_name = "- name: Produce fail-closed shadow impact plan"
+        self.assertLess(impact.index(default_name), impact.index(checkout_name))
+        self.assertLess(impact.index(default_name), impact.index(plan_name))
+        self.assertIn("id: fail_full", impact)
+        self.assertIn(
+            "run: printf 'gateway_image_required=true\\n' >> \"$GITHUB_OUTPUT\"",
+            impact,
+        )
+        self.assertIn(
+            "gateway_image_required: "
+            "${{ steps.plan.outputs.gateway_image_required || "
+            "steps.fail_full.outputs.gateway_image_required }}",
+            impact,
+        )
+        self.assertIn("if .gateway_image_required == true then \"true\"", impact)
+        self.assertIn("elif .gateway_image_required == false then \"false\"", impact)
+        self.assertIn(
+            'else error("gateway_image_required must be a boolean")', impact
+        )
+        self.assertIn("printf 'gateway_image_required=%s\\n'", impact)
+        self.assertNotRegex(
+            CI_WORKFLOW,
+            r"(?m)^\s*if:.*needs\.ci_impact_shadow\.outputs\.gateway_image_required",
+        )
+        assurance = CI_WORKFLOW.split("\n  assurance:\n", 1)[1].split(
+            "\n  provenance:\n", 1
+        )[0]
+        self.assertNotIn("gateway_image_required", assurance)
 
     def test_ci_gateway_uploads_only_complete_successful_evidence(self) -> None:
         gateway = CI_WORKFLOW.split("\n  gateway_image:\n", 1)[1].split(


### PR DESCRIPTION
## Summary

- replace the first impact map with a closed v2 shadow contract
- add an explicit, validated repository root and canonical `gateway_image_required` decision
- default the workflow boundary to fail-full before candidate-head planning
- add repository-wide tracked-path and exact gateway build-context coverage

## Safety boundary

This PR does not skip a job and does not change the stable `assurance` aggregator. The candidate-head decision is diagnostic only. Protected `main`, unknown paths, empty changes and control/toolchain changes continue to select full exact-commit assurance.

Moving to selective PR execution remains a separate change. It requires trusted-base and candidate-plan agreement, with missing, malformed, failed or disagreeing plans defaulting to full assurance, plus representative native shadow evidence.

## Verification

- 50 focused planner and workflow contract tests
- all 833 tracked paths mapped
- all 235 tracked gateway build-context paths require image assurance
- contracts: 84 schemas and 106 records
- links: 462 links, 183 research hashes and 2 ledgers
- versions, secrets, YAML parsing, Python compilation and diff checks
- independent exact-commit review: no P0–P2 findings

The branch plan for this PR is `force_full=true`, `gateway_image_required=true`, with no unmatched paths.
