### PR TITLE
fix(qual-206): reload Git tree control plans

### DIFF
--- a/changelog.d/QUAL-206-chatgpt-plan-reload.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-plan-reload.fixed.md
@@ -1,0 +1,4 @@
+- Fix the bounded ChatGPT tunnel pack so a prepared control plan accepts the
+  repository's 40-character Git tree object identity when it is reloaded before
+  connection. A regression rejects an incorrect 64-character SHA-256 substitution;
+  no tunnel, provider, activation or deployment behaviour is widened.

--- a/scripts/qual_206_chatgpt_tunnel_exact_five_harness.mjs
+++ b/scripts/qual_206_chatgpt_tunnel_exact_five_harness.mjs
@@ -38,7 +38,7 @@ const PROFILE_NAME = "gis-ai-go-v0-2-exact-five-v1";
 const CLIENT_LABEL = "chatgpt-openai-tunnel-client-0.0.13";
 const STATUS_SCHEMA = "gis-ai-go.qual-206-chatgpt-tunnel-status.v1";
 const PLAN_SCHEMA = "gis-ai-go.qual-206-chatgpt-tunnel-control-plan.v1";
-const FULL_COMMIT = /^[0-9a-f]{40}$/u;
+const GIT_OBJECT_ID = /^[0-9a-f]{40}$/u;
 const SHA256 = /^[0-9a-f]{64}$/u;
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -268,7 +268,9 @@ function runGit(args, allowFailure = false) {
 }
 
 export function verifyProtectedMainCheckout(sourceCommit) {
-  if (!FULL_COMMIT.test(sourceCommit)) fail("source commit must be a full lowercase SHA");
+  if (!GIT_OBJECT_ID.test(sourceCommit)) {
+    fail("source commit must be a full lowercase SHA");
+  }
   const head = runGit(["rev-parse", "HEAD"]);
   const originMain = runGit(["rev-parse", "origin/main"]);
   const tree = runGit(["rev-parse", "HEAD^{tree}"]);
@@ -448,7 +450,7 @@ export function parseChatGptTunnelHarnessArguments(argv, environment = process.e
   }
   if (phase === "prepare") {
     if (!UUID_V4.test(values.get("--run-id"))) fail("run ID must be a UUID v4");
-    if (!FULL_COMMIT.test(values.get("--source-commit"))) {
+    if (!GIT_OBJECT_ID.test(values.get("--source-commit"))) {
       fail("source commit must be a full lowercase SHA");
     }
     if (!RUNTIME_KEY_ENVIRONMENT_NAMES.has(values.get("--runtime-key-env"))) {
@@ -534,7 +536,7 @@ function commandEnvironment(plan, requireRuntimeKey, ambientEnvironment = proces
   return environment;
 }
 
-function validatePlan(plan, operatorRoot) {
+export function validateTunnelControlPlan(plan, operatorRoot) {
   if (
     !plainRecord(plan) ||
     plan.schema !== PLAN_SCHEMA ||
@@ -544,8 +546,8 @@ function validatePlan(plan, operatorRoot) {
     plan.tunnel_id !== TUNNEL_ID ||
     plan.tunnel_name !== TUNNEL_NAME ||
     !UUID_V4.test(plan.run_id) ||
-    !FULL_COMMIT.test(plan.source_commit) ||
-    !SHA256.test(plan.source_tree) ||
+    !GIT_OBJECT_ID.test(plan.source_commit) ||
+    !GIT_OBJECT_ID.test(plan.source_tree) ||
     !isAbsolute(plan.client_path) ||
     !SHA256.test(plan.client_sha256) ||
     !Number.isSafeInteger(plan.client_dev) ||
@@ -609,10 +611,10 @@ function readPrivatePlan(path) {
   }
 }
 
-function loadPlan(operatorRoot) {
+export function loadTunnelControlPlan(operatorRoot) {
   ensurePrivateDirectory(operatorRoot);
   const path = join(operatorRoot, PLAN_FILE);
-  return validatePlan(readPrivatePlan(path), operatorRoot);
+  return validateTunnelControlPlan(readPrivatePlan(path), operatorRoot);
 }
 
 export function executeBoundedTunnelCommand(
@@ -1016,7 +1018,7 @@ async function main() {
     result = prepare(options);
     runId = result.run_id;
   } else {
-    const plan = loadPlan(options.operatorRoot);
+    const plan = loadTunnelControlPlan(options.operatorRoot);
     runId = plan.run_id;
     if (options.phase === "connect") result = runPreparedTunnelConnect(plan);
     if (options.phase === "status-after") result = runPreparedTunnelStatusAfter(plan);

--- a/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_harness.mjs
+++ b/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_harness.mjs
@@ -5,6 +5,7 @@ import {
   chmodSync,
   copyFileSync,
   existsSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -20,12 +21,14 @@ import test from "node:test";
 import {
   buildObserverCommand,
   executeBoundedTunnelCommand,
+  loadTunnelControlPlan,
   parseChatGptTunnelHarnessArguments,
   projectStoppedTunnelStatus,
   projectTunnelStatus,
   runPreparedTunnelConnect,
   runPreparedTunnelStatusAfter,
   runPreparedTunnelStop,
+  validateTunnelControlPlan,
   validatePrivateRootLayout,
   verifyTunnelClient,
 } from "../../scripts/qual_206_chatgpt_tunnel_exact_five_harness.mjs";
@@ -612,6 +615,65 @@ test("private roots must be new siblings beneath one owner-only parent", (t) => 
       join(process.cwd(), "operator"),
     ),
     /outside the Git checkout/u,
+  );
+});
+
+test("a prepared control plan reloads the repository's real Git tree identity", (t) => {
+  const parent = mkdtempSync(join(tmpdir(), "gis-ai-go-control-plan-test-"));
+  const captureRoot = join(parent, "capture");
+  const operatorRoot = join(parent, "operator");
+  mkdirSync(captureRoot, { mode: 0o700 });
+  mkdirSync(operatorRoot, { mode: 0o700 });
+  t.after(() => rmSync(parent, { force: true, recursive: true }));
+  const identity = (path) => {
+    const info = lstatSync(path);
+    return { dev: info.dev, ino: info.ino, uid: info.uid, mode: info.mode };
+  };
+  const plan = {
+    schema: "gis-ai-go.qual-206-chatgpt-tunnel-control-plan.v1",
+    run_id: randomUUID(),
+    source_commit: "a".repeat(40),
+    source_tree: "b".repeat(40),
+    repository_origin: "https://github.com/chris-page-gov/gis-ai-go.git",
+    clean_detached_checkout: true,
+    capture_root: captureRoot,
+    operator_root: operatorRoot,
+    capture_root_identity: identity(captureRoot),
+    operator_root_identity: identity(operatorRoot),
+    client_path: join(operatorRoot, "tunnel-client-v0.0.13"),
+    client_version: "0.0.13",
+    client_build_sha: "c".repeat(40),
+    client_reported_version: "0.0.13+test",
+    client_bytes: 20_336_818,
+    client_sha256: "d".repeat(64),
+    client_dev: 101,
+    client_ino: 202,
+    client_nlink: 1,
+    client_uid: process.getuid(),
+    client_mode: 0o100500,
+    tunnel_id: TUNNEL_ID,
+    tunnel_name: TUNNEL_NAME,
+    alias: ALIAS,
+    profile_name: ALIAS,
+    runtime_key_environment: "OPENAI_API_KEY",
+    runtime: RUNTIME,
+    mcp_command: MCP_COMMAND,
+    mcp_command_sha256: MCP_COMMAND_SHA256,
+  };
+
+  assert.equal(validateTunnelControlPlan(plan, operatorRoot), plan);
+  writeFileSync(
+    join(operatorRoot, "qual-206-chatgpt-tunnel-control-plan.v1.json"),
+    `${JSON.stringify(plan)}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  assert.deepEqual(loadTunnelControlPlan(operatorRoot), plan);
+  assert.throws(
+    () => validateTunnelControlPlan(
+      { ...plan, source_tree: "e".repeat(64) },
+      operatorRoot,
+    ),
+    /private tunnel control plan is invalid/u,
   );
 });
 


### PR DESCRIPTION
## Outcome

Fix the bounded ChatGPT tunnel pack so the private plan produced by `prepare`
can be read back before `connect`.

The repository uses SHA-1 Git object identities. `git rev-parse HEAD^{tree}`
therefore produces 40 lowercase hexadecimal characters, but the reload gate
incorrectly required the tree identity to be a 64-character SHA-256 value. The
pack failed closed before opening the tunnel.

## Change

- validate the source commit and source tree as 40-character Git object IDs;
- keep client, command and runtime-closure SHA-256 checks unchanged;
- exercise the real owner-only plan write, bounded read and reload path;
- reject the incorrect 64-character tree substitution; and
- record the correction in a changelog fragment.

## Verification

- 40 Node exact-five harness and observer tests pass;
- 23 Python exact-five contract tests pass;
- the actual prepared plan from the failed pre-network run reloads successfully;
- 93 schemas and 153 records validate, including 10 rejected mutations;
- 474 Markdown links, 183 research hashes, 2 ledgers and 71 sources pass;
- 864 text files pass the secret and machine-path scan; and
- independent review found no P0 or P1 issue and prompted the real file-reload
  regression.

## Boundary

No tunnel, provider call, activation, registration, deployment or release is
introduced by this pull request. The observed failure occurred before network
activity, and the authorised ChatGPT observation will restart only from fresh
roots after this fix reaches protected `main`.
