### PR TITLE
fix(qual-206): allow ten-turn exact-five completion

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -52,9 +52,14 @@ The supported target active set is exactly `catalogue.search`,
   from exact protected-main commit `d2f3e72858272dbfe3f79a83d290d622977c65e6`
   reached reported turn 7 in `tool_use` state after the same first four calls, so
   the fifth request was not dispatched and the verifier again wrote no projection.
-  Retain the explicit fifth-call instruction and `end_turn` requirement, increase
-  the agentic ceiling to eight with a corresponding maximum of nine reported turns,
-  and re-observe only after that evidence-supported change passes protected `main`;
+  A fourth bounded run from exact protected-main commit
+  `b9e777a9ed3744dd7291c0cd69347dd07aab2672` reached reported turn 8 in
+  `tool_use` state after the same four calls. Its final output supplied a distinct
+  fifth receipt-shaped value without a corresponding request or response, so
+  independent verification rejected it and wrote no projection. Retain the exact
+  five-call and `end_turn` gates, increase the bounded agentic ceiling to ten with
+  a corresponding maximum of 11 reported turns, and re-observe only after that
+  evidence-supported change passes protected `main`;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;

--- a/changelog.d/QUAL-206-claude-ten-turn-boundary.fixed.md
+++ b/changelog.d/QUAL-206-claude-ten-turn-boundary.fixed.md
@@ -1,0 +1,5 @@
+- Increase the bounded Claude exact-five profile from eight to ten agentic turns
+  after an owner-only protected-main observation again stopped after four calls,
+  at reported turn 8 in `tool_use` state. Preserve both observed turn-boundary
+  regressions, the exact five-call closure, final `end_turn` gate, distinct receipt
+  verification, MCP-subtree network denial and fail-closed publication boundary.

--- a/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
@@ -5,15 +5,20 @@
 This additive pack prepares a bounded Claude Code `2.1.245` observation of the
 complete deterministic exact-five journey over local MCP `2026-07-28` STDIO. It
 now includes closed private-run, per-session and minimised public-evidence schemas,
-plus an offline verifier and adversarial regression coverage. Three bounded
+plus an offline verifier and adversarial regression coverage. Four bounded
 protected-main observations on 27 August 2026 completed the first four operations
 but did not complete `evidence.inspect`. The first two produced the final structured
 answer early. The third used the seven-agentic-turn ceiling at exact commit
 `d2f3e72858272dbfe3f79a83d290d622977c65e6`; Claude reported turn 7 with a
-`tool_use` terminal state before the fifth request was dispatched. All three private
-runs were rejected because their final output reused the inspected search receipt
-as if it were the inspection call's own receipt. No public projection was written
-and there is no accepted public exact-five capability evidence yet.
+`tool_use` terminal state before the fifth request was dispatched. Those first three
+private runs were rejected because their final output reused the inspected search
+receipt as if it were the inspection call's own receipt. The fourth used the
+eight-agentic-turn ceiling at exact commit
+`b9e777a9ed3744dd7291c0cd69347dd07aab2672`; Claude reported turn 8 in
+`tool_use` state after the same four calls. Its structured output supplied a distinct
+fifth receipt-shaped value, but there was no observed `evidence.inspect` request or
+response, so independent result verification rejected it. No public projection was
+written and there is no accepted public exact-five capability evidence yet.
 
 The existing QUAL-206-HOST-002 schemas, verifier and evidence remain unchanged.
 That accepted one-tool observation continues to prove only `catalogue.search`.
@@ -60,23 +65,30 @@ The separate launcher:
   closure before execution;
 - retains the existing MCP-subtree Seatbelt network denial and credential
   removal;
-- permits at most eight agentic turns; and
+- permits at most ten bounded agentic turns; and
 - rejects missing, duplicated, reordered or altered calls, including inspection
   of any receipt other than the search receipt.
 
-The exact protected-main observation above establishes that `--max-turns 7` can
-stop in `tool_use` state before the fifth request is dispatched. The `--max-turns 8`
-ceiling reserves one additional bounded tool-use round trip. Anthropic
-[defines that ceiling](https://code.claude.com/docs/en/agent-sdk/agent-loop) as a
-maximum number of tool-use round trips, while `num_turns` reports the total actually
-taken and includes a final no-tool turn. The verifier therefore accepts between
-three and nine reported turns rather than treating the ceiling as a target. The
-lower bound follows from the search-to-inspection dependency plus the final no-tool
-turn. It still requires an `end_turn` terminal state, so a success-shaped
-`tool_use` result cannot be accepted. It accepts only one closed call session and
-the observed bounded negotiation variants. This includes the accepted two-session
-shape in which the first session performs `server/discover` and the second performs
-`tools/list` then the five ordered calls.
+The exact protected-main observations above establish that both `--max-turns 7`
+and `--max-turns 8` can stop in `tool_use` state after the first four calls. The
+`--max-turns 10` ceiling is the smallest conservative boundary that reserves two
+further native CLI turns of headroom beyond the observed turn-8 stop. This allows
+the next bounded observation to attempt the fifth request-result and required final
+response without assigning that work to particular reported turns. Anthropic
+[documents `max_turns`](https://code.claude.com/docs/en/agent-sdk/agent-loop) as a
+maximum number of tool-use round trips and describes the final no-tool response as
+an additional turn. However, the exact native CLI observations at configured
+ceilings of seven and eight each reported the configured ceiling while the observer
+recorded only four calls. Configured `max_turns` and reported `num_turns` are
+therefore bounded metadata here, not evidence of how many MCP calls occurred. The
+observer's request-result trace remains authoritative. The accepted one-tool
+observation used a ceiling of two and reported three turns after its final response,
+so the verifier accepts between three and 11 reported turns rather than treating
+the ceiling as a target. It still requires an `end_turn` terminal state, so a
+success-shaped `tool_use` result cannot be accepted. It accepts only one closed call
+session and the observed bounded negotiation variants. This includes the accepted
+two-session shape in which the first session performs `server/discover` and the
+second performs `tools/list` then the five ordered calls.
 
 Each exact-five observer session retains one canonical, owner-only and size-bounded
 result file locally. The offline Node verifier rechecks the discovery and listing
@@ -88,7 +100,8 @@ to the request-event chain, source/runtime closure, final Claude structured outp
 process cleanup and provider audit.
 
 The fake-client suites exercise the complete one-session and two-session success
-paths, the observed four-call `tool_use` termination, wrong order, wrong arguments,
+paths, both observed turn-7 and turn-8 four-call `tool_use` terminations, wrong
+order, wrong arguments,
 a duplicate call, a substituted inspection receipt and a cryptographically
 invalid receipt. Offline projection tests additionally reject result reordering,
 duplication, body-parity failure, inspection-relationship substitution, extra

--- a/schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json
+++ b/schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json
@@ -182,11 +182,11 @@
         "input_tokens": {"type": "integer", "minimum": 1, "maximum": 10000000},
         "output_tokens": {"type": "integer", "minimum": 1, "maximum": 1000000},
         "claude_cli_reported_turns": {
-          "type": "integer", "minimum": 3, "maximum": 9
+          "type": "integer", "minimum": 3, "maximum": 11
         },
-        "agentic_turn_limit": {"const": 8},
+        "agentic_turn_limit": {"const": 10},
         "turn_count_semantics": {
-          "const": "claude-cli-reported-total-turns-at-most-eight-tool-use-round-trips-plus-one-final-turn"
+          "const": "claude-code-2.1.245-cli-configured-max-turns-ten-reported-num-turns-at-most-eleven"
         },
         "client_exit_code": {"const": 0}
       }
@@ -214,7 +214,7 @@
         },
         "permission_mode": {"const": "dontAsk"},
         "session_persistence": {"const": false},
-        "maximum_agentic_turns": {"const": 8},
+        "maximum_agentic_turns": {"const": 10},
         "mcp_subtree_network_access_allowed": {"const": false},
         "mcp_subtree_network_sandbox": {"const": "macos-seatbelt-deny-network"},
         "mcp_child_recognised_credentials_forwarded": {"const": false},

--- a/schemas/qual-206-claude-exact-five-capability-private-run-v1.schema.json
+++ b/schemas/qual-206-claude-exact-five-capability-private-run-v1.schema.json
@@ -187,7 +187,7 @@
         },
         "permission_mode": {"const": "dontAsk"},
         "session_persistence": {"const": false},
-        "maximum_turns": {"const": 8},
+        "maximum_turns": {"const": 10},
         "effort": {"const": "low"},
         "process_group_absent": {"type": "boolean"},
         "spawned_process_executable_attested": {"type": "boolean"}

--- a/scripts/qual_206_claude_capability_harness.mjs
+++ b/scripts/qual_206_claude_capability_harness.mjs
@@ -266,7 +266,7 @@ export const CLAUDE_EXACT_FIVE_CAPABILITY_PROFILE = Object.freeze({
   caseId: "QUAL-206-CLAUDE-EXACT-FIVE-V1",
   clientLabel: "claude-code-2.1.245-exact-five-v1",
   manifestSchema: "gis-ai-go.qual-206-claude-exact-five-capability-private-run.v1",
-  maximumTurns: 8,
+  maximumTurns: 10,
   outputSchema: EXACT_FIVE_OUTPUT_SCHEMA,
   permissionAliases: Object.freeze(Object.values(buildClaudePermissionAliasMap(
     "gis-ai-go-qual-206-exact-five-v1",

--- a/scripts/verify_qual_206_claude_exact_five_capability.py
+++ b/scripts/verify_qual_206_claude_exact_five_capability.py
@@ -47,11 +47,11 @@ PROFILE_ID = "exact-five-v1"
 CASE_ID = "QUAL-206-CLAUDE-EXACT-FIVE-V1"
 SERVER_NAME = "gis-ai-go-qual-206-exact-five-v1"
 PROTOCOL = "2026-07-28"
-MAXIMUM_AGENTIC_TURNS = 8
+MAXIMUM_AGENTIC_TURNS = 10
 MINIMUM_CLAUDE_REPORTED_TURNS = 3
 MAXIMUM_CLAUDE_REPORTED_TURNS = MAXIMUM_AGENTIC_TURNS + 1
 TURN_COUNT_SEMANTICS = (
-    "claude-cli-reported-total-turns-at-most-eight-tool-use-round-trips-plus-one-final-turn"
+    "claude-code-2.1.245-cli-configured-max-turns-ten-reported-num-turns-at-most-eleven"
 )
 OPERATIONS = (
     "catalogue.search",

--- a/tests/contract/test_qual_206_claude_capability.py
+++ b/tests/contract/test_qual_206_claude_capability.py
@@ -570,10 +570,10 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
             )
         }
         expected = {
-            "tests": 25,
-            "pass": 25 if sys.platform == "darwin" else 5,
+            "tests": 26,
+            "pass": 26 if sys.platform == "darwin" else 5,
             "fail": 0,
-            "skipped": 0 if sys.platform == "darwin" else 20,
+            "skipped": 0 if sys.platform == "darwin" else 21,
         }
         self.assertEqual(summary, expected, completed.stdout)
 

--- a/tests/contract/test_qual_206_claude_exact_five_capability.py
+++ b/tests/contract/test_qual_206_claude_exact_five_capability.py
@@ -341,8 +341,8 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             self.assertEqual(
                 projection["transport"]["guarded_provider_api_invocations"], 0
             )
-            self.assertEqual(projection["result"]["claude_cli_reported_turns"], 9)
-            self.assertEqual(projection["result"]["agentic_turn_limit"], 8)
+            self.assertEqual(projection["result"]["claude_cli_reported_turns"], 11)
+            self.assertEqual(projection["result"]["agentic_turn_limit"], 10)
             receipts = [
                 item["receipt_id"] for item in projection["result"]["operation_receipts"]
             ]
@@ -461,7 +461,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             remote["claims"]["remote_http_interoperability"] = True
             mutations.append(("remote HTTP inflation", remote))
             turns = copy.deepcopy(projection)
-            turns["result"]["claude_cli_reported_turns"] = 10
+            turns["result"]["claude_cli_reported_turns"] = 12
             mutations.append(("reported turn bound inflation", turns))
             too_few_turns = copy.deepcopy(projection)
             too_few_turns["result"]["claude_cli_reported_turns"] = 2
@@ -541,7 +541,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             original_manifest = manifest_path.read_bytes()
             try:
                 output = json.loads(original_output)
-                output["num_turns"] = 10
+                output["num_turns"] = 12
                 output_path.write_bytes(
                     json.dumps(output, separators=(",", ":")).encode()
                 )
@@ -619,50 +619,62 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
     )
     def test_four_call_tool_use_terminal_is_rejected(self) -> None:
         evidence_before = sorted((ROOT / "tests/interoperability/evidence").iterdir())
-        with tempfile.TemporaryDirectory(dir="/private/tmp") as value:
-            capture = Path(value) / "capture"
-            capture.mkdir(mode=0o700)
-            os.chmod(capture, 0o700)
-            executable_bytes, executable_sha256 = create_fake_capture(
-                capture,
-                scenario="premature-tool-use",
-            )
-            output = json.loads((capture / "stdout.json").read_text(encoding="utf-8"))
-            self.assertEqual(output["subtype"], "success")
-            self.assertIs(output["is_error"], False)
-            self.assertEqual(output["stop_reason"], "tool_use")
-            self.assertEqual(output["num_turns"], 7)
-            self.assertEqual(output["structured_output"]["operation_order"], OPERATIONS)
-            summary = json.loads(
-                (
-                    capture
-                    / "observer/session-2/exact-five-capability.json"
-                ).read_text(encoding="utf-8")
-            )
-            self.assertEqual(len(summary["operations"]), 4)
-            self.assertEqual(
-                [item["request"]["operation"] for item in summary["operations"]],
-                OPERATIONS[:4],
-            )
-            self.assertEqual(summary["protocol_session_status"], "failed")
-            with self.assertRaisesRegex(
-                verifier.ExactFiveCapabilityVerificationError,
-                "session-end does not describe one clean, complete observation",
-            ):
-                verifier.verify_and_project(
-                    capture,
-                    source_verifier=fake_source_boundary,
-                    private_validator=fake_host_validator(
-                        PRIVATE_SCHEMA,
-                        executable_bytes=executable_bytes,
-                        executable_sha256=executable_sha256,
-                    ),
-                    public_validator=fake_host_validator(
-                        PUBLIC_SCHEMA,
-                        executable_bytes=executable_bytes,
-                        executable_sha256=executable_sha256,
-                    ),
-                )
+        for scenario, expected_turns in (
+            ("premature-tool-use-seven", 7),
+            ("premature-tool-use", 8),
+        ):
+            with self.subTest(scenario=scenario):
+                with tempfile.TemporaryDirectory(dir="/private/tmp") as value:
+                    capture = Path(value) / "capture"
+                    capture.mkdir(mode=0o700)
+                    os.chmod(capture, 0o700)
+                    executable_bytes, executable_sha256 = create_fake_capture(
+                        capture,
+                        scenario=scenario,
+                    )
+                    output = json.loads(
+                        (capture / "stdout.json").read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(output["subtype"], "success")
+                    self.assertIs(output["is_error"], False)
+                    self.assertEqual(output["stop_reason"], "tool_use")
+                    self.assertEqual(output["num_turns"], expected_turns)
+                    self.assertEqual(
+                        output["structured_output"]["operation_order"], OPERATIONS
+                    )
+                    summary = json.loads(
+                        (
+                            capture
+                            / "observer/session-2/exact-five-capability.json"
+                        ).read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(len(summary["operations"]), 4)
+                    self.assertEqual(
+                        [
+                            item["request"]["operation"]
+                            for item in summary["operations"]
+                        ],
+                        OPERATIONS[:4],
+                    )
+                    self.assertEqual(summary["protocol_session_status"], "failed")
+                    with self.assertRaisesRegex(
+                        verifier.ExactFiveCapabilityVerificationError,
+                        "session-end does not describe one clean, complete observation",
+                    ):
+                        verifier.verify_and_project(
+                            capture,
+                            source_verifier=fake_source_boundary,
+                            private_validator=fake_host_validator(
+                                PRIVATE_SCHEMA,
+                                executable_bytes=executable_bytes,
+                                executable_sha256=executable_sha256,
+                            ),
+                            public_validator=fake_host_validator(
+                                PUBLIC_SCHEMA,
+                                executable_bytes=executable_bytes,
+                                executable_sha256=executable_sha256,
+                            ),
+                        )
         evidence_after = sorted((ROOT / "tests/interoperability/evidence").iterdir())
         self.assertEqual(evidence_after, evidence_before)
 

--- a/tests/interoperability/fixtures/qual_206_fake_claude_exact_five_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_exact_five_client.mjs
@@ -177,7 +177,7 @@ async function main() {
   if (
     optionValue(argumentsValue, "--output-format") !== "json" ||
     optionValue(argumentsValue, "--permission-mode") !== "dontAsk" ||
-    optionValue(argumentsValue, "--max-turns") !== "8" ||
+    optionValue(argumentsValue, "--max-turns") !== "10" ||
     optionValue(argumentsValue, "--tools") !== "" ||
     JSON.stringify(optionValues(
       argumentsValue,
@@ -206,7 +206,11 @@ async function main() {
     fail("fake Claude received a widened MCP configuration");
   }
   const server = servers[0][1];
-  const splitSessions = ["split-sessions", "premature-tool-use"].includes(SCENARIO);
+  const prematureToolUse = [
+    "premature-tool-use",
+    "premature-tool-use-seven",
+  ].includes(SCENARIO);
+  const splitSessions = SCENARIO === "split-sessions" || prematureToolUse;
   if (splitSessions) {
     const discoverySession = startSession(server);
     let discoveryError = null;
@@ -226,7 +230,7 @@ async function main() {
     if (splitSessions) await listTools(session.request);
     else await discover(session.request);
     const calls = PROFILE.operations.map((operation) => ({ ...operation }));
-    if (SCENARIO === "premature-tool-use") calls.pop();
+    if (prematureToolUse) calls.pop();
     if (SCENARIO === "wrong-order") [calls[0], calls[1]] = [calls[1], calls[0]];
     for (const operation of calls) {
       const argumentsValue = operation.name === "evidence.inspect"
@@ -261,8 +265,10 @@ async function main() {
     );
   }
 
-  if (SCENARIO === "premature-tool-use") {
-    receipts["evidence.inspect"] = receipts["catalogue.search"];
+  if (prematureToolUse) {
+    receipts["evidence.inspect"] = SCENARIO === "premature-tool-use-seven"
+      ? receipts["catalogue.search"]
+      : `gis-ai-go:evidence-receipt:sha256:${"f".repeat(64)}`;
   }
 
   process.stdout.write(JSON.stringify({
@@ -270,12 +276,13 @@ async function main() {
     subtype: "success",
     is_error: false,
     permission_denials: [],
-    num_turns: SCENARIO === "premature-tool-use" ? 7 : 9,
+    num_turns: SCENARIO === "premature-tool-use-seven" ? 7 :
+      SCENARIO === "premature-tool-use" ? 8 : 11,
     duration_ms: 800,
     duration_api_ms: 700,
     result: "The exact-five-v1 result is available in structured_output.",
     session_id: "00000000-0000-4000-8000-000000000005",
-    stop_reason: SCENARIO === "premature-tool-use" ? "tool_use" : "end_turn",
+    stop_reason: prematureToolUse ? "tool_use" : "end_turn",
     total_cost_usd: 0.01,
     usage: {
       input_tokens: 256,

--- a/tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs
@@ -198,7 +198,7 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
     "gis-ai-go.qual-206-claude-exact-five-capability-private-run.v1");
   assert.equal(manifest.profile, "exact-five-v1");
   assert.equal(manifest.execution.built_in_tools_available, false);
-  assert.equal(manifest.execution.maximum_turns, 8);
+  assert.equal(manifest.execution.maximum_turns, 10);
   assert.equal(manifest.isolation.mcp_subtree_network_access_allowed, false);
   assert.deepEqual(readdirSync(join(root, "observer")).sort(), [
     "exact-five-v1.claim.json",
@@ -222,7 +222,7 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
     summary.inspection_relationship.search_receipt_id,
   );
   const output = JSON.parse(readFileSync(join(root, "stdout.json"), "utf8"));
-  assert.equal(output.num_turns, 9);
+  assert.equal(output.num_turns, 11);
   assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
   assert.deepEqual(
     output.structured_output.receipt_ids,
@@ -237,52 +237,58 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
   );
 });
 
-macRuntimeTest(
-  "a four-call tool-use terminal remains failed private material",
-  async (t) => {
-    const root = privateRoot(t);
-    const { manifest } = await runClaudeExactFiveCapability(
-      options(root),
-      dependencies("premature-tool-use"),
-    );
-    assert.equal(manifest.execution.exit_code, 0);
-    const output = JSON.parse(readFileSync(join(root, "stdout.json"), "utf8"));
-    assert.equal(output.subtype, "success");
-    assert.equal(output.is_error, false);
-    assert.equal(output.stop_reason, "tool_use");
-    assert.equal(output.num_turns, 7);
-    assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
-    assert.deepEqual(readdirSync(join(root, "observer")).sort(), [
-      "exact-five-v1.claim.json",
-      "session-1",
-      "session-2",
-    ]);
-    const summary = JSON.parse(readFileSync(
-      join(root, "observer", "session-2", "exact-five-capability.json"),
-      "utf8",
-    ));
-    assert.equal(summary.session_profile, "invalid");
-    assert.equal(summary.protocol_session_status, "failed");
-    assert.equal(summary.operations.length, 4);
-    assert.deepEqual(
-      summary.operations.map(({ request }) => request.operation),
-      OPERATIONS.slice(0, 4),
-    );
-    assert.equal(
-      output.structured_output.receipt_ids["evidence.inspect"],
-      output.structured_output.receipt_ids["catalogue.search"],
-    );
-    const events = readFileSync(
-      join(root, "observer", "session-2", "events.jsonl"),
-      "utf8",
-    ).trim().split("\n").map((line) => JSON.parse(line));
-    const calls = events.filter(({ event, method }) =>
-      event === "request" && method === "tools/call"
-    ).map(({ operation }) => operation);
-    assert.deepEqual(calls, OPERATIONS.slice(0, 4));
-    assert.equal(calls.includes("evidence.inspect"), false);
-  },
-);
+for (const [scenario, expectedTurns, reusesSearchReceipt] of [
+  ["premature-tool-use-seven", 7, true],
+  ["premature-tool-use", 8, false],
+]) {
+  macRuntimeTest(
+    `a four-call tool-use terminal at turn ${expectedTurns} remains failed private material`,
+    async (t) => {
+      const root = privateRoot(t);
+      const { manifest } = await runClaudeExactFiveCapability(
+        options(root),
+        dependencies(scenario),
+      );
+      assert.equal(manifest.execution.exit_code, 0);
+      const output = JSON.parse(readFileSync(join(root, "stdout.json"), "utf8"));
+      assert.equal(output.subtype, "success");
+      assert.equal(output.is_error, false);
+      assert.equal(output.stop_reason, "tool_use");
+      assert.equal(output.num_turns, expectedTurns);
+      assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
+      assert.deepEqual(readdirSync(join(root, "observer")).sort(), [
+        "exact-five-v1.claim.json",
+        "session-1",
+        "session-2",
+      ]);
+      const summary = JSON.parse(readFileSync(
+        join(root, "observer", "session-2", "exact-five-capability.json"),
+        "utf8",
+      ));
+      assert.equal(summary.session_profile, "invalid");
+      assert.equal(summary.protocol_session_status, "failed");
+      assert.equal(summary.operations.length, 4);
+      assert.deepEqual(
+        summary.operations.map(({ request }) => request.operation),
+        OPERATIONS.slice(0, 4),
+      );
+      assert.equal(
+        output.structured_output.receipt_ids["evidence.inspect"] ===
+          output.structured_output.receipt_ids["catalogue.search"],
+        reusesSearchReceipt,
+      );
+      const events = readFileSync(
+        join(root, "observer", "session-2", "events.jsonl"),
+        "utf8",
+      ).trim().split("\n").map((line) => JSON.parse(line));
+      const calls = events.filter(({ event, method }) =>
+        event === "request" && method === "tools/call"
+      ).map(({ operation }) => operation);
+      assert.deepEqual(calls, OPERATIONS.slice(0, 4));
+      assert.equal(calls.includes("evidence.inspect"), false);
+    },
+  );
+}
 
 macRuntimeTest(
   "fake Claude may negotiate and call across the accepted two-session shape",


### PR DESCRIPTION
## Summary

- increase the bounded Claude exact-five profile from 8 to 10 configured turns
- preserve separate regressions for the observed turn-7 and turn-8 four-call `tool_use` terminations
- keep the observer trace, exact-five closure, final `end_turn`, distinct receipts and fail-closed publication boundary authoritative
- record the fourth protected-main observation without publishing private evidence

## Evidence basis

The bounded owner-only observation from protected-main commit `b9e777a9ed3744dd7291c0cd69347dd07aab2672` again stopped after four observed MCP calls. Claude Code reported turn 8 and `tool_use`; its structured output included a fifth receipt-shaped value with no corresponding `evidence.inspect` request or result. Independent verification rejected the run and wrote no public projection.

Ten is the smallest conservative next ceiling with two turns of headroom beyond the observed stop. The verifier treats configured and reported turn counts as bounded metadata; the observed request-result trace remains the acceptance authority.

## Verification

- Node QUAL-206 capability suites: 26 passed
- Python QUAL-206 contract suites: 11 passed
- TypeScript type checks: passed across 8 workspace projects
- contracts: 87 schemas and 106 records validated
- links: 462 local links, 183 research hashes and 2 ledger snapshots checked
- secret and machine-path scan: 888 text files passed
- version consistency: 13 manifests and locks passed

No public exact-five capability evidence is claimed by this change. A further bounded observation will run only from the exact protected-main merge commit.

Refs #24
