### PR TITLE
docs(qual-206): publish exact-five capability evidence

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -38,11 +38,12 @@ The supported target active set is exactly `catalogue.search`,
   metadata while keeping attribution and exact-case evidence predicates closed;
 - accept the verifier-produced `HOST-002` projection from exact protected-main
   commit `5837bd65a482e90238c466673318f007e305c744` as one bounded
-  model-mediated `catalogue.search` capability pass; keep exact-five model
-  capability, remote HTTP, live geospatial-provider use, registry publication,
-  activation, deployment and release false and open;
+  model-mediated `catalogue.search` capability pass. That narrow projection does
+  not establish exact-five model capability; keep remote HTTP, live
+  geospatial-provider use, registry publication, activation, deployment and release
+  false and open;
 - retain the additive `exact-five-v1` private/session/public schemas and offline
-  verifier candidate, which independently rechecks the retained canonical result
+  verifier, which independently rechecks the retained canonical result
   bodies, five operation-specific receipts, search-to-inspection relation, exact
   request and method closure, Claude final output and process/runtime closure. Its
   fake one-session and accepted two-session shapes pass. Bounded protected-main
@@ -53,8 +54,8 @@ The supported target active set is exactly `catalogue.search`,
   contained all five canonical tools while Claude's model-facing set contained only
   four and omitted `evidence.inspect`. That tool alone used the canonical v1/v2
   top-level `oneOf` and `$defs` input schema. Treat this as an observed compatibility
-  correlation and a testable hypothesis, not proof of Claude parser causation;
-  retain the exact five-call and `end_turn` gates. Present only the existing closed
+  correlation and a testable hypothesis, not proof of Claude parser causation.
+  Present only the existing closed
   v1 `receipt_id` schema through a narrowly scoped exact-five observer projection,
   while leaving the canonical gateway, OpenAPI, HTTP, ordinary STDIO and v2
   reconciliation contracts unchanged. Bind the complete canonical and presented
@@ -69,15 +70,25 @@ The supported target active set is exactly `catalogue.search`,
   structured-output success shape: retain `end_turn`, and accept `tool_use` only
   when the result is successful and structured, the terminal reason is `completed`,
   the process closes cleanly and every existing exact-five verifier gate passes.
-  Keep the four-call `tool_use` regressions rejected. Do not promote the withheld
-  run retrospectively; require this correction to pass protected-main checks and a
-  new bounded observation from that exact protected `main` before writing any
-  public capability projection;
+  Keep the four-call `tool_use` regressions rejected and the withheld run private
+  and unpromoted;
+- record that the terminal-state correction merged through
+  [pull request 87](https://github.com/chris-page-gov/gis-ai-go/pull/87) as exact
+  protected-main commit `029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+  `96f75d96b1e0680465494834ddad8661539cbd62`, with every exact-main CI job and
+  CodeQL analysis passing. Accept the fresh verifier-produced
+  [exact-five projection](tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+  with SHA-256
+  `06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+  It records all five ordered local STDIO calls at reported turn 7, with every
+  contract, distinct receipt, parity check and inspection relation independently
+  valid. This closes local STDIO exact-five model capability only. Raw capture
+  remains local and owner-only; remote HTTP, live-provider use, registry publication,
+  activation, deployment and release remain false and open;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;
-- complete the remaining exact-five desktop capability and remote-HTTP host
-  evidence;
+- complete the remaining remote-HTTP host evidence;
   and
 - continue provider-neutral preparation, but stop before public provisioning or
   spend until a provider account, numeric monthly ceiling and operational hosting
@@ -384,9 +395,9 @@ or release is claimed.
 
 1. Preserve the verified Claude Code `2.1.241` and `2.1.245` strict-modern transport
    summaries, the separate historical default-negotiation record, the accepted
-   one-case `HOST-002` capability projection and the protected-main loopback HTTP
-   projection. Complete the exact-five desktop capability and remaining remote-HTTP
-   host evidence without widening any narrow result.
+   one-case `HOST-002` capability projection, the exact-five local STDIO capability
+   projection and the protected-main loopback HTTP projection. Complete the remaining
+   remote-HTTP host evidence without widening any narrow result.
 2. Retain the exact protected-main UBI, independent-derivation and provenance
    evidence from runs `32760872035` and `32760871684`; rebuild and repeat it after
    every later source-changing activation or release commit.
@@ -418,8 +429,9 @@ or release is claimed.
   for exact Claude Code `2.1.241` and `2.1.245` establish strict MCP `2026-07-28`
   desktop-STDIO transport readiness, but neither involved a model task or tool
   call. The later accepted `HOST-002` projection scores one bounded
-  `catalogue.search` case only; exact-five model capability and remote-HTTP host
-  evidence remain incomplete.
+  `catalogue.search` case only. A separate fresh protected-main observation now
+  passes all five ordered local STDIO calls; remote-HTTP host evidence remains
+  incomplete.
   Security, accessibility, governed ingress/storage admission, retention/disposal
   and host-specific lifecycle evidence remain activation gates.
 - Direct routes and MCP transports now exist on protected `main`, but the
@@ -446,6 +458,25 @@ or release is claimed.
   the open product.
 
 ## Latest evidence
+
+- Claude Code `2.1.245` bounded exact-five capability: the fresh verifier-produced
+  [path-free projection](tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+  binds exact protected-main commit
+  `029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+  `96f75d96b1e0680465494834ddad8661539cbd62`, with SHA-256
+  `06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+  Every job in
+  [CI run 33114396425](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396425)
+  and every analysis in
+  [CodeQL run 33114396546](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396546)
+  passed. Claude Code `2.1.245`, reporting model `claude-sonnet-5`, made the five
+  ordered MCP `2026-07-28` calls over local STDIO at reported turn 7. Independent
+  verification accepted every output contract, five distinct receipts,
+  structured/plain-text parity and the search-to-inspection relationship. The
+  deterministic fixture made one synthetic provider transport call and zero guarded
+  live-provider API invocations. Raw capture remains owner-only and local. This
+  closes local STDIO exact-five model capability only; remote HTTP, live-provider
+  use, registry publication, activation, deployment and release remain false;
 
 - QUAL-206 protected-main local HTTP transport preflight: the
   [path-free projection](tests/interoperability/evidence/local-http-transport-preflight-2026-08-25.json)
@@ -550,9 +581,11 @@ or release is claimed.
   reporting model `claude-sonnet-5`, made exactly one canonical MCP `2026-07-28`
   `catalogue.search` call and returned the same independently verified inline
   receipt. The CLI ceiling was two agentic turns and the exact final host report
-  was `num_turns: 3`. Raw capture remains owner-only and local. Exact-five model
-  capability, remote HTTP interoperability, live geospatial-provider use, registry
-  publication, activation, deployment and release remain false and open;
+  was `num_turns: 3`. Raw capture remains owner-only and local. That narrow
+  projection alone does not establish exact-five model capability; the separate
+  later projection above does. Remote HTTP interoperability, live
+  geospatial-provider use, registry publication, activation, deployment and release
+  remain false and open;
 
 - Claude Code `2.1.245` strict-modern STDIO readiness: the
   [path-free source-bound summary](tests/interoperability/evidence/claude-code-2.1.245-modern-stdio-readiness-2026-08-25.json)
@@ -562,10 +595,10 @@ or release is claimed.
   MCP `2026-07-28` `server/discover` probe and a separate successful `tools/list`
   session. Independent replay accepted both, all provider, egress, pending-request,
   anomaly, error and stderr counters were zero, and no observer or fixture remained.
-  This is transport readiness only: capability, exact-five operations and
-  remote-HTTP evidence remain incomplete. The raw capture and client output remain
-  owner-only and local, while the 2.1.241 schema and result remain byte-exact
-  historical lineage;
+  This readiness record by itself does not establish capability or exact-five; the
+  later projection above does. Remote-HTTP evidence remains incomplete. The raw
+  capture and client output remain owner-only and local, while the 2.1.241 schema
+  and result remain byte-exact historical lineage;
 
 - Claude Code `2.1.241` strict-modern STDIO readiness: the
   [path-free source-bound summary](tests/interoperability/evidence/claude-code-2.1.241-modern-stdio-readiness-2026-08-25.json)
@@ -575,9 +608,9 @@ or release is claimed.
   `2026-07-28` `server/discover` probe and a separate successful `tools/list`
   session. Independent offline replay accepted both sessions with zero provider
   calls, pending requests, anomalies or stderr, and read-only process checks found
-  no retained observer or fixture. This is transport readiness only: capability,
-  exact-five operations and remote-HTTP evidence remain incomplete. Raw captures
-  remain owner-only and local;
+  no retained observer or fixture. That 2.1.241 observation itself establishes
+  transport readiness only, not capability or exact-five; remote-HTTP evidence
+  remains incomplete. Raw captures remain owner-only and local;
 
 - Claude Code `2.1.241` historical default-negotiation observation: the
   [additive source-bound summary](tests/interoperability/evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json)

--- a/changelog.d/QUAL-206-claude-exact-five-capability-evidence.added.md
+++ b/changelog.d/QUAL-206-claude-exact-five-capability-evidence.added.md
@@ -1,0 +1,4 @@
+Publish the minimised, source-bound Claude Code 2.1.245 local STDIO exact-five
+capability projection while retaining raw capture locally and keeping remote HTTP,
+live-provider, registry publication, activation, deployment and release claims
+closed.

--- a/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_CAPABILITY.md
@@ -29,10 +29,12 @@ Claude Code `2.1.245`, reporting model `claude-sonnet-5`, completed MCP
 `catalogue.search` call and a valid independently checked receipt. The accepted
 projection records a two-agentic-turn CLI ceiling and exact final host
 `num_turns: 3`; the counters are not interchangeable. This is one bounded
-capability pass only. Exact-five model capability, remote HTTP interoperability,
-live geospatial-provider use, registry publication, activation, deployment and
-release remain explicitly false and open. The raw observation remains local and
-owner-only.
+capability pass only. That projection itself keeps exact-five model capability,
+remote HTTP interoperability, live geospatial-provider use, registry publication,
+activation, deployment and release explicitly false. A separate later
+[exact-five projection](../../tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+closes local STDIO exact-five model capability only; all the other boundaries
+remain false and open. The raw observation remains local and owner-only.
 
 ## Closed observation boundary
 

--- a/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
+++ b/docs/operations/QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md
@@ -27,7 +27,23 @@ search-to-inspection relationship. The real CLI result reported
 `subtype: "success"` and a schema-valid `structured_output`. Publication was
 correctly withheld because the verifier still encoded the earlier assumption that
 only `stop_reason: "end_turn"` could be terminal success. No public projection was
-written and there is no accepted public exact-five capability evidence yet.
+written from that observation, which remains private and unpromoted.
+
+The terminal-state correction subsequently merged through
+[pull request 87](https://github.com/chris-page-gov/gis-ai-go/pull/87) as exact
+protected-main commit `029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+`96f75d96b1e0680465494834ddad8661539cbd62`. Every exact-main CI job passed in
+[run 33114396425](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396425),
+and every CodeQL analysis passed in
+[run 33114396546](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396546).
+A fresh bounded observation from those exact bytes completed the five ordered calls
+at reported turn 7. Independent verification accepted all five distinct receipts,
+every output contract, structured/plain-text parity, the search-to-inspection
+relationship and the documented structured terminal form. The minimised
+[public projection](../../tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+has SHA-256
+`06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+This closes only local STDIO exact-five model capability.
 
 The dedicated QUAL-206-HOST-002 capability schemas, verifier outcome and evidence
 remain unchanged. The shared composite event schema and verifier gain only optional
@@ -166,14 +182,15 @@ four-call `tool_use` regressions remain failures.
 
 ## Publication boundary
 
-Do not treat the private harness result or the withheld post-projection observation
-as public evidence. The terminal-state correction must first merge and pass
-protected-main checks. A new bounded observation from that exact protected `main`
-must then complete all five calls and every independent verifier gate before any
-public capability projection may be written. Raw prompts, responses, paths, process
-details, costs, identifiers and private logs must remain local. Only a successful,
-schema-valid and minimised verifier projection may enter the public evidence
-directory. Failed or incomplete projections are not publishable.
+Do not treat the private harness result, earlier incomplete observations or the
+withheld first post-projection observation as public evidence. The accepted public
+projection comes only from the fresh run after the terminal-state correction passed
+protected-main checks. It records two sessions, seven requests and responses, five
+ordered tool calls, zero resource reads, one deterministic synthetic-provider
+transport call and zero guarded live-provider API invocations. Raw prompts,
+responses, paths, raw process details, private run/session/process identifiers,
+costs and private logs must remain local. Failed or incomplete projections remain
+unpublishable.
 
-This pack does not establish remote HTTP interoperability, live provider use,
-registry publication, activation, deployment or release.
+This accepted result does not establish remote HTTP interoperability, live provider
+use, registry publication, activation, deployment or release.

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -14,9 +14,10 @@
   strict-modern STDIO transport readiness from protected `main`; a later bounded
   `HOST-002` observation from exact protected-main bytes passed one model-mediated
   canonical `catalogue.search` call and independent receipt verification;
+  a fresh bounded exact-five observation from later exact protected-main bytes
+  passed all five ordered local STDIO calls and independent verification;
   deterministic `HOST-015` application recovery passes locally but remains non-live
-  and unscored; exact-five model capability, remote HTTP evidence and activation
-  remain pending
+  and unscored; remote HTTP evidence and activation remain pending
 - reviewed source base: `66507f9a6e6c0da23a8af4682268f9362d93bc06`
 - local HTTP transport evidence source: protected `main` commit
   `066a9cb22f719d22e29c95cd99857ddf694c878e`
@@ -24,6 +25,8 @@
   `e905c632724ecc9d13b13452fee37328e75cc2a4`
 - accepted Claude `HOST-002` capability source: protected `main` commit
   `5837bd65a482e90238c466673318f007e305c744`
+- accepted Claude exact-five capability source: protected `main` commit
+  `029a9d5c7efcafcd45941194394384ee6c578fe9`
 - historical Claude legacy transport-readiness source: protected `main` commit
   `30b575beb27ff805745a2864c1acf44392774046`
 - legacy fallback integration base: protected `main` commit
@@ -84,6 +87,19 @@ cover the exact five operations and three resource classes. The private capture
 remains local and unpublished. This does not exercise TLS, a public hostname, an
 independent remote host, a model, a live provider or a deployment, so it cannot
 close the remote-HTTP or capability gates.
+
+The separate verifier-produced
+[Claude Code exact-five projection](../../tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+binds protected-main commit `029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+`96f75d96b1e0680465494834ddad8661539cbd62`, with SHA-256
+`06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+Claude Code `2.1.245`, reporting model `claude-sonnet-5`, completed all five ordered
+MCP `2026-07-28` calls over local STDIO at reported turn 7. Every result contract,
+distinct receipt, structured/plain-text parity check and the inspection relationship
+passed independent verification. The deterministic fixture made one synthetic
+provider transport call and zero guarded live-provider API invocations. This closes
+local STDIO exact-five model capability only; remote HTTP and every production gate
+remain open.
 
 ## Build the exact local candidate
 
@@ -253,6 +269,7 @@ MCP registry for a conformance run.
 | Claude Code 2.1.241, v2 automatic negotiation, 25 August | Two-session credential-free `mcp list` observation against exact protected main `c679b6f` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
 | Claude Code 2.1.245, v2 automatic negotiation, 25 August | Fresh two-session credential-free `mcp list` observation after the parent-identity repair reached exact protected main `e905c63` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
 | Claude Code 2.1.245, bounded `HOST-002`, 26 August | One model-mediated `catalogue.search` call from exact protected main `5837bd6`, with independent receipt verification | `capability_pass` for the one bounded MCP `2026-07-28` case; exact-five and remote HTTP remain open |
+| Claude Code 2.1.245, bounded exact-five, 27 August | Five ordered model-mediated calls from exact protected main `029a9d5`, with independent contract, receipt, parity and relationship verification | `capability_pass` for local MCP `2026-07-28` STDIO exact-five; remote HTTP remains open |
 | VS Code 1.134.0 | Temporary workspace and MCP registry; prove correct window attachment | `not_ready`: no GitHub token and no proved chat attachment; zero MCP traffic |
 | Official SDK client | HTTP and STDIO discovery, calls, resources and shutdown | Accepted on protected `main` |
 
@@ -686,8 +703,9 @@ This record does not change either historical result. The 20 August
 modern-only attempt remains `not_ready` because it received `-32022`, and the
 uncommitted fallback observation remains exploratory. The later accepted
 `HOST-002` projection scores only its separately authorised bounded
-`catalogue.search` case. Complete the remaining exact-five desktop and remote HTTP
-evidence before claiming the full independent-host gate.
+`catalogue.search` case. The later exact-five projection separately closes local
+desktop STDIO model capability. Complete the remaining remote HTTP evidence before
+claiming the full independent-host gate.
 
 This fallback is local-only. Do not attach it to the existing ChatGPT tunnel,
 change that tunnel's profile, publish its address, activate a production tool or
@@ -841,6 +859,31 @@ boundary and procedure. The accepted pass closes only the single model-mediated
 `catalogue.search` case. It does not establish exact-five model capability, remote
 HTTP interoperability, live-provider readiness, registration, activation,
 deployment or release.
+
+The later verifier-produced
+[`Claude Code 2.1.245 exact-five capability projection`](../../tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+binds exact protected-main commit
+`029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+`96f75d96b1e0680465494834ddad8661539cbd62`. Its SHA-256 is
+`06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+Exact-main
+[CI run 33114396425](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396425)
+and
+[CodeQL run 33114396546](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396546)
+passed before the fresh observation. Claude Code `2.1.245`, reporting model
+`claude-sonnet-5`, completed all five ordered local STDIO calls over MCP
+`2026-07-28`, with seven requests and responses across two sessions. The final host
+result reported `stop_reason: "tool_use"`, `terminal_reason: "completed"` and seven
+turns. Independent verification accepted five distinct receipts, every output
+contract and parity check, and the search-to-inspection relationship. Raw capture
+remains local and owner-only. The deterministic fixture made one synthetic provider
+transport call and zero guarded live-provider API invocations.
+
+This closes local STDIO exact-five model capability only. It does not establish
+remote HTTP interoperability, live-provider readiness, registry publication, activation,
+deployment or release. See the
+[exact-five capability runbook](QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md) for the
+closed profile, terminal predicate and publication boundary.
 
 ## Historical failure-derived cases
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -16,8 +16,11 @@ event. Its deterministic, non-live and unscored `QUAL-206-HOST-015` case passes
 locally. The repository-only QUAL-206 preflight is accepted on protected `main`, but
 its evaluation receipts remain non-live, unscored and incomplete for release. A
 separate protected-main projection proves the exact-five journey over one real IPv4
-loopback listener only; remote-host acceptance is false and capability remains
-unscored.
+loopback listener only; that HTTP result remains capability-unscored and remote-host
+acceptance is false. A later protected-main Claude Code projection separately
+passes all five ordered calls over local MCP `2026-07-28` STDIO. It closes local
+STDIO model capability only; remote HTTP, live-provider and production gates remain
+open.
 Default capability lists remain empty, activation and publication remain blocked,
 and no public MCP service or API is deployed.
 

--- a/scripts/validate_contracts.py
+++ b/scripts/validate_contracts.py
@@ -922,7 +922,19 @@ def main() -> None:
         ),
         (
             "qual-206-claude-exact-five-capability-evidence-v1.schema.json",
-            [],
+            [
+                (
+                    "tests/interoperability/evidence/"
+                    "claude-code-2.1.245-exact-five-capability-2026-08-27.json",
+                    load_json(
+                        ROOT
+                        / "tests"
+                        / "interoperability"
+                        / "evidence"
+                        / "claude-code-2.1.245-exact-five-capability-2026-08-27.json"
+                    ),
+                )
+            ],
         ),
         (
             "qual-206-local-http-transport-preflight.schema.json",

--- a/tests/contract/test_qual_206_claude_exact_five_capability.py
+++ b/tests/contract/test_qual_206_claude_exact_five_capability.py
@@ -30,6 +30,22 @@ SESSION_SCHEMA = (
 PUBLIC_SCHEMA = (
     ROOT / "schemas/qual-206-claude-exact-five-capability-evidence-v1.schema.json"
 )
+PUBLIC_EVIDENCE_PATH = (
+    ROOT
+    / "tests"
+    / "interoperability"
+    / "evidence"
+    / "claude-code-2.1.245-exact-five-capability-2026-08-27.json"
+)
+PUBLIC_SOURCE_COMMIT = "029a9d5c7efcafcd45941194394384ee6c578fe9"
+PUBLIC_SOURCE_TREE = "96f75d96b1e0680465494834ddad8661539cbd62"
+PUBLIC_EVIDENCE_SHA256 = "06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6"
+PUBLIC_BOUNDARY = (
+    "One bounded Claude Code 2.1.245 model-mediated exact-five-v1 observation over "
+    "local MCP 2026-07-28 STDIO with a deterministic synthetic provider fixture. "
+    "This does not prove remote HTTP interoperability, a live geospatial provider, "
+    "registry publication, activation, deployment or release."
+)
 OPERATIONS = list(verifier.OPERATIONS)
 FORBIDDEN_PUBLIC = re.compile(
     r"(?:/Users/|/home/|/Volumes/|/private/tmp/|/tmp/|/var/folders/|"
@@ -894,13 +910,81 @@ class ClaudeExactFiveCapabilityContractsTest(unittest.TestCase):
         evidence_after = sorted((ROOT / "tests/interoperability/evidence").iterdir())
         self.assertEqual(evidence_after, evidence_before)
 
-    def test_no_exact_five_public_evidence_is_registered_before_a_live_run(self) -> None:
+    def test_public_evidence_is_exactly_registered_and_minimised(self) -> None:
         matches = sorted(
             (ROOT / "tests/interoperability/evidence").glob(
                 "claude-code-2.1.245-exact-five-capability-*.json"
             )
         )
-        self.assertEqual(matches, [])
+        self.assertEqual(matches, [PUBLIC_EVIDENCE_PATH])
+
+        raw = PUBLIC_EVIDENCE_PATH.read_bytes()
+        document = json.loads(raw)
+        self.assertEqual(hashlib.sha256(raw).hexdigest(), PUBLIC_EVIDENCE_SHA256)
+        self.assertEqual(list(validator(PUBLIC_SCHEMA).iter_errors(document)), [])
+
+        self.assertEqual(document["source"]["commit"], PUBLIC_SOURCE_COMMIT)
+        self.assertEqual(document["source"]["tree"], PUBLIC_SOURCE_TREE)
+        recorded_tree = subprocess.check_output(
+            ["git", "rev-parse", f"{PUBLIC_SOURCE_COMMIT}^{{tree}}"],
+            cwd=ROOT,
+            text=True,
+        ).strip()
+        self.assertEqual(recorded_tree, PUBLIC_SOURCE_TREE)
+        ancestry = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", PUBLIC_SOURCE_COMMIT, "HEAD"],
+            cwd=ROOT,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.assertEqual(ancestry.returncode, 0)
+
+        self.assertEqual(
+            document["claims"],
+            {
+                "local_stdio_exact_five_model_capability": True,
+                "remote_http_interoperability": False,
+                "live_geospatial_provider": False,
+                "registry_publication": False,
+                "activation": False,
+                "deployment": False,
+                "release": False,
+            },
+        )
+        self.assertEqual(document["transport"]["protocol"], "2026-07-28")
+        self.assertEqual(document["transport"]["session_count"], 2)
+        self.assertEqual(document["transport"]["request_count"], 7)
+        self.assertEqual(document["transport"]["response_count"], 7)
+        self.assertEqual(document["transport"]["tool_call_count"], 5)
+        self.assertEqual(document["transport"]["resource_read_count"], 0)
+        self.assertEqual(document["transport"]["resources_advertised"], 0)
+        self.assertEqual(document["transport"]["provider_transport_calls"], 1)
+        self.assertEqual(document["transport"]["guarded_provider_api_invocations"], 0)
+        self.assertEqual(document["result"]["classification"], "capability_pass")
+        self.assertEqual(document["result"]["operation_order"], OPERATIONS)
+        receipts = document["result"]["operation_receipts"]
+        self.assertEqual([item["operation"] for item in receipts], OPERATIONS)
+        self.assertEqual(len({item["receipt_id"] for item in receipts}), 5)
+        self.assertTrue(all(item["output_contract_valid"] for item in receipts))
+        self.assertTrue(all(item["receipt_verification_valid"] for item in receipts))
+        self.assertTrue(all(item["structured_plain_text_parity"] for item in receipts))
+        self.assertTrue(document["result"]["inspection_relationship"]["valid"])
+        self.assertTrue(document["result"]["independent_result_verification"])
+        self.assertTrue(document["result"]["model_output_match"])
+        self.assertEqual(document["result"]["claude_cli_reported_turns"], 7)
+        self.assertEqual(document["result"]["claude_cli_stop_reason"], "tool_use")
+        self.assertEqual(document["result"]["claude_cli_terminal_reason"], "completed")
+        self.assertEqual(document["result"]["agentic_turn_limit"], 10)
+        self.assertFalse(document["isolation"]["built_in_tools_available"])
+        self.assertFalse(document["isolation"]["mcp_subtree_network_access_allowed"])
+        self.assertTrue(document["private_capture"]["retained"])
+        self.assertFalse(document["private_capture"]["published"])
+        self.assertEqual(document["boundary"], PUBLIC_BOUNDARY)
+
+        rendered = raw.decode("utf-8")
+        self.assertIsNone(FORBIDDEN_PUBLIC.search(rendered))
+        self.assertFalse(nested_field_names(document) & FORBIDDEN_FIELDS)
 
     @unittest.skipUnless(
         sys.platform == "darwin",

--- a/tests/interoperability/README.md
+++ b/tests/interoperability/README.md
@@ -17,6 +17,9 @@ described in the
 [local HTTP transport preflight runbook](../../docs/operations/QUAL-206_LOCAL_HTTP_TRANSPORT_PREFLIGHT.md).
 The resulting classification remains local, non-live and capability-unscored;
 remote-host acceptance is false.
+The separate accepted Claude Code exact-five projection closes local STDIO model
+capability only; it does not upgrade this HTTP result or close remote-host
+acceptance.
 The normal gateway suite also routes the owner-only capture and independent
 verifier regressions, including safe Git object resolution, atomic public-output
 finalisation and process-group cleanup for a timed-out nested runner.
@@ -145,6 +148,21 @@ It records one model-mediated canonical `catalogue.search` call through MCP
 interoperability, a live geospatial provider, registry publication, activation,
 deployment or release. See the
 [capability runbook](../../docs/operations/QUAL-206_CLAUDE_CAPABILITY.md).
+
+The later verifier-produced
+[Claude Code 2.1.245 exact-five projection](evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+binds exact protected-main commit
+`029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+`96f75d96b1e0680465494834ddad8661539cbd62`, with SHA-256
+`06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+Claude Code `2.1.245`, reporting model `claude-sonnet-5`, made the five ordered
+MCP `2026-07-28` calls over local STDIO at reported turn 7. Independent verification
+accepted every output contract, five distinct receipts, structured/plain-text
+parity and the search-to-inspection relationship. The deterministic fixture made
+one synthetic provider transport call and zero guarded live-provider API
+invocations. Raw capture remains owner-only and local. This closes local STDIO
+exact-five model capability only; remote HTTP, live-provider use, registry publication,
+activation, deployment and release remain false.
 
 See the [QUAL-206 interoperability runbook](../../docs/operations/QUAL-206_INTEROPERABILITY.md)
 for repeatable ChatGPT secure-tunnel and independent-host procedures.

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -99,6 +99,26 @@ interoperability, live geospatial-provider use, registry publication, activation
 deployment and release false. Raw Claude and MCP capture remains owner-only and
 local.
 
+The later
+[`Claude Code 2.1.245 exact-five capability projection`](claude-code-2.1.245-exact-five-capability-2026-08-27.json)
+is a fresh verifier-produced pass from exact protected-main commit
+`029a9d5c7efcafcd45941194394384ee6c578fe9`, tree
+`96f75d96b1e0680465494834ddad8661539cbd62`, with projection SHA-256
+`06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`.
+Every exact-main CI job passed in
+[run 33114396425](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396425),
+and every analysis passed in
+[CodeQL run 33114396546](https://github.com/chris-page-gov/gis-ai-go/actions/runs/33114396546).
+Claude Code `2.1.245`, reporting model `claude-sonnet-5`, completed the five ordered
+MCP `2026-07-28` calls over local STDIO. The verifier accepted all five distinct
+receipts, every result contract, structured/plain-text parity, the inspection
+relationship and the documented `tool_use` plus `completed` terminal form at
+reported turn 7. The deterministic fixture made one synthetic provider transport
+call and zero guarded live-provider API invocations. This closes local STDIO
+exact-five model capability only. Remote HTTP interoperability, a live geospatial
+provider, registry publication, activation, deployment and release remain false.
+Raw capture remains owner-only and local.
+
 The
 [`protected-main local HTTP transport preflight`](local-http-transport-preflight-2026-08-25.json)
 is a separate path-free projection from exact protected-main commit

--- a/tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json
+++ b/tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json
@@ -1,0 +1,215 @@
+{
+  "schema": "gis-ai-go.qual-206-claude-exact-five-capability-evidence.v1",
+  "status": "capability_pass",
+  "observed_at": "2026-08-27T20:55:58.173Z",
+  "source": {
+    "repository": "chris-page-gov/gis-ai-go",
+    "repository_origin": "https://github.com/chris-page-gov/gis-ai-go.git",
+    "commit": "029a9d5c7efcafcd45941194394384ee6c578fe9",
+    "tree": "96f75d96b1e0680465494834ddad8661539cbd62",
+    "version": "0.1.0",
+    "local_origin_main_match": true,
+    "protected_main_verification": "external-publication-gate",
+    "production_activation": false
+  },
+  "host": {
+    "name": "Claude Code",
+    "version": "2.1.245",
+    "executable_bytes": 376109392,
+    "executable_sha256": "9f7c2260251765a18d0b35198669dacc1912f6e8129a3b01f6b58d93365ff1f1",
+    "model_requested": "claude-sonnet-5",
+    "auth_kind": "first-party-login",
+    "auth_preflight": {
+      "logged_in": true,
+      "api_provider": "firstParty",
+      "auth_method": "claude.ai",
+      "subscription_type_observed": true
+    },
+    "model_provider_usage_observed": true,
+    "guarded_provider_api_invocations": 0
+  },
+  "profile": {
+    "id": "exact-five-v1",
+    "profile_sha256": "3d70ea0bf8ca83a9c1da76a88920907384211c125be0d51427a417342a89c8ef",
+    "prompt_sha256": "6625234b2968f0adefd3682cb21d822e8054fbc2d29e640c089d06cce4ca5f1d",
+    "operation_order": [
+      "catalogue.search",
+      "catalogue.describe",
+      "selection.resolve",
+      "data.query",
+      "evidence.inspect"
+    ],
+    "prompt_text_repeated_in_projection": false
+  },
+  "transport": {
+    "protocol": "2026-07-28",
+    "kind": "operating-system-stdio-pipes",
+    "session_count": 2,
+    "request_count": 7,
+    "response_count": 7,
+    "tool_call_count": 5,
+    "resource_read_count": 0,
+    "resources_advertised": 0,
+    "provider_transport_calls": 1,
+    "aborted_provider_calls": 0,
+    "ledger_event_count": 4,
+    "guarded_provider_api_invocations": 0,
+    "tool_schema_projection": {
+      "canonical_contract": "urn:gis-ai-go:schema:evidence-inspect-operation-request:v1",
+      "canonical_tools_sha256": "d5f493f1002faebd2e21129f02fd41f3132d2881655bfd0c8fb4297887b45faf",
+      "changed_operations": [
+        "evidence.inspect"
+      ],
+      "presented_contract": "urn:gis-ai-go:schema:evidence-inspect-request:v1",
+      "presented_tools_sha256": "3264923f6f822fe74afca0a04a418e0350f4e12fb76eec2a6fd97aa5b2c2fa72",
+      "profile": "exact-five-v1",
+      "projection_id": "evidence-inspect-receipt-id-v1",
+      "schema": "gis-ai-go.qual-206-claude-exact-five-tool-projection.v1",
+      "source_operation": "evidence.inspect"
+    }
+  },
+  "result": {
+    "classification": "capability_pass",
+    "capability": "passed",
+    "profile": "exact-five-v1",
+    "operation_order": [
+      "catalogue.search",
+      "catalogue.describe",
+      "selection.resolve",
+      "data.query",
+      "evidence.inspect"
+    ],
+    "operation_receipts": [
+      {
+        "operation": "catalogue.search",
+        "ordinal": 0,
+        "output_contract_valid": true,
+        "receipt_id": "gis-ai-go:evidence-receipt:sha256:03038fda49d0d7f934f0192f3d755988d59753dcf647090015332a0475e78f16",
+        "receipt_verification_valid": true,
+        "structured_plain_text_parity": true
+      },
+      {
+        "operation": "catalogue.describe",
+        "ordinal": 1,
+        "output_contract_valid": true,
+        "receipt_id": "gis-ai-go:evidence-receipt:sha256:7df79e16266b55a82661ae6f6b525088fb88cf91c80bd502d4a3b2015c220f78",
+        "receipt_verification_valid": true,
+        "structured_plain_text_parity": true
+      },
+      {
+        "operation": "selection.resolve",
+        "ordinal": 2,
+        "output_contract_valid": true,
+        "receipt_id": "gis-ai-go:evidence-receipt:sha256:19bab48947380c4874be2888a9999b73e94f723c183da5b8ebf88a3d0abc26f6",
+        "receipt_verification_valid": true,
+        "structured_plain_text_parity": true
+      },
+      {
+        "operation": "data.query",
+        "ordinal": 3,
+        "output_contract_valid": true,
+        "receipt_id": "gis-ai-go:evidence-receipt:sha256:ff4c820f8cd633cf6205442eaacd9397c9e7d9cf71706e8455c0129d8aed41ef",
+        "receipt_verification_valid": true,
+        "structured_plain_text_parity": true
+      },
+      {
+        "operation": "evidence.inspect",
+        "ordinal": 4,
+        "output_contract_valid": true,
+        "receipt_id": "gis-ai-go:evidence-receipt:sha256:0868035d5f2916dcdb9dad3df10c17483a4415921958a36e13ed6bad9f5af572",
+        "receipt_verification_valid": true,
+        "structured_plain_text_parity": true
+      }
+    ],
+    "inspection_relationship": {
+      "inspected_receipt_id": "gis-ai-go:evidence-receipt:sha256:03038fda49d0d7f934f0192f3d755988d59753dcf647090015332a0475e78f16",
+      "inspection_receipt_id": "gis-ai-go:evidence-receipt:sha256:0868035d5f2916dcdb9dad3df10c17483a4415921958a36e13ed6bad9f5af572",
+      "search_receipt_id": "gis-ai-go:evidence-receipt:sha256:03038fda49d0d7f934f0192f3d755988d59753dcf647090015332a0475e78f16",
+      "valid": true
+    },
+    "independent_result_verification": true,
+    "model_output_match": true,
+    "model_reported": "claude-sonnet-5",
+    "model_usage_observed": true,
+    "input_tokens": 54431,
+    "output_tokens": 1908,
+    "claude_cli_reported_turns": 7,
+    "claude_cli_stop_reason": "tool_use",
+    "claude_cli_terminal_reason": "completed",
+    "agentic_turn_limit": 10,
+    "turn_count_semantics": "claude-code-2.1.245-cli-configured-max-turns-ten-reported-num-turns-at-most-eleven",
+    "client_exit_code": 0
+  },
+  "isolation": {
+    "built_in_tools_available": false,
+    "allowed_mcp_tool_count": 5,
+    "claude_permission_aliases": [
+      "mcp__gis-ai-go-qual-206-exact-five-v1__catalogue_search",
+      "mcp__gis-ai-go-qual-206-exact-five-v1__catalogue_describe",
+      "mcp__gis-ai-go-qual-206-exact-five-v1__selection_resolve",
+      "mcp__gis-ai-go-qual-206-exact-five-v1__data_query",
+      "mcp__gis-ai-go-qual-206-exact-five-v1__evidence_inspect"
+    ],
+    "permission_mode": "dontAsk",
+    "session_persistence": false,
+    "maximum_agentic_turns": 10,
+    "mcp_subtree_network_access_allowed": false,
+    "mcp_subtree_network_sandbox": "macos-seatbelt-deny-network",
+    "mcp_child_recognised_credentials_forwarded": false,
+    "raw_host_output_published": false
+  },
+  "runtime_binding": {
+    "tracked_source_material_count": 18,
+    "generated_first_party_closure": {
+      "bytes": 2266594,
+      "file_count": 278,
+      "manifest_sha256": "f08e8d16823610e4e2ecea8999da7fac311e9c3ac545f5d0047688477e791f7a",
+      "reference_manifest_sha256": "f08e8d16823610e4e2ecea8999da7fac311e9c3ac545f5d0047688477e791f7a",
+      "reference_matches_current": true
+    },
+    "installed_dependency_closure": {
+      "bytes": 137178519,
+      "entry_count": 5396,
+      "manifest_sha256": "90e7021a75394d28d01767ecbe181b179512a2489d9b0a2b59480881cd160f7f"
+    },
+    "node_runtime": {
+      "bytes": 50320,
+      "sha256": "1ef99ea25fe70c9b67e7efe768ef8ee22148d3cabc703db6131b57aeb617d040",
+      "version": "26.7.0"
+    },
+    "network_sandbox": {
+      "bytes": 102560,
+      "profile_sha256": "0a5222386587bf836d30a070bd759c0194f999bf5503ba76c6c0f8cb84b19db2",
+      "sha256": "8290e4be7387a0df83cd1559e86afd880464f269450573d012795761fe298f16"
+    },
+    "network_sandbox_probe": {
+      "fsync_pass": true,
+      "loopback_denied": true,
+      "probe_script_sha256": "c6540fbbb22b0c3b965a6ce5dceb81eb2064e99ceb324c122db31ad6f0a8f426"
+    },
+    "complete_first_party_generated_closure_binding": false,
+    "third_party_runtime_binding": "installed-closure-digest-plus-pnpm-lockfile",
+    "complete_runtime_source_binding": false,
+    "dependency_materials_stable": true,
+    "runtime_materials_stable": true,
+    "source_checkout_stable": true
+  },
+  "claims": {
+    "local_stdio_exact_five_model_capability": true,
+    "remote_http_interoperability": false,
+    "live_geospatial_provider": false,
+    "registry_publication": false,
+    "activation": false,
+    "deployment": false,
+    "release": false
+  },
+  "private_capture": {
+    "retained": true,
+    "published": false,
+    "manifest_sha256": "758e782736aa629915a3ced78b75b320249602d926db7c2d3a656d19bc136c0e",
+    "stdout_sha256": "5d5df18100af7f46c970ccbd3d345adeb3397a8747b5078debbb9bc1592b44d2",
+    "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "result_material_sha256": "905f319c5aed2b456e3c3ccbe161d3981adb2a1dad9b915fb2df0213494ecdbd"
+  },
+  "boundary": "One bounded Claude Code 2.1.245 model-mediated exact-five-v1 observation over local MCP 2026-07-28 STDIO with a deterministic synthetic provider fixture. This does not prove remote HTTP interoperability, a live geospatial provider, registry publication, activation, deployment or release."
+}


### PR DESCRIPTION
## Outcome

Publish the minimised public projection from the fresh Claude Code 2.1.245
exact-five observation after the terminal-state correction reached protected
`main`.

This change:

- registers the evidence against its closed schema;
- locks its exact path, SHA-256, source commit/tree, claims and minimisation
  boundary in contract tests;
- records all five ordered MCP `2026-07-28` calls, five distinct verified
  receipts, structured/plain-text parity and the inspection relationship; and
- updates the QUAL-206 status and runbooks so local STDIO exact-five model
  capability is closed while remote HTTP and production gates stay open.

## Provenance

- observed source commit: `029a9d5c7efcafcd45941194394384ee6c578fe9`
- observed source tree: `96f75d96b1e0680465494834ddad8661539cbd62`
- public projection SHA-256:
  `06311b896963503bd7f6f88d32d34edfda52afb49b3d9e5b6c05eaed3230f0a6`
- exact-main CI: run `33114396425`, all jobs passed
- exact-main CodeQL: run `33114396546`, all analyses passed

The accepted run used two sessions, seven requests and responses, exactly five
ordered tool calls and zero resource reads. The deterministic fixture made one
synthetic provider transport call and zero guarded live-provider API invocations.
Raw capture remains owner-only and local.

## Boundary

This does not prove remote HTTP interoperability, a live geospatial provider,
registry publication, activation, deployment or release. It changes no gateway,
canonical tool, schema, provider adapter, activation list or runtime entrypoint.

## Verification

- `node --test tests/interoperability/test_qual_206_claude_exact_five_capability_harness.mjs` — 11 passed
- `./.venv/bin/python -m unittest tests.contract.test_qual_206_claude_exact_five_capability` — 5 passed
- `./.venv/bin/python -m unittest tests.contract.test_qual_206_claude_capability` — 7 passed
- `pnpm run validate:contracts` — 87 schemas and 107 records
- `pnpm run validate:links` — 471 local links
- `pnpm run validate:secrets`
- `git diff --check`

Related: #24 and #25.
