### PR TITLE
fix(qual-206): accept completed structured output

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -58,10 +58,21 @@ The supported target active set is exactly `catalogue.search`,
   v1 `receipt_id` schema through a narrowly scoped exact-five observer projection,
   while leaving the canonical gateway, OpenAPI, HTTP, ordinary STDIO and v2
   reconciliation contracts unchanged. Bind the complete canonical and presented
-  tool sets with separate, domain-separated digests. Write no public capability
-  projection until this change passes protected-main checks and a new bounded
-  observation passes every
-  independent verifier gate;
+  tool sets with separate, domain-separated digests;
+- record that the first bounded post-projection observation from exact protected
+  `main` completed all five calls, with every contract, receipt and inspection
+  relation independently valid. The real CLI result reported
+  `stop_reason: "tool_use"`, `terminal_reason: "completed"`,
+  `subtype: "success"` and a schema-valid `structured_output`. Publication was
+  correctly withheld because the verifier still assumed terminal success required
+  `end_turn`. Align only that predicate with Anthropic's documented Agent SDK
+  structured-output success shape: retain `end_turn`, and accept `tool_use` only
+  when the result is successful and structured, the terminal reason is `completed`,
+  the process closes cleanly and every existing exact-five verifier gate passes.
+  Keep the four-call `tool_use` regressions rejected. Do not promote the withheld
+  run retrospectively; require this correction to pass protected-main checks and a
+  new bounded observation from that exact protected `main` before writing any
+  public capability projection;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;

--- a/changelog.d/QUAL-206-claude-structured-output-terminal.fixed.md
+++ b/changelog.d/QUAL-206-claude-structured-output-terminal.fixed.md
@@ -1,0 +1,7 @@
+- Align the Claude exact-five terminal gate with Anthropic's structured-output
+  result contract. Retain `end_turn` and accept `stop_reason: "tool_use"` only when
+  the real CLI also reports `subtype: "success"`, a schema-valid
+  `structured_output` and `terminal_reason: "completed"`, the process closes
+  cleanly, and all five calls, contracts, receipts and the inspection relation pass
+  independent verification. Keep incomplete tool-use runs fail-closed and require
+  a new protected-main observation before publication.

--- a/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
@@ -17,8 +17,17 @@ Of the five canonical input schemas, `evidence.inspect` alone uses the existing
 v1/v2 top-level `oneOf` and `$defs` structure. That is an observed compatibility
 correlation and the basis of a narrowly testable hypothesis; it does not prove
 that Claude's schema parser caused the omission. Independent result verification
-rejected every incomplete observation. No public projection was written and there
-is no accepted public exact-five capability evidence yet.
+rejected every incomplete observation.
+
+The first bounded post-projection observation from exact protected `main` then
+completed all five ordered calls. Independent checks validated every result
+contract and receipt, structured-content and plain-text parity, and the required
+search-to-inspection relationship. The real CLI result reported
+`stop_reason: "tool_use"` and `terminal_reason: "completed"`, with
+`subtype: "success"` and a schema-valid `structured_output`. Publication was
+correctly withheld because the verifier still encoded the earlier assumption that
+only `stop_reason: "end_turn"` could be terminal success. No public projection was
+written and there is no accepted public exact-five capability evidence yet.
 
 The dedicated QUAL-206-HOST-002 capability schemas, verifier outcome and evidence
 remain unchanged. The shared composite event schema and verifier gain only optional
@@ -52,8 +61,8 @@ call's own distinct receipt before producing structured output. The search recei
 may be reused only as the inspection input and `inspected_search_receipt_id`; it
 must not be substituted for the inspection call's receipt. No receipt may be
 inferred, invented or calculated. The existing five-call evidence predicates remain
-unchanged and fail closed; the independent verifier additionally rejects a
-non-`end_turn` terminal state.
+unchanged and fail closed. The terminal-state correction described below does not
+weaken any call, result, receipt or inspection predicate.
 
 ## Isolation and fail-closed behaviour
 
@@ -86,11 +95,10 @@ therefore bounded metadata here, not evidence of how many MCP calls occurred. Th
 observer's request-result trace remains authoritative. The accepted one-tool
 observation used a ceiling of two and reported three turns after its final response,
 so the verifier accepts between three and 11 reported turns rather than treating
-the ceiling as a target. It still requires an `end_turn` terminal state, so a
-success-shaped `tool_use` result cannot be accepted. It accepts only one closed call
-session and the observed bounded negotiation variants. This includes the accepted
-two-session shape in which the first session performs `server/discover` and the
-second performs `tools/list` then the five ordered calls.
+the ceiling as a target. It accepts only one closed call session and the observed
+bounded negotiation variants. This includes the accepted two-session shape in which
+the first session performs `server/discover` and the second performs `tools/list`
+then the five ordered calls.
 
 ## Observer-only compatibility projection
 
@@ -132,14 +140,37 @@ a duplicate call, a substituted inspection receipt and a cryptographically
 invalid receipt. Offline projection tests additionally reject result reordering,
 duplication, body-parity failure, inspection-relationship substitution, extra
 protocol methods, changed request digests, out-of-bound turn counts,
-non-`end_turn` results, inflated claims and private-data leakage.
+invalid terminal combinations, inflated claims and private-data leakage.
+
+## Structured-output terminal state
+
+Anthropic's
+[Agent SDK structured-output guidance](https://code.claude.com/docs/en/agent-sdk/structured-outputs)
+defines its successful TypeScript result predicate as `subtype: "success"` with a
+present `structured_output`. It does not use `stop_reason: "end_turn"` as part of
+that predicate. Its
+[TypeScript SDK result contract](https://code.claude.com/docs/en/agent-sdk/typescript)
+defines `terminal_reason` separately as the reason the agent loop ended, including
+the value `completed`. The first real post-projection CLI observation matched that
+documented structured-output shape and reported `terminal_reason: "completed"`,
+despite retaining `stop_reason: "tool_use"` after the fifth MCP call.
+
+The correction is deliberately narrow. It retains `end_turn` as an ordinary
+successful stop reason and permits `tool_use` only for the observed
+structured-output terminal form: the result must have `subtype: "success"`,
+`is_error: false`, a schema-valid `structured_output` and
+`terminal_reason: "completed"`; the process must close cleanly; and every existing
+exact-five call, contract, receipt and inspection check must already have passed.
+`tool_use` alone is not evidence of completion. In particular, both historical
+four-call `tool_use` regressions remain failures.
 
 ## Publication boundary
 
-Do not treat the private harness result as evidence. No public capability projection
-may be written until this observer projection has merged and passed protected-main
-checks and a new bounded observation from exact protected `main` completes all five
-calls and every independent verifier gate. Raw prompts, responses, paths, process
+Do not treat the private harness result or the withheld post-projection observation
+as public evidence. The terminal-state correction must first merge and pass
+protected-main checks. A new bounded observation from that exact protected `main`
+must then complete all five calls and every independent verifier gate before any
+public capability projection may be written. Raw prompts, responses, paths, process
 details, costs, identifiers and private logs must remain local. Only a successful,
 schema-valid and minimised verifier projection may enter the public evidence
 directory. Failed or incomplete projections are not publishable.

--- a/schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json
+++ b/schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json
@@ -142,8 +142,9 @@
         "operation_receipts", "inspection_relationship",
         "independent_result_verification", "model_output_match", "model_reported",
         "model_usage_observed", "input_tokens", "output_tokens",
-        "claude_cli_reported_turns", "agentic_turn_limit", "turn_count_semantics",
-        "client_exit_code"
+        "claude_cli_reported_turns", "claude_cli_stop_reason",
+        "claude_cli_terminal_reason", "agentic_turn_limit",
+        "turn_count_semantics", "client_exit_code"
       ],
       "properties": {
         "classification": {"const": "capability_pass"},
@@ -185,6 +186,8 @@
         "claude_cli_reported_turns": {
           "type": "integer", "minimum": 3, "maximum": 11
         },
+        "claude_cli_stop_reason": {"enum": ["end_turn", "tool_use"]},
+        "claude_cli_terminal_reason": {"const": "completed"},
         "agentic_turn_limit": {"const": 10},
         "turn_count_semantics": {
           "const": "claude-code-2.1.245-cli-configured-max-turns-ten-reported-num-turns-at-most-eleven"

--- a/scripts/verify_qual_206_claude_exact_five_capability.py
+++ b/scripts/verify_qual_206_claude_exact_five_capability.py
@@ -1095,8 +1095,17 @@ def verify_output(
         or execution["maximum_turns"] != MAXIMUM_AGENTIC_TURNS
     ):
         fail("Claude CLI reported turns fall outside the bounded turn semantics")
-    if output.get("stop_reason") != "end_turn":
-        fail("Claude final output did not end with an end_turn terminal state")
+    stop_reason = output.get("stop_reason")
+    terminal_reason = output.get("terminal_reason")
+    if terminal_reason != "completed":
+        fail("Claude final output did not report a completed terminal reason")
+    if stop_reason not in {"end_turn", "tool_use"}:
+        fail(
+            "Claude final output did not use an accepted end_turn or tool_use "
+            "stop reason"
+        )
+    if "deferred_tool_use" in output:
+        fail("Claude final output retained deferred tool use")
     if (
         output.get("type") != "result"
         or output.get("is_error") is not False
@@ -1124,6 +1133,8 @@ def verify_output(
         "input_tokens": sum(bounded_aggregate[:3]),
         "output_tokens": bounded_aggregate[3],
         "claude_cli_reported_turns": num_turns,
+        "claude_cli_stop_reason": stop_reason,
+        "claude_cli_terminal_reason": terminal_reason,
         "agentic_turn_limit": execution["maximum_turns"],
         "turn_count_semantics": TURN_COUNT_SEMANTICS,
     }

--- a/tests/contract/test_qual_206_claude_capability.py
+++ b/tests/contract/test_qual_206_claude_capability.py
@@ -570,10 +570,10 @@ class ClaudeCapabilityContractsTest(unittest.TestCase):
             )
         }
         expected = {
-            "tests": 26,
-            "pass": 26 if sys.platform == "darwin" else 5,
+            "tests": 27,
+            "pass": 27 if sys.platform == "darwin" else 5,
             "fail": 0,
-            "skipped": 0 if sys.platform == "darwin" else 21,
+            "skipped": 0 if sys.platform == "darwin" else 22,
         }
         self.assertEqual(summary, expected, completed.stdout)
 

--- a/tests/contract/test_qual_206_claude_exact_five_capability.py
+++ b/tests/contract/test_qual_206_claude_exact_five_capability.py
@@ -350,6 +350,10 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
                 schema_projection["presented_tools_sha256"],
             )
             self.assertEqual(projection["result"]["claude_cli_reported_turns"], 11)
+            self.assertEqual(projection["result"]["claude_cli_stop_reason"], "end_turn")
+            self.assertEqual(
+                projection["result"]["claude_cli_terminal_reason"], "completed"
+            )
             self.assertEqual(projection["result"]["agentic_turn_limit"], 10)
             receipts = [
                 item["receipt_id"] for item in projection["result"]["operation_receipts"]
@@ -503,6 +507,15 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             too_few_turns = copy.deepcopy(projection)
             too_few_turns["result"]["claude_cli_reported_turns"] = 2
             mutations.append(("reported turn bound deflation", too_few_turns))
+            stop_reason = copy.deepcopy(projection)
+            stop_reason["result"]["claude_cli_stop_reason"] = "maximum_turns"
+            mutations.append(("unaccepted stop reason", stop_reason))
+            terminal_reason = copy.deepcopy(projection)
+            terminal_reason["result"]["claude_cli_terminal_reason"] = "maximum_turns"
+            mutations.append(("incomplete terminal reason", terminal_reason))
+            missing_terminal_reason = copy.deepcopy(projection)
+            del missing_terminal_reason["result"]["claude_cli_terminal_reason"]
+            mutations.append(("missing terminal reason", missing_terminal_reason))
             order = copy.deepcopy(projection)
             order["result"]["operation_order"][0:2] = reversed(
                 order["result"]["operation_order"][0:2]
@@ -664,6 +677,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
             try:
                 output = json.loads(original_output)
                 output["stop_reason"] = "tool_use"
+                output["terminal_reason"] = "maximum_turns"
                 output_path.write_bytes(
                     json.dumps(output, separators=(",", ":")).encode()
                 )
@@ -671,7 +685,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
                 rebind_stdout(capture)
                 with self.assertRaisesRegex(
                     verifier.ExactFiveCapabilityVerificationError,
-                    "end_turn terminal state",
+                    "completed terminal reason",
                 ):
                     verifier.verify_and_project(
                         capture,
@@ -684,6 +698,133 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
                 manifest_path.write_bytes(original_manifest)
                 os.chmod(output_path, 0o600)
                 os.chmod(manifest_path, 0o600)
+        evidence_after = sorted((ROOT / "tests/interoperability/evidence").iterdir())
+        self.assertEqual(evidence_after, evidence_before)
+
+    @unittest.skipUnless(
+        sys.platform == "darwin",
+        "the accepted Claude exact-five runtime uses macOS Seatbelt",
+    )
+    def test_completed_tool_use_terminal_with_all_five_calls_projects(self) -> None:
+        evidence_before = sorted((ROOT / "tests/interoperability/evidence").iterdir())
+        with tempfile.TemporaryDirectory(dir="/private/tmp") as value:
+            capture = Path(value) / "capture"
+            capture.mkdir(mode=0o700)
+            os.chmod(capture, 0o700)
+            executable_bytes, executable_sha256 = create_fake_capture(
+                capture,
+                scenario="complete-tool-use",
+            )
+            private_check = fake_host_validator(
+                PRIVATE_SCHEMA,
+                executable_bytes=executable_bytes,
+                executable_sha256=executable_sha256,
+            )
+            public_check = fake_host_validator(
+                PUBLIC_SCHEMA,
+                executable_bytes=executable_bytes,
+                executable_sha256=executable_sha256,
+            )
+            output_path = capture / "stdout.json"
+            manifest_path = capture / "run-manifest.json"
+            output = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(output["stop_reason"], "tool_use")
+            self.assertEqual(output["terminal_reason"], "completed")
+            self.assertNotIn("deferred_tool_use", output)
+            self.assertEqual(output["num_turns"], 7)
+            projection = verifier.verify_and_project(
+                capture,
+                source_verifier=fake_source_boundary,
+                private_validator=private_check,
+                public_validator=public_check,
+            )
+            self.assertEqual(projection["status"], "capability_pass")
+            self.assertEqual(projection["transport"]["tool_call_count"], 5)
+            self.assertEqual(projection["result"]["claude_cli_stop_reason"], "tool_use")
+            self.assertEqual(
+                projection["result"]["claude_cli_terminal_reason"], "completed"
+            )
+
+            original_output = output_path.read_bytes()
+            original_manifest = manifest_path.read_bytes()
+            output["terminal_reason"] = "maximum_turns"
+            output_path.write_bytes(json.dumps(output, separators=(",", ":")).encode())
+            os.chmod(output_path, 0o600)
+            rebind_stdout(capture)
+            with self.assertRaisesRegex(
+                verifier.ExactFiveCapabilityVerificationError,
+                "completed terminal reason",
+            ):
+                verifier.verify_and_project(
+                    capture,
+                    source_verifier=fake_source_boundary,
+                    private_validator=private_check,
+                    public_validator=public_check,
+                )
+            output_path.write_bytes(original_output)
+            manifest_path.write_bytes(original_manifest)
+            os.chmod(output_path, 0o600)
+            os.chmod(manifest_path, 0o600)
+
+            output = json.loads(original_output)
+            output["stop_reason"] = "maximum_turns"
+            output_path.write_bytes(json.dumps(output, separators=(",", ":")).encode())
+            os.chmod(output_path, 0o600)
+            rebind_stdout(capture)
+            with self.assertRaisesRegex(
+                verifier.ExactFiveCapabilityVerificationError,
+                "accepted end_turn or tool_use stop reason",
+            ):
+                verifier.verify_and_project(
+                    capture,
+                    source_verifier=fake_source_boundary,
+                    private_validator=private_check,
+                    public_validator=public_check,
+                )
+            output_path.write_bytes(original_output)
+            manifest_path.write_bytes(original_manifest)
+            os.chmod(output_path, 0o600)
+            os.chmod(manifest_path, 0o600)
+
+            output = json.loads(original_output)
+            del output["terminal_reason"]
+            output_path.write_bytes(json.dumps(output, separators=(",", ":")).encode())
+            os.chmod(output_path, 0o600)
+            rebind_stdout(capture)
+            with self.assertRaisesRegex(
+                verifier.ExactFiveCapabilityVerificationError,
+                "completed terminal reason",
+            ):
+                verifier.verify_and_project(
+                    capture,
+                    source_verifier=fake_source_boundary,
+                    private_validator=private_check,
+                    public_validator=public_check,
+                )
+            output_path.write_bytes(original_output)
+            manifest_path.write_bytes(original_manifest)
+            os.chmod(output_path, 0o600)
+            os.chmod(manifest_path, 0o600)
+
+            output = json.loads(original_output)
+            output["deferred_tool_use"] = True
+            output_path.write_bytes(json.dumps(output, separators=(",", ":")).encode())
+            os.chmod(output_path, 0o600)
+            rebind_stdout(capture)
+            with self.assertRaisesRegex(
+                verifier.ExactFiveCapabilityVerificationError,
+                "retained deferred tool use",
+            ):
+                verifier.verify_and_project(
+                    capture,
+                    source_verifier=fake_source_boundary,
+                    private_validator=private_check,
+                    public_validator=public_check,
+                )
+            output_path.write_bytes(original_output)
+            manifest_path.write_bytes(original_manifest)
+            os.chmod(output_path, 0o600)
+            os.chmod(manifest_path, 0o600)
         evidence_after = sorted((ROOT / "tests/interoperability/evidence").iterdir())
         self.assertEqual(evidence_after, evidence_before)
 
@@ -712,6 +853,7 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
                     self.assertEqual(output["subtype"], "success")
                     self.assertIs(output["is_error"], False)
                     self.assertEqual(output["stop_reason"], "tool_use")
+                    self.assertEqual(output["terminal_reason"], "completed")
                     self.assertEqual(output["num_turns"], expected_turns)
                     self.assertEqual(
                         output["structured_output"]["operation_order"], OPERATIONS

--- a/tests/interoperability/fixtures/qual_206_fake_claude_exact_five_client.mjs
+++ b/tests/interoperability/fixtures/qual_206_fake_claude_exact_five_client.mjs
@@ -227,7 +227,9 @@ async function main() {
     "premature-tool-use",
     "premature-tool-use-seven",
   ].includes(SCENARIO);
-  const splitSessions = SCENARIO === "split-sessions" || prematureToolUse;
+  const completeToolUse = SCENARIO === "complete-tool-use";
+  const splitSessions = ["split-sessions", "complete-tool-use"].includes(SCENARIO) ||
+    prematureToolUse;
   if (splitSessions) {
     const discoverySession = startSession(server);
     let discoveryError = null;
@@ -278,7 +280,8 @@ async function main() {
   } finally {
     await stopSession(
       session,
-      ["positive", "split-sessions"].includes(SCENARIO) && sessionError === null,
+      ["positive", "split-sessions", "complete-tool-use"].includes(SCENARIO) &&
+        sessionError === null,
     );
   }
 
@@ -293,13 +296,14 @@ async function main() {
     subtype: "success",
     is_error: false,
     permission_denials: [],
-    num_turns: SCENARIO === "premature-tool-use-seven" ? 7 :
+    num_turns: ["complete-tool-use", "premature-tool-use-seven"].includes(SCENARIO) ? 7 :
       SCENARIO === "premature-tool-use" ? 8 : 11,
     duration_ms: 800,
     duration_api_ms: 700,
     result: "The exact-five-v1 result is available in structured_output.",
     session_id: "00000000-0000-4000-8000-000000000005",
-    stop_reason: prematureToolUse ? "tool_use" : "end_turn",
+    stop_reason: prematureToolUse || completeToolUse ? "tool_use" : "end_turn",
+    terminal_reason: "completed",
     total_cost_usd: 0.01,
     usage: {
       input_tokens: 256,

--- a/tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs
+++ b/tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs
@@ -269,6 +269,9 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
   );
   const output = JSON.parse(readFileSync(join(root, "stdout.json"), "utf8"));
   assert.equal(output.num_turns, 11);
+  assert.equal(output.stop_reason, "end_turn");
+  assert.equal(output.terminal_reason, "completed");
+  assert.equal(Object.hasOwn(output, "deferred_tool_use"), false);
   assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
   assert.deepEqual(
     output.structured_output.receipt_ids,
@@ -282,6 +285,35 @@ macRuntimeTest("fake Claude completes the closed exact-five-v1 journey", async (
     summary.inspection_relationship.search_receipt_id,
   );
 });
+
+macRuntimeTest(
+  "a completed structured-output tool-use terminal retains all five verified calls",
+  async (t) => {
+    const root = privateRoot(t);
+    const { manifest } = await runClaudeExactFiveCapability(
+      options(root),
+      dependencies("complete-tool-use"),
+    );
+    assert.equal(manifest.execution.exit_code, 0);
+    assert.equal(manifest.execution.harness_classification, null);
+    assert.equal(manifest.execution.process_group_absent, true);
+    const output = JSON.parse(readFileSync(join(root, "stdout.json"), "utf8"));
+    assert.equal(output.stop_reason, "tool_use");
+    assert.equal(output.terminal_reason, "completed");
+    assert.equal(Object.hasOwn(output, "deferred_tool_use"), false);
+    assert.equal(output.num_turns, 7);
+    assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
+    const summary = JSON.parse(readFileSync(
+      join(root, "observer", "session-2", "exact-five-capability.json"),
+      "utf8",
+    ));
+    assert.equal(summary.protocol_session_status, "passed");
+    assert.deepEqual(
+      summary.operations.map(({ request }) => request.operation),
+      OPERATIONS,
+    );
+  },
+);
 
 for (const [scenario, expectedTurns, reusesSearchReceipt] of [
   ["premature-tool-use-seven", 7, true],
@@ -300,6 +332,8 @@ for (const [scenario, expectedTurns, reusesSearchReceipt] of [
       assert.equal(output.subtype, "success");
       assert.equal(output.is_error, false);
       assert.equal(output.stop_reason, "tool_use");
+      assert.equal(output.terminal_reason, "completed");
+      assert.equal(Object.hasOwn(output, "deferred_tool_use"), false);
       assert.equal(output.num_turns, expectedTurns);
       assert.deepEqual(output.structured_output.operation_order, OPERATIONS);
       assert.deepEqual(readdirSync(join(root, "observer")).sort(), [


### PR DESCRIPTION
## Outcome

Align the QUAL-206 exact-five verifier with Anthropic's documented Agent SDK
structured-output completion contract, without weakening any existing capability
gate.

The first bounded post-projection observation from exact protected `main` made all
five required MCP calls successfully, but publication was withheld because the
verifier still assumed that successful completion required
`stop_reason: "end_turn"`. The Agent SDK instead reports successful structured
completion through `subtype: "success"`, validated `structured_output` and
`terminal_reason: "completed"`; `stop_reason` remains a separate model-response
field.

## Change

- require `terminal_reason: "completed"`;
- accept only `stop_reason: "end_turn"` or `stop_reason: "tool_use"`;
- reject any `deferred_tool_use`;
- retain the independent exact-five ordered-call, receipt, inspection,
  schema-projection, usage and clean-process gates;
- expose the non-sensitive stop and terminal reasons in any verifier-produced
  public evidence; and
- add adversarial regressions, including the seven- and eight-turn four-call
  `tool_use` captures, which remain rejected.

This does not retrospectively promote the withheld private observation. A new
bounded observation from the exact protected-main result of this change is still
required before any public capability evidence may be written.

## Verification

- focused Node capability suite: 27 of 27 passed;
- integrated Python contract wrapper: 12 passed;
- contract validation: 87 schemas and 106 records;
- link validation: 462 links, 183 research hashes, 2 ledgers and 71 sources;
- secret and machine-path scan: 890 files, no match;
- Python and Node syntax checks passed;
- `git diff --check` passed; and
- independent fail-closed review found no blocker.

## Boundaries

- no public evidence is added;
- no activation, registry publication, provider call, deployment, tag or release
  occurs; and
- the canonical gateway, OpenAPI, MCP HTTP, ordinary STDIO and v1/v2
  reconciliation contracts remain unchanged.

The separate process retrospective is tracked in #86 and is explicitly deferred
until local `v0.2.0` finalisation.
