### PR TITLE
fix(qual-206): allow eighth exact-five turn

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -48,10 +48,13 @@ The supported target active set is exactly `catalogue.search`,
   fake one-session and accepted two-session shapes pass. Two bounded protected-main
   observations on 27 August 2026 stopped after four valid calls, before
   `evidence.inspect`, and falsely reused the search receipt in their final output;
-  the verifier rejected both and wrote no public projection. Correct the model's
-  premature-completion instruction, allow the fifth call with a seven-turn ceiling,
-  require an `end_turn` terminal state, and re-observe only after those changes pass
-  protected `main`;
+  the verifier rejected both and wrote no public projection. A third bounded run
+  from exact protected-main commit `d2f3e72858272dbfe3f79a83d290d622977c65e6`
+  reached reported turn 7 in `tool_use` state after the same first four calls, so
+  the fifth request was not dispatched and the verifier again wrote no projection.
+  Retain the explicit fifth-call instruction and `end_turn` requirement, increase
+  the agentic ceiling to eight with a corresponding maximum of nine reported turns,
+  and re-observe only after that evidence-supported change passes protected `main`;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;

--- a/changelog.d/QUAL-206-claude-eight-turn-boundary.fixed.md
+++ b/changelog.d/QUAL-206-claude-eight-turn-boundary.fixed.md
@@ -1,0 +1,4 @@
+- Increase the bounded Claude exact-five profile from seven to eight agentic turns
+  after an owner-only protected-main observation reached reported turn 7 in
+  `tool_use` state before dispatching `evidence.inspect`. Retain the exact-five,
+  distinct-receipt, `end_turn`, private-capture and fail-closed publication gates.

--- a/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
@@ -5,12 +5,15 @@
 This additive pack prepares a bounded Claude Code `2.1.245` observation of the
 complete deterministic exact-five journey over local MCP `2026-07-28` STDIO. It
 now includes closed private-run, per-session and minimised public-evidence schemas,
-plus an offline verifier and adversarial regression coverage. Two bounded
+plus an offline verifier and adversarial regression coverage. Three bounded
 protected-main observations on 27 August 2026 completed the first four operations
-but produced the final structured answer before calling `evidence.inspect`. Both
-private runs were rejected because Claude reused the inspected search receipt as
-if it were the inspection call's own receipt. No public projection was written and
-there is no accepted public exact-five capability evidence yet.
+but did not complete `evidence.inspect`. The first two produced the final structured
+answer early. The third used the seven-agentic-turn ceiling at exact commit
+`d2f3e72858272dbfe3f79a83d290d622977c65e6`; Claude reported turn 7 with a
+`tool_use` terminal state before the fifth request was dispatched. All three private
+runs were rejected because their final output reused the inspected search receipt
+as if it were the inspection call's own receipt. No public projection was written
+and there is no accepted public exact-five capability evidence yet.
 
 The existing QUAL-206-HOST-002 schemas, verifier and evidence remain unchanged.
 That accepted one-tool observation continues to prove only `catalogue.search`.
@@ -57,21 +60,23 @@ The separate launcher:
   closure before execution;
 - retains the existing MCP-subtree Seatbelt network denial and credential
   removal;
-- permits at most seven agentic turns; and
+- permits at most eight agentic turns; and
 - rejects missing, duplicated, reordered or altered calls, including inspection
   of any receipt other than the search receipt.
 
-The CLI's `--max-turns 7` ceiling allows the fifth call after the observed
-four-call cut-off. Anthropic [defines that ceiling](https://code.claude.com/docs/en/agent-sdk/agent-loop)
-as a maximum number of tool-use round trips, while `num_turns` reports the total
-actually taken and includes a final no-tool turn. The verifier therefore accepts
-between three and eight reported turns rather than treating the ceiling as a
-target. The lower bound follows from the search-to-inspection dependency plus the
-final no-tool turn. It also requires an `end_turn` terminal state, so a
-success-shaped `tool_use` result cannot be accepted. It accepts only one closed
-call session and the observed bounded negotiation variants. This includes the
-accepted two-session shape in which the first session performs `server/discover`
-and the second performs `tools/list` then the five ordered calls.
+The exact protected-main observation above establishes that `--max-turns 7` can
+stop in `tool_use` state before the fifth request is dispatched. The `--max-turns 8`
+ceiling reserves one additional bounded tool-use round trip. Anthropic
+[defines that ceiling](https://code.claude.com/docs/en/agent-sdk/agent-loop) as a
+maximum number of tool-use round trips, while `num_turns` reports the total actually
+taken and includes a final no-tool turn. The verifier therefore accepts between
+three and nine reported turns rather than treating the ceiling as a target. The
+lower bound follows from the search-to-inspection dependency plus the final no-tool
+turn. It still requires an `end_turn` terminal state, so a success-shaped
+`tool_use` result cannot be accepted. It accepts only one closed call session and
+the observed bounded negotiation variants. This includes the accepted two-session
+shape in which the first session performs `server/discover` and the second performs
+`tools/list` then the five ordered calls.
 
 Each exact-five observer session retains one canonical, owner-only and size-bounded
 result file locally. The offline Node verifier rechecks the discovery and listing

--- a/schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json
+++ b/schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json
@@ -182,11 +182,11 @@
         "input_tokens": {"type": "integer", "minimum": 1, "maximum": 10000000},
         "output_tokens": {"type": "integer", "minimum": 1, "maximum": 1000000},
         "claude_cli_reported_turns": {
-          "type": "integer", "minimum": 3, "maximum": 8
+          "type": "integer", "minimum": 3, "maximum": 9
         },
-        "agentic_turn_limit": {"const": 7},
+        "agentic_turn_limit": {"const": 8},
         "turn_count_semantics": {
-          "const": "claude-cli-reported-total-turns-at-most-seven-tool-use-round-trips-plus-one-final-turn"
+          "const": "claude-cli-reported-total-turns-at-most-eight-tool-use-round-trips-plus-one-final-turn"
         },
         "client_exit_code": {"const": 0}
       }
@@ -214,7 +214,7 @@
         },
         "permission_mode": {"const": "dontAsk"},
         "session_persistence": {"const": false},
-        "maximum_agentic_turns": {"const": 7},
+        "maximum_agentic_turns": {"const": 8},
         "mcp_subtree_network_access_allowed": {"const": false},
         "mcp_subtree_network_sandbox": {"const": "macos-seatbelt-deny-network"},
         "mcp_child_recognised_credentials_forwarded": {"const": false},

--- a/schemas/qual-206-claude-exact-five-capability-private-run-v1.schema.json
+++ b/schemas/qual-206-claude-exact-five-capability-private-run-v1.schema.json
@@ -187,7 +187,7 @@
         },
         "permission_mode": {"const": "dontAsk"},
         "session_persistence": {"const": false},
-        "maximum_turns": {"const": 7},
+        "maximum_turns": {"const": 8},
         "effort": {"const": "low"},
         "process_group_absent": {"type": "boolean"},
         "spawned_process_executable_attested": {"type": "boolean"}

--- a/scripts/qual_206_claude_capability_harness.mjs
+++ b/scripts/qual_206_claude_capability_harness.mjs
@@ -266,7 +266,7 @@ export const CLAUDE_EXACT_FIVE_CAPABILITY_PROFILE = Object.freeze({
   caseId: "QUAL-206-CLAUDE-EXACT-FIVE-V1",
   clientLabel: "claude-code-2.1.245-exact-five-v1",
   manifestSchema: "gis-ai-go.qual-206-claude-exact-five-capability-private-run.v1",
-  maximumTurns: 7,
+  maximumTurns: 8,
   outputSchema: EXACT_FIVE_OUTPUT_SCHEMA,
   permissionAliases: Object.freeze(Object.values(buildClaudePermissionAliasMap(
     "gis-ai-go-qual-206-exact-five-v1",

--- a/scripts/verify_qual_206_claude_exact_five_capability.py
+++ b/scripts/verify_qual_206_claude_exact_five_capability.py
@@ -47,11 +47,11 @@ PROFILE_ID = "exact-five-v1"
 CASE_ID = "QUAL-206-CLAUDE-EXACT-FIVE-V1"
 SERVER_NAME = "gis-ai-go-qual-206-exact-five-v1"
 PROTOCOL = "2026-07-28"
-MAXIMUM_AGENTIC_TURNS = 7
+MAXIMUM_AGENTIC_TURNS = 8
 MINIMUM_CLAUDE_REPORTED_TURNS = 3
 MAXIMUM_CLAUDE_REPORTED_TURNS = MAXIMUM_AGENTIC_TURNS + 1
 TURN_COUNT_SEMANTICS = (
-    "claude-cli-reported-total-turns-at-most-seven-tool-use-round-trips-plus-one-final-turn"
+    "claude-cli-reported-total-turns-at-most-eight-tool-use-round-trips-plus-one-final-turn"
 )
 OPERATIONS = (
     "catalogue.search",

--- a/tests/contract/test_qual_206_claude_exact_five_capability.py
+++ b/tests/contract/test_qual_206_claude_exact_five_capability.py
@@ -341,8 +341,8 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             self.assertEqual(
                 projection["transport"]["guarded_provider_api_invocations"], 0
             )
-            self.assertEqual(projection["result"]["claude_cli_reported_turns"], 7)
-            self.assertEqual(projection["result"]["agentic_turn_limit"], 7)
+            self.assertEqual(projection["result"]["claude_cli_reported_turns"], 9)
+            self.assertEqual(projection["result"]["agentic_turn_limit"], 8)
             receipts = [
                 item["receipt_id"] for item in projection["result"]["operation_receipts"]
             ]
@@ -461,7 +461,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             remote["claims"]["remote_http_interoperability"] = True
             mutations.append(("remote HTTP inflation", remote))
             turns = copy.deepcopy(projection)
-            turns["result"]["claude_cli_reported_turns"] = 9
+            turns["result"]["claude_cli_reported_turns"] = 10
             mutations.append(("reported turn bound inflation", turns))
             too_few_turns = copy.deepcopy(projection)
             too_few_turns["result"]["claude_cli_reported_turns"] = 2
@@ -541,7 +541,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             original_manifest = manifest_path.read_bytes()
             try:
                 output = json.loads(original_output)
-                output["num_turns"] = 9
+                output["num_turns"] = 10
                 output_path.write_bytes(
                     json.dumps(output, separators=(",", ":")).encode()
                 )
@@ -631,7 +631,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             self.assertEqual(output["subtype"], "success")
             self.assertIs(output["is_error"], False)
             self.assertEqual(output["stop_reason"], "tool_use")
-            self.assertEqual(output["num_turns"], 6)
+            self.assertEqual(output["num_turns"], 7)
             self.assertEqual(output["structured_output"]["operation_order"], OPERATIONS)
             summary = json.loads(
                 (

--- a/tests/interoperability/fixtures/qual_206_fake_claude_exact_five_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_exact_five_client.mjs
@@ -177,7 +177,7 @@ async function main() {
   if (
     optionValue(argumentsValue, "--output-format") !== "json" ||
     optionValue(argumentsValue, "--permission-mode") !== "dontAsk" ||
-    optionValue(argumentsValue, "--max-turns") !== "7" ||
+    optionValue(argumentsValue, "--max-turns") !== "8" ||
     optionValue(argumentsValue, "--tools") !== "" ||
     JSON.stringify(optionValues(
       argumentsValue,
@@ -270,7 +270,7 @@ async function main() {
     subtype: "success",
     is_error: false,
     permission_denials: [],
-    num_turns: SCENARIO === "premature-tool-use" ? 6 : 7,
+    num_turns: SCENARIO === "premature-tool-use" ? 7 : 9,
     duration_ms: 800,
     duration_api_ms: 700,
     result: "The exact-five-v1 result is available in structured_output.",

--- a/tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs
@@ -198,7 +198,7 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
     "gis-ai-go.qual-206-claude-exact-five-capability-private-run.v1");
   assert.equal(manifest.profile, "exact-five-v1");
   assert.equal(manifest.execution.built_in_tools_available, false);
-  assert.equal(manifest.execution.maximum_turns, 7);
+  assert.equal(manifest.execution.maximum_turns, 8);
   assert.equal(manifest.isolation.mcp_subtree_network_access_allowed, false);
   assert.deepEqual(readdirSync(join(root, "observer")).sort(), [
     "exact-five-v1.claim.json",
@@ -222,7 +222,7 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
     summary.inspection_relationship.search_receipt_id,
   );
   const output = JSON.parse(readFileSync(join(root, "stdout.json"), "utf8"));
-  assert.equal(output.num_turns, 7);
+  assert.equal(output.num_turns, 9);
   assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
   assert.deepEqual(
     output.structured_output.receipt_ids,
@@ -250,7 +250,7 @@ macRuntimeTest(
     assert.equal(output.subtype, "success");
     assert.equal(output.is_error, false);
     assert.equal(output.stop_reason, "tool_use");
-    assert.equal(output.num_turns, 6);
+    assert.equal(output.num_turns, 7);
     assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
     assert.deepEqual(readdirSync(join(root, "observer")).sort(), [
       "exact-five-v1.claim.json",


### PR DESCRIPTION
## Summary

- raise the closed Claude `exact-five-v1` ceiling from seven to eight agentic turns;
- permit a final Claude-reported count of up to nine turns while still requiring
  `end_turn` and exactly five ordered MCP calls; and
- bind the observed turn-7 premature termination in the fake-client regression,
  schemas, runbook, progress record and changelog.

## Evidence basis

One owner-only observation from exact protected-main commit
`d2f3e72858272dbfe3f79a83d290d622977c65e6` reached reported turn 7 with a
`tool_use` terminal state after only the first four calls were dispatched. The
independent verifier rejected it and wrote no public projection. This PR reserves
one further bounded tool-use round trip; it contains no live observation evidence.

The exact-five order, distinct operation receipts, search-to-inspection relation,
`end_turn`, zero provider egress, private capture and fail-closed publication gates
remain unchanged.

## Verification

- 25/25 shared and exact-five Node harness tests pass with the required macOS
  process and loopback boundary;
- 11/11 shared and exact-five Python contract tests pass;
- TypeScript type checking passes across all maintained workspaces;
- 87 schemas and 106 records validate;
- 462 local links, 183 research hashes and 2 ledger snapshots validate;
- the secret and machine-path scan passes across 840 text files;
- version and Git diff checks pass.

No live provider, public endpoint, registry publication, activation, deployment,
tag or release is introduced.

Refs #24.
