### PR TITLE
fix(qual-206): prove current tunnel poll readiness

### DIFF
--- a/changelog.d/QUAL-206-chatgpt-poll-readiness.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-poll-readiness.fixed.md
@@ -1,0 +1,3 @@
+Fix the QUAL-206 ChatGPT tunnel readiness gate so it uses tunnel-client v0.0.13's
+credential-free successful-poll probe for the current runtime, with a narrowly
+bounded startup retry and fail-closed error handling.

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -268,15 +268,39 @@ that downstream fixture: the observer starts it through the reviewed macOS
 describes the fixture process and must not be read as a claim that the immediate
 observer process is itself network-sandboxed.
 
-Connect success is insufficient by itself. The harness immediately obtains a fresh
-JSON status and emits only an endpoint-free `tunnel-status-before.json`. It requires:
+Connect success is insufficient by itself. The harness obtains a fresh JSON status,
+then invokes the reviewed client's credential-free
+`health --url-file ... --pid ... --require-control-plane-poll --json` probe before
+it emits an endpoint-free `tunnel-status-before.json`. It requires:
 
 - exact local alias, remote tunnel ID and remote name;
 - the fixed profile and SHA-256 digest of the exact reviewed MCP command;
 - successful remote lookup with no local or remote error and no stale state;
 - managed process running, runtime state `ready`, healthy and ready true;
 - effective local `/healthz` and `/readyz` status `200`; and
-- a healthy or direct control-plane poll route of kind `control_plane`.
+- one recent successful control-plane poll, proved by a positive
+  `commands_poll_last_successful_timestamp_seconds` metric from the exact bound
+  loopback runtime. The timestamp must be an integer no more than 120 seconds old;
+  only 5 seconds of future clock skew is tolerated.
+
+In tunnel-client `v0.0.13`, `runtimes status` can legitimately report
+`state: unknown` with `no live admin UI system snapshot` for the current managed
+runtime even when its local endpoints are ready. The harness does not turn that
+unknown state into a pass. It keeps the status identity checks and uses the
+client's purpose-built poll probe as the independent readiness condition. The
+probe receives no runtime credential, must resolve the exact owner-only health URL
+file to `127.0.0.1`, must confirm that the exact managed process ID is still
+running, and must return healthy `200` responses from both endpoints.
+
+The poll probe allows up to eight attempts, separated by 5 seconds, so the bounded
+window covers the reviewed client's 30-second long poll and 5-second deadline
+guardrail. Each probe command also has a 5-second execution cap. It
+retries only the exact first-party `no successful control-plane poll observed`
+startup result. Missing metrics, locator drift, endpoint failure, malformed output,
+stderr, a different error or any other exit fails closed and triggers the normal
+automatic teardown. The isolated tunnel process receives no proxy environment and
+the generated control-plane profile has no proxy configuration, so a successful
+poll remains bound to the direct control-plane route.
 
 Any mismatch fails closed.
 

--- a/scripts/qual_206_chatgpt_tunnel_exact_five_harness.mjs
+++ b/scripts/qual_206_chatgpt_tunnel_exact_five_harness.mjs
@@ -48,6 +48,12 @@ const RUNTIME_KEY_ENVIRONMENT_NAMES = new Set([
 ]);
 const MAX_COMMAND_OUTPUT_BYTES = 1_048_576;
 const MAX_COMMAND_MILLISECONDS = 60_000;
+const MAX_HEALTH_COMMAND_MILLISECONDS = 5_000;
+const POLL_HEALTH_ATTEMPTS = 8;
+const POLL_HEALTH_RETRY_MILLISECONDS = 5_000;
+const POLL_NOT_READY_ERROR = "no successful control-plane poll observed";
+const MAX_POLL_SUCCESS_AGE_SECONDS = 120;
+const MAX_POLL_SUCCESS_FUTURE_SKEW_SECONDS = 5;
 const SAFE_GIT_OPTIONS = Object.freeze([
   "-c",
   "core.fsmonitor=false",
@@ -617,12 +623,13 @@ export function loadTunnelControlPlan(operatorRoot) {
   return validateTunnelControlPlan(readPrivatePlan(path), operatorRoot);
 }
 
-export function executeBoundedTunnelCommand(
+function executeTunnelClientCommand(
   plan,
   label,
   args,
   requireRuntimeKey = true,
   dependencies = {},
+  timeout = MAX_COMMAND_MILLISECONDS,
 ) {
   const verifyClient = dependencies.verifyTunnelClient ?? verifyTunnelClient;
   const run = dependencies.spawnSync ?? spawnSync;
@@ -651,7 +658,7 @@ export function executeBoundedTunnelCommand(
     env: environment,
     maxBuffer: MAX_COMMAND_OUTPUT_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: MAX_COMMAND_MILLISECONDS,
+    timeout,
   });
   const finishedAt = new Date().toISOString();
   const stdout = typeof result.stdout === "string" ? result.stdout : "";
@@ -679,6 +686,23 @@ export function executeBoundedTunnelCommand(
   ) {
     fail("tunnel client changed while the bounded command executed");
   }
+  return Object.freeze({ result, stdout, stderr });
+}
+
+export function executeBoundedTunnelCommand(
+  plan,
+  label,
+  args,
+  requireRuntimeKey = true,
+  dependencies = {},
+) {
+  const { result, stdout } = executeTunnelClientCommand(
+    plan,
+    label,
+    args,
+    requireRuntimeKey,
+    dependencies,
+  );
   if (result.error || result.status !== 0) {
     fail(`${label} failed closed`);
   }
@@ -693,6 +717,119 @@ function nullableEmpty(value, label) {
 function nestedRecord(value, key, label) {
   if (!plainRecord(value) || !plainRecord(value[key])) fail(`${label} is missing ${key}`);
   return value[key];
+}
+
+function emptyOrAbsent(value) {
+  return value === null || value === undefined || value === "";
+}
+
+function expectedHealthUrlFile(plan) {
+  return join(
+    plan.operator_root,
+    "tunnel-state",
+    "health",
+    `${LOCAL_ALIAS}.url`,
+  );
+}
+
+function validateLoopbackBaseUrl(value, label) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail(`${label} is not a valid URL`);
+  }
+  if (
+    parsed.protocol !== "http:" ||
+    parsed.hostname !== "127.0.0.1" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    !/^[0-9]{1,5}$/u.test(parsed.port) ||
+    Number(parsed.port) < 1 ||
+    Number(parsed.port) > 65_535
+  ) {
+    fail(`${label} is not an exact loopback HTTP base URL`);
+  }
+  return parsed.origin;
+}
+
+function validatePollHealthEnvelope(raw, healthUrlFile, expectedPid) {
+  if (!plainRecord(raw)) fail("control-plane poll health input is invalid");
+  const locator = nestedRecord(raw, "locator", "control-plane poll health");
+  const processRecord = nestedRecord(raw, "process", "control-plane poll health");
+  const healthz = nestedRecord(raw, "healthz", "control-plane poll health");
+  const readyz = nestedRecord(raw, "readyz", "control-plane poll health");
+  const poll = nestedRecord(raw, "control_plane_poll", "control-plane poll health");
+  const baseUrl = validateLoopbackBaseUrl(
+    locator.resolved_base_url,
+    "control-plane poll health locator",
+  );
+  if (
+    locator.kind !== "url_file" ||
+    locator.url_file !== healthUrlFile ||
+    !emptyOrAbsent(locator.error) ||
+    processRecord.pid !== expectedPid ||
+    processRecord.running !== true ||
+    !emptyOrAbsent(processRecord.error) ||
+    raw.base_url !== baseUrl ||
+    healthz.url !== `${baseUrl}/healthz` ||
+    healthz.ok !== true ||
+    healthz.status !== 200 ||
+    healthz.body !== "live" ||
+    !emptyOrAbsent(healthz.error) ||
+    readyz.url !== `${baseUrl}/readyz` ||
+    readyz.ok !== true ||
+    readyz.status !== 200 ||
+    readyz.body !== "ready" ||
+    !emptyOrAbsent(readyz.error) ||
+    poll.url !== `${baseUrl}/metrics`
+  ) {
+    fail("control-plane poll health does not bind the ready loopback runtime");
+  }
+  return poll;
+}
+
+export function validateSuccessfulPollHealth(
+  raw,
+  healthUrlFile,
+  expectedPid,
+  nowMilliseconds = Date.now(),
+) {
+  const poll = validatePollHealthEnvelope(raw, healthUrlFile, expectedPid);
+  const nowSeconds = nowMilliseconds / 1_000;
+  const pollAgeSeconds = nowSeconds - poll.value;
+  if (
+    raw.result !== "ok" ||
+    poll.ok !== true ||
+    !Number.isSafeInteger(poll.value) ||
+    poll.value <= 0 ||
+    pollAgeSeconds < -MAX_POLL_SUCCESS_FUTURE_SKEW_SECONDS ||
+    pollAgeSeconds > MAX_POLL_SUCCESS_AGE_SECONDS ||
+    !emptyOrAbsent(poll.error)
+  ) {
+    fail("control-plane poll health does not prove a recent successful poll");
+  }
+  return Object.freeze({ state: "healthy", route_kind: "control_plane" });
+}
+
+function validatePendingPollHealth(raw, healthUrlFile, expectedPid) {
+  const poll = validatePollHealthEnvelope(raw, healthUrlFile, expectedPid);
+  if (
+    raw.result !== "fail" ||
+    poll.ok !== false ||
+    Object.hasOwn(poll, "value") ||
+    poll.error !== POLL_NOT_READY_ERROR
+  ) {
+    fail("control-plane poll health failed outside the bounded startup state");
+  }
+}
+
+function waitForPollRetry(milliseconds) {
+  const signal = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  Atomics.wait(signal, 0, 0, milliseconds);
 }
 
 function validateRuntimeBinding(raw, expectedMcpCommandSha256) {
@@ -716,26 +853,24 @@ function validateRuntimeBinding(raw, expectedMcpCommandSha256) {
   });
 }
 
-export function projectTunnelStatus(
-  raw,
-  phase,
-  expectedMcpCommandSha256,
-  observedAt = new Date().toISOString(),
-) {
-  if (!plainRecord(raw) || !["before", "after"].includes(phase)) {
-    fail("tunnel status input is invalid");
-  }
+function validateReadyTunnelStatus(raw, expectedMcpCommandSha256, healthUrlFile) {
+  if (!plainRecord(raw)) fail("tunnel status input is invalid");
   const binding = validateRuntimeBinding(raw, expectedMcpCommandSha256);
+  const processRecord = nestedRecord(raw, "process", "ready tunnel status");
   const remote = raw.remote;
   const local = raw.local;
   const effectiveHealth = nestedRecord(local, "effective_health", "local status");
   const healthz = nestedRecord(effectiveHealth, "healthz", "effective health");
   const readyz = nestedRecord(effectiveHealth, "readyz", "effective health");
-  const poll = raw.control_plane_poll_health;
-  const route = nestedRecord(poll, "route", "control-plane poll health");
-  const pollState = poll.state;
-  const routeHealthy = ["healthy", "direct"].includes(pollState) &&
+  const poll = nestedRecord(raw, "control_plane_poll_health", "tunnel status");
+  const route = poll.route;
+  const directRoute = plainRecord(route) &&
+    ["healthy", "direct"].includes(poll.state) &&
     route.kind === "control_plane";
+  const currentRuntimeSnapshotUnavailable =
+    poll.state === "unknown" &&
+    poll.reason === "no live admin UI system snapshot" &&
+    !Object.hasOwn(poll, "route");
   if (
     raw.alias !== LOCAL_ALIAS ||
     raw.tunnel_id !== TUNNEL_ID ||
@@ -743,19 +878,44 @@ export function projectTunnelStatus(
     remote.id !== TUNNEL_ID ||
     remote.name !== TUNNEL_NAME ||
     raw.stale !== false ||
+    !emptyOrAbsent(raw.error) ||
+    !emptyOrAbsent(raw.remote_error) ||
     raw.runtime_state !== "ready" ||
     raw.healthy !== true ||
     raw.ready !== true ||
     raw.remote_lookup_attempted !== true ||
     raw.process_running !== true ||
+    processRecord.mode !== "process" ||
+    !positiveInteger(processRecord.pid) ||
+    raw.health_url_file !== healthUrlFile ||
     healthz.ok !== true ||
     healthz.status !== 200 ||
     readyz.ok !== true ||
     readyz.status !== 200 ||
-    !routeHealthy
+    (!directRoute && !currentRuntimeSnapshotUnavailable)
   ) {
     fail("tunnel status does not establish the required healthy ready identity");
   }
+  return Object.freeze({ binding, healthz, readyz, pid: processRecord.pid });
+}
+
+export function projectTunnelStatus(
+  raw,
+  pollHealth,
+  phase,
+  expectedMcpCommandSha256,
+  healthUrlFile,
+  observedAt = new Date().toISOString(),
+) {
+  if (!["before", "after"].includes(phase)) {
+    fail("tunnel status input is invalid");
+  }
+  const { binding, pid } = validateReadyTunnelStatus(
+    raw,
+    expectedMcpCommandSha256,
+    healthUrlFile,
+  );
+  const pollProjection = validateSuccessfulPollHealth(pollHealth, healthUrlFile, pid);
   return Object.freeze({
     schema: STATUS_SCHEMA,
     phase,
@@ -770,10 +930,7 @@ export function projectTunnelStatus(
     runtime_state: "ready",
     healthy: true,
     ready: true,
-    control_plane_poll_health: Object.freeze({
-      state: pollState,
-      route_kind: "control_plane",
-    }),
+    control_plane_poll_health: pollProjection,
     remote_lookup_attempted: true,
     process_running: true,
     local: Object.freeze({
@@ -855,7 +1012,55 @@ function captureStatus(plan, phase, dependencies = {}) {
     true,
     dependencies,
   );
-  const status = projectTunnelStatus(raw, phase, plan.mcp_command_sha256);
+  const healthUrlFile = expectedHealthUrlFile(plan);
+  const { pid } = validateReadyTunnelStatus(
+    raw,
+    plan.mcp_command_sha256,
+    healthUrlFile,
+  );
+  let pollHealth;
+  for (let attempt = 1; attempt <= POLL_HEALTH_ATTEMPTS; attempt += 1) {
+    const label = `tunnel-poll-health-${phase}-attempt-${attempt}-raw`;
+    const { result, stdout, stderr } = executeTunnelClientCommand(
+      plan,
+      label,
+      [
+        "health",
+        "--url-file",
+        healthUrlFile,
+        "--pid",
+        String(pid),
+        "--require-control-plane-poll",
+        "--json",
+      ],
+      false,
+      dependencies,
+      MAX_HEALTH_COMMAND_MILLISECONDS,
+    );
+    if (result.error || result.signal !== null || stderr !== "") {
+      fail(`${label} failed closed`);
+    }
+    const candidate = parseJson(stdout, `${label} stdout`);
+    if (result.status === 0) {
+      validateSuccessfulPollHealth(candidate, healthUrlFile, pid);
+      pollHealth = candidate;
+      break;
+    }
+    if (result.status !== 2) fail(`${label} failed closed`);
+    validatePendingPollHealth(candidate, healthUrlFile, pid);
+    if (attempt === POLL_HEALTH_ATTEMPTS) {
+      fail("control-plane poll did not succeed within the bounded readiness window");
+    }
+    const wait = dependencies.waitForPollRetry ?? waitForPollRetry;
+    wait(POLL_HEALTH_RETRY_MILLISECONDS);
+  }
+  const status = projectTunnelStatus(
+    raw,
+    pollHealth,
+    phase,
+    plan.mcp_command_sha256,
+    healthUrlFile,
+  );
   writePrivateJson(join(plan.capture_root, `tunnel-status-${phase}.json`), status);
   return status;
 }

--- a/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
+++ b/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
@@ -994,6 +994,9 @@ const tunnelId = "tunnel_6a873e7214308191bfe27240c1c03f68";
 const tunnelName = "gis-ai-go-v0-2-interoperability";
 const command = "/usr/bin/env -i synthetic-observer-command";
 const commandSha256 = createHash("sha256").update(command, "utf8").digest("hex");
+const healthUrlFile =
+  "/private/tmp/operator/tunnel-state/health/gis-ai-go-v0-2-exact-five-v1.url";
+const healthBaseUrl = "http://127.0.0.1:61234";
 const raw = {
   alias,
   tunnel_id: tunnelId,
@@ -1006,12 +1009,12 @@ const raw = {
   healthy: true,
   ready: true,
   control_plane_poll_health: {
-    state: "direct",
-    route: { kind: "control_plane", endpoint: "private-and-not-projected" },
-    history: ["private-and-not-projected"],
+    state: "unknown",
+    reason: "no live admin UI system snapshot",
   },
   remote_lookup_attempted: true,
   process_running: true,
+  health_url_file: healthUrlFile,
   process: {
     alias,
     tunnel_id: tunnelId,
@@ -1023,6 +1026,7 @@ const raw = {
   },
   local: {
     effective_health: {
+      base_url: healthBaseUrl,
       healthz: { ok: true, status: 200, url: "private-and-not-projected" },
       readyz: { ok: true, status: 200, url: "private-and-not-projected" },
     },
@@ -1030,8 +1034,33 @@ const raw = {
   },
   pid: 12345,
 };
+const pollHealth = {
+  locator: {
+    kind: "url_file",
+    url_file: healthUrlFile,
+    resolved_base_url: healthBaseUrl,
+  },
+  process: { pid: 12345, running: true },
+  base_url: healthBaseUrl,
+  ui_url: `${healthBaseUrl}/ui`,
+  healthz: {
+    url: `${healthBaseUrl}/healthz`, ok: true, status: 200, body: "live",
+  },
+  readyz: {
+    url: `${healthBaseUrl}/readyz`, ok: true, status: 200, body: "ready",
+  },
+  control_plane_poll: {
+    url: `${healthBaseUrl}/metrics`, value: Math.floor(Date.now() / 1000), ok: true,
+  },
+  result: "ok",
+};
 const ready = projectTunnelStatus(
-  raw, "before", commandSha256, "2026-08-27T12:00:00.000Z",
+  raw,
+  pollHealth,
+  "before",
+  commandSha256,
+  healthUrlFile,
+  "2026-08-27T12:00:00.000Z",
 );
 const stoppedRaw = {
   ...raw,
@@ -1085,7 +1114,7 @@ process.stdout.write(`${JSON.stringify([ready, stopped])}\n`);
         status_validator.validate(stopped)
         self.assertEqual(
             ready["control_plane_poll_health"],
-            {"state": "direct", "route_kind": "control_plane"},
+            {"state": "healthy", "route_kind": "control_plane"},
         )
         self.assertTrue(ready["local"]["direct_healthy_poll_route"])
         self.assertIsNone(stopped["control_plane_poll_health"])

--- a/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_harness.mjs
+++ b/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_harness.mjs
@@ -29,6 +29,7 @@ import {
   runPreparedTunnelStatusAfter,
   runPreparedTunnelStop,
   validateTunnelControlPlan,
+  validateSuccessfulPollHealth,
   validatePrivateRootLayout,
   verifyTunnelClient,
 } from "../../scripts/qual_206_chatgpt_tunnel_exact_five_harness.mjs";
@@ -41,6 +42,9 @@ import {
 const TUNNEL_ID = "tunnel_6a873e7214308191bfe27240c1c03f68";
 const TUNNEL_NAME = "gis-ai-go-v0-2-interoperability";
 const ALIAS = "gis-ai-go-v0-2-exact-five-v1";
+const HEALTH_URL_FILE =
+  "/private/tmp/operator/tunnel-state/health/gis-ai-go-v0-2-exact-five-v1.url";
+const HEALTH_BASE_URL = "http://127.0.0.1:61234";
 const macRuntimeTest = process.platform === "darwin" ? test : test.skip;
 
 function hash(bytes) {
@@ -74,7 +78,7 @@ test("the runbook selects the reviewed Node runtime for every command", () => {
   assert.ok((runbook.match(/^"\$QUAL206_NODE"\s/gmu) ?? []).length >= 6);
 });
 
-function validRawStatus() {
+function validRawStatus(healthUrlFile = HEALTH_URL_FILE, baseUrl = HEALTH_BASE_URL) {
   return {
     alias: ALIAS,
     tunnel_id: TUNNEL_ID,
@@ -87,12 +91,12 @@ function validRawStatus() {
     healthy: true,
     ready: true,
     control_plane_poll_health: {
-      state: "direct",
-      route: { kind: "control_plane", endpoint: "private-and-not-projected" },
-      history: ["private-and-not-projected"],
+      state: "unknown",
+      reason: "no live admin UI system snapshot",
     },
     remote_lookup_attempted: true,
     process_running: true,
+    health_url_file: healthUrlFile,
     process: {
       alias: ALIAS,
       tunnel_id: TUNNEL_ID,
@@ -104,6 +108,7 @@ function validRawStatus() {
     },
     local: {
       effective_health: {
+        base_url: baseUrl,
         healthz: { ok: true, status: 200, url: "private-and-not-projected" },
         readyz: { ok: true, status: 200, url: "private-and-not-projected" },
       },
@@ -112,6 +117,56 @@ function validRawStatus() {
     command: "private-and-not-projected",
     pid: 12345,
   };
+}
+
+function validPollHealth(
+  healthUrlFile = HEALTH_URL_FILE,
+  baseUrl = HEALTH_BASE_URL,
+  pid = 12345,
+) {
+  return {
+    locator: {
+      kind: "url_file",
+      url_file: healthUrlFile,
+      resolved_base_url: baseUrl,
+    },
+    process: { pid, running: true },
+    base_url: baseUrl,
+    ui_url: `${baseUrl}/ui`,
+    healthz: {
+      url: `${baseUrl}/healthz`,
+      ok: true,
+      status: 200,
+      body: "live",
+    },
+    readyz: {
+      url: `${baseUrl}/readyz`,
+      ok: true,
+      status: 200,
+      body: "ready",
+    },
+    control_plane_poll: {
+      url: `${baseUrl}/metrics`,
+      value: Math.floor(Date.now() / 1_000),
+      ok: true,
+    },
+    result: "ok",
+  };
+}
+
+function pendingPollHealth(
+  healthUrlFile = HEALTH_URL_FILE,
+  baseUrl = HEALTH_BASE_URL,
+  pid = 12345,
+) {
+  const value = validPollHealth(healthUrlFile, baseUrl, pid);
+  value.control_plane_poll = {
+    url: `${baseUrl}/metrics`,
+    ok: false,
+    error: "no successful control-plane poll observed",
+  };
+  value.result = "fail";
+  return value;
 }
 
 function validStoppedRawStatus() {
@@ -176,8 +231,15 @@ function operationalHarness(t) {
     mcp_command_sha256: MCP_COMMAND_SHA256,
   });
   const calls = [];
+  const waits = [];
   let verificationCount = 0;
   const responses = [];
+  const healthUrlFile = join(
+    operatorRoot,
+    "tunnel-state",
+    "health",
+    `${ALIAS}.url`,
+  );
   const dependencies = {
     environment: { CONTROL_PLANE_API_KEY: "bound" + "ed-test-key" },
     verifyProtectedMainCheckout: () => ({ commit: plan.source_commit }),
@@ -185,6 +247,7 @@ function operationalHarness(t) {
       verificationCount += 1;
       return client;
     },
+    waitForPollRetry: (milliseconds) => waits.push(milliseconds),
     spawnSync: (_path, argumentsValue, options) => {
       calls.push({ argumentsValue, environment: options.env });
       const response = responses.shift();
@@ -201,8 +264,10 @@ function operationalHarness(t) {
     calls,
     client,
     dependencies,
+    healthUrlFile,
     plan,
     responses,
+    waits,
     verificationCount: () => verificationCount,
   };
 }
@@ -395,8 +460,10 @@ macRuntimeTest("the reference build ignores an ambient pnpmfile hook", (t) => {
 test("status projection retains only healthy allowlisted facts", () => {
   const projection = projectTunnelStatus(
     validRawStatus(),
+    validPollHealth(),
     "before",
     MCP_COMMAND_SHA256,
+    HEALTH_URL_FILE,
     "2026-08-27T12:00:00.000Z",
   );
 
@@ -417,7 +484,7 @@ test("status projection retains only healthy allowlisted facts", () => {
     healthy: true,
     ready: true,
     control_plane_poll_health: {
-      state: "direct",
+      state: "healthy",
       route_kind: "control_plane",
     },
     remote_lookup_attempted: true,
@@ -441,19 +508,27 @@ for (const [name, mutate] of [
   ["unready runtime", (value) => { value.ready = false; }],
   ["missing remote lookup", (value) => { value.remote_lookup_attempted = false; }],
   ["stopped process", (value) => { value.process_running = false; }],
+  ["wrong process mode", (value) => { value.process.mode = "tmux"; }],
+  ["missing process PID", (value) => { delete value.process.pid; }],
   ["failed local health", (value) => { value.local.effective_health.healthz.status = 503; }],
-  ["unhealthy poll route", (value) => {
-    value.control_plane_poll_health.state = "unhealthy";
+  ["unexpected poll snapshot", (value) => {
+    value.control_plane_poll_health.reason = "different";
   }],
-  ["wrong poll route", (value) => {
-    value.control_plane_poll_health.route.kind = "mcp";
+  ["contradictory poll route", (value) => {
+    value.control_plane_poll_health.route = { kind: "mcp" };
   }],
   ["remote error", (value) => { value.remote_error = "lookup failed"; }],
 ]) {
   test(`status projection rejects ${name}`, () => {
     const value = validRawStatus();
     mutate(value);
-    assert.throws(() => projectTunnelStatus(value, "after", MCP_COMMAND_SHA256));
+    assert.throws(() => projectTunnelStatus(
+      value,
+      validPollHealth(),
+      "after",
+      MCP_COMMAND_SHA256,
+      HEALTH_URL_FILE,
+    ));
   });
 }
 
@@ -461,10 +536,46 @@ test("status projection rejects MCP command drift", () => {
   const value = validRawStatus();
   value.process.target_value = `${MCP_COMMAND} --mutated`;
   assert.throws(
-    () => projectTunnelStatus(value, "after", MCP_COMMAND_SHA256),
+    () => projectTunnelStatus(
+      value,
+      validPollHealth(),
+      "after",
+      MCP_COMMAND_SHA256,
+      HEALTH_URL_FILE,
+    ),
     /bind the reviewed profile and MCP command/u,
   );
 });
+
+for (const [name, mutate] of [
+  ["zero poll timestamp", (value) => { value.control_plane_poll.value = 0; }],
+  ["missing poll timestamp", (value) => { delete value.control_plane_poll.value; }],
+  ["failed poll", (value) => { value.control_plane_poll.ok = false; }],
+  ["poll error", (value) => { value.control_plane_poll.error = "synthetic"; }],
+  ["stale poll timestamp", (value) => {
+    value.control_plane_poll.value = Math.floor(Date.now() / 1_000) - 121;
+  }],
+  ["future poll timestamp", (value) => {
+    value.control_plane_poll.value = Math.floor(Date.now() / 1_000) + 6;
+  }],
+  ["fractional poll timestamp", (value) => {
+    value.control_plane_poll.value = (Date.now() / 1_000) - 1;
+  }],
+  ["wrong process PID", (value) => { value.process.pid = 54321; }],
+  ["stopped process probe", (value) => { value.process.running = false; }],
+  ["wrong locator", (value) => { value.locator.url_file = "/private/tmp/other"; }],
+  ["non-loopback locator", (value) => {
+    value.locator.resolved_base_url = "https://example.invalid";
+  }],
+  ["failed health endpoint", (value) => { value.healthz.status = 503; }],
+  ["failed result", (value) => { value.result = "fail"; }],
+]) {
+  test(`poll health proof rejects ${name}`, () => {
+    const value = validPollHealth();
+    mutate(value);
+    assert.throws(() => validateSuccessfulPollHealth(value, HEALTH_URL_FILE, 12345));
+  });
+}
 
 test("stopped projection proves local teardown without claiming a remote lookup", () => {
   const value = validStoppedRawStatus();
@@ -681,21 +792,159 @@ test("connect and ready status receive only the allowlisted runtime key", (t) =>
   const harness = operationalHarness(t);
   harness.responses.push(
     { payload: {} },
-    { payload: validRawStatus() },
+    { payload: validRawStatus(harness.healthUrlFile) },
+    { payload: validPollHealth(harness.healthUrlFile) },
   );
   const status = runPreparedTunnelConnect(harness.plan, harness.dependencies);
   assert.equal(status.phase, "before");
-  assert.equal(harness.calls.length, 2);
-  for (const call of harness.calls) {
+  assert.equal(harness.calls.length, 3);
+  for (const call of harness.calls.slice(0, 2)) {
     assert.equal(call.environment.CONTROL_PLANE_API_KEY, "bounded-test-key");
     assert.equal(Object.hasOwn(call.environment, "OPENAI_API_KEY"), false);
   }
-  assert.equal(harness.verificationCount(), 5);
+  assert.equal(
+    Object.hasOwn(harness.calls[2].environment, "CONTROL_PLANE_API_KEY"),
+    false,
+  );
+  assert.deepEqual(harness.calls[2].argumentsValue, [
+    "health",
+    "--url-file",
+    harness.healthUrlFile,
+    "--pid",
+    "12345",
+    "--require-control-plane-poll",
+    "--json",
+  ]);
+  assert.equal(harness.verificationCount(), 7);
   assert.equal(
     existsSync(join(harness.plan.capture_root, "tunnel-status-before.json")),
     true,
   );
 });
+
+test("connect retries only the bounded not-yet-polled health result", (t) => {
+  const harness = operationalHarness(t);
+  harness.responses.push(
+    { payload: {} },
+    { payload: validRawStatus(harness.healthUrlFile) },
+    { status: 2, payload: pendingPollHealth(harness.healthUrlFile) },
+    { payload: validPollHealth(harness.healthUrlFile) },
+  );
+  const status = runPreparedTunnelConnect(harness.plan, harness.dependencies);
+  assert.equal(status.control_plane_poll_health.state, "healthy");
+  assert.deepEqual(harness.waits, [5_000]);
+  assert.equal(harness.calls.length, 4);
+  assert.equal(
+    existsSync(join(
+      harness.plan.operator_root,
+      "raw",
+      "tunnel-poll-health-before-attempt-1-raw.json",
+    )),
+    true,
+  );
+  assert.equal(
+    existsSync(join(
+      harness.plan.operator_root,
+      "raw",
+      "tunnel-poll-health-before-attempt-2-raw.json",
+    )),
+    true,
+  );
+});
+
+test("connect stops after eight not-yet-polled health results", (t) => {
+  const harness = operationalHarness(t);
+  harness.responses.push(
+    { payload: {} },
+    { payload: validRawStatus(harness.healthUrlFile) },
+    ...Array.from({ length: 8 }, () => ({
+      status: 2,
+      payload: pendingPollHealth(harness.healthUrlFile),
+    })),
+    { payload: validStoppedRawStatus() },
+  );
+  assert.throws(
+    () => runPreparedTunnelConnect(harness.plan, harness.dependencies),
+    /bounded readiness window/u,
+  );
+  assert.deepEqual(harness.waits, Array(7).fill(5_000));
+  assert.equal(harness.calls.length, 11);
+  assert.equal(
+    existsSync(join(harness.plan.capture_root, "tunnel-status-stopped.json")),
+    true,
+  );
+});
+
+test("connect accepts a first successful poll on the eighth attempt", (t) => {
+  const harness = operationalHarness(t);
+  harness.responses.push(
+    { payload: {} },
+    { payload: validRawStatus(harness.healthUrlFile) },
+    ...Array.from({ length: 7 }, () => ({
+      status: 2,
+      payload: pendingPollHealth(harness.healthUrlFile),
+    })),
+    { payload: validPollHealth(harness.healthUrlFile) },
+  );
+  const status = runPreparedTunnelConnect(harness.plan, harness.dependencies);
+  assert.equal(status.control_plane_poll_health.state, "healthy");
+  assert.deepEqual(harness.waits, Array(7).fill(5_000));
+  assert.equal(harness.calls.length, 10);
+});
+
+test("connect does not probe poll health after a status error", (t) => {
+  const harness = operationalHarness(t);
+  const errored = validRawStatus(harness.healthUrlFile);
+  errored.remote_error = "synthetic remote lookup error";
+  harness.responses.push(
+    { payload: {} },
+    { payload: errored },
+    { payload: validStoppedRawStatus() },
+  );
+  assert.throws(
+    () => runPreparedTunnelConnect(harness.plan, harness.dependencies),
+    /healthy ready identity/u,
+  );
+  assert.deepEqual(harness.waits, []);
+  assert.equal(harness.calls.length, 3);
+  assert.deepEqual(harness.calls[2].argumentsValue, [
+    "runtimes",
+    "stop",
+    ALIAS,
+    "--json",
+  ]);
+});
+
+for (const [name, mutate] of [
+  ["missing metric", (value) => {
+    value.control_plane_poll.error =
+      "missing commands_poll_last_successful_timestamp_seconds metric";
+  }],
+  ["explicit zero metric", (value) => { value.control_plane_poll.value = 0; }],
+  ["endpoint failure", (value) => {
+    value.readyz.ok = false;
+    value.readyz.status = 503;
+  }],
+  ["locator drift", (value) => { value.locator.url_file = "/private/tmp/drift"; }],
+]) {
+  test(`connect does not retry ${name}`, (t) => {
+    const harness = operationalHarness(t);
+    const failed = pendingPollHealth(harness.healthUrlFile);
+    mutate(failed);
+    harness.responses.push(
+      { payload: {} },
+      { payload: validRawStatus(harness.healthUrlFile) },
+      { status: 2, payload: failed },
+      { payload: validStoppedRawStatus() },
+    );
+    assert.throws(
+      () => runPreparedTunnelConnect(harness.plan, harness.dependencies),
+      /control-plane poll health/u,
+    );
+    assert.deepEqual(harness.waits, []);
+    assert.equal(harness.calls.length, 4);
+  });
+}
 
 test("normal stop receives no credential and writes stopped evidence", (t) => {
   const harness = operationalHarness(t);
@@ -805,7 +1054,7 @@ test("automatic non-zero stop preserves both errors and no stopped evidence", (t
 
 test("failed status-after performs one validated credential-free stop", (t) => {
   const harness = operationalHarness(t);
-  const invalidReady = validRawStatus();
+  const invalidReady = validRawStatus(harness.healthUrlFile);
   invalidReady.ready = false;
   harness.responses.push(
     { payload: invalidReady },
@@ -818,6 +1067,27 @@ test("failed status-after performs one validated credential-free stop", (t) => {
   assert.equal(harness.calls.length, 2);
   assert.equal(harness.calls[0].environment.CONTROL_PLANE_API_KEY, "bounded-test-key");
   assert.equal(Object.hasOwn(harness.calls[1].environment, "CONTROL_PLANE_API_KEY"), false);
+  assert.equal(
+    existsSync(join(harness.plan.capture_root, "tunnel-status-stopped.json")),
+    true,
+  );
+});
+
+test("status-after rejects a stale successful poll and stops", (t) => {
+  const harness = operationalHarness(t);
+  const stale = validPollHealth(harness.healthUrlFile);
+  stale.control_plane_poll.value = Math.floor(Date.now() / 1_000) - 121;
+  harness.responses.push(
+    { payload: validRawStatus(harness.healthUrlFile) },
+    { payload: stale },
+    { payload: validStoppedRawStatus() },
+  );
+  assert.throws(
+    () => runPreparedTunnelStatusAfter(harness.plan, harness.dependencies),
+    /recent successful poll/u,
+  );
+  assert.deepEqual(harness.waits, []);
+  assert.equal(harness.calls.length, 3);
   assert.equal(
     existsSync(join(harness.plan.capture_root, "tunnel-status-stopped.json")),
     true,


### PR DESCRIPTION
## Summary

- retain the exact tunnel identity, remote lookup and local endpoint checks
- prove current-runtime readiness with the reviewed tunnel-client v0.0.13
  credential-free health command and exact managed PID
- retry only the documented not-yet-polled result across the reviewed 35-second
  poll-cycle bound
- reject stale, future, fractional, missing or failed poll evidence and tear down
  credential-free on every failure

## Cause

Tunnel-client v0.0.13 can report `no live admin UI system snapshot` for the current
managed runtime even when the runtime is healthy. The previous harness required a
route object from that status projection, so the first protected-main connection
failed closed before any ChatGPT host observation.

This change does not reinterpret the unknown status as success. It uses the
client's purpose-built successful-poll probe and keeps raw paths, URLs, ports, PIDs
and command output private.

## Verification

- 84 impacted interoperability tests pass
- 23 focused Python contract tests pass
- 93 schemas and 153 records validate; 10 forbidden mutations are rejected
- 474 Markdown links, 183 research hashes, 2 ledger snapshots and 71 source IDs pass
- 865 text files pass secret and machine-path scanning
- two independent reviews report no remaining P0-P2 findings

No new tunnel or ChatGPT observation was run from this branch.
