### PR TITLE
fix(interop): accept completed request ID reuse

### DIFF
--- a/changelog.d/QUAL-206-chatgpt-current-id-semantics.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-current-id-semantics.fixed.md
@@ -1,0 +1,1 @@
+Correct the ChatGPT exact-five evidence harness for MCP 2026-07-28 request identifiers: a client may reuse an identifier after its response completes, while simultaneous reuse and duplicate or orphan responses still fail closed. Treat the refreshed developer app's exact `tools/list` result, rather than its stable connection-version identifier, as the tool-surface evidence.

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -306,18 +306,22 @@ Any mismatch fails closed.
 
 ## Refresh the ChatGPT app before use
 
-The historical app version
-`asdk_app_v_6a873f85363081918f25a5aeaee98159` cached the earlier two-tool surface.
-Do not reuse it as exact-five evidence.
-
 In ChatGPT developer mode, refresh or recreate the version of app
 `GIS AI GO v0.2 interoperability` for app ID
 `asdk_app_6a873f853628819184bccb4a9b961576`, selecting the exact tunnel above.
 Before prompting, inspect the refreshed app and confirm that it presents exactly the
-five canonical operations with their closed schemas. Record the new non-secret
-`asdk_app_v_...` identifier; the finaliser explicitly rejects the historical value.
+five canonical operations with their closed schemas. Record the displayed non-secret
+`asdk_app_v_...` identifier. ChatGPT refreshes the developer connection in place, so
+that identifier is not an immutable tool-surface version and may remain unchanged.
+The captured, exact `tools/list` result is the authoritative schema evidence.
 
 ## One bounded host observation
+
+[The MCP 2026-07-28 request identifier rule][mcp-basic] applies to requests that
+are still outstanding. The observer accepts an identifier reused only after the earlier
+response has completed. Simultaneous reuse, an orphan response or a duplicate
+response fails closed. `request_id_unique: true` records that no request with
+the same identifier was awaiting a response when the request was issued.
 
 Start a new ChatGPT conversation and select only the refreshed GIS AI GO app. Keep
 the full prompt and conversation identifier private. In substance, instruct ChatGPT
@@ -374,7 +378,7 @@ observation window. Then create the immutable private run manifest:
   --started-at <UTC-start> \
   --finished-at <UTC-finish> \
   --displayed-model <operator-observed-model-label> \
-  --app-version-id <new-asdk-app-version-id> \
+  --app-version-id <operator-observed-asdk-app-version-id> \
   --conversation-id-sha256 <sha256>
 ```
 
@@ -408,7 +412,8 @@ Do not publish a pass if any of these occurs:
 
 - the checkout is not clean, detached and exact protected `main`;
 - client bytes or reported build differ from the reviewed `v0.0.13` identity;
-- the app still presents the historical two-tool surface or historical app version;
+- the refreshed app or captured `tools/list` presents anything other than the exact
+  five-tool surface;
 - either ready-status attestation fails, remote identity drifts, or the stopped
   attestation does not prove local teardown;
 - the host splits the five calls across sessions, changes order, duplicates or adds
@@ -424,3 +429,4 @@ Do not publish a pass if any of these occurs:
 None of these stop conditions is grounds to weaken a schema or verifier.
 
 [profile]: ../../tests/interoperability/fixtures/qual_206_chatgpt_tunnel_exact_five_profile.v1.json
+[mcp-basic]: https://modelcontextprotocol.io/specification/2026-07-28/basic

--- a/schemas/qual-206-chatgpt-tunnel-exact-five-event-v1.schema.json
+++ b/schemas/qual-206-chatgpt-tunnel-exact-five-event-v1.schema.json
@@ -359,7 +359,10 @@
         "request_ordinal": {"$ref": "#/$defs/nonNegativeInteger"},
         "request_id_sha256": {"$ref": "#/$defs/sha256"},
         "request_id_kind": {"enum": ["string", "integer"]},
-        "request_id_unique": {"type": "boolean"},
+        "request_id_unique": {
+          "type": "boolean",
+          "description": "True when no request with this identifier was awaiting a response when this request was issued."
+        },
         "method": {"$ref": "#/$defs/method"},
         "operation": {"$ref": "#/$defs/operation"},
         "protocol_claim": {"enum": ["2026-07-28", "absent", "other"]},

--- a/schemas/qual-206-chatgpt-tunnel-exact-five-evidence-v1.schema.json
+++ b/schemas/qual-206-chatgpt-tunnel-exact-five-evidence-v1.schema.json
@@ -47,8 +47,7 @@
         "app_id": {"const": "asdk_app_6a873f853628819184bccb4a9b961576"},
         "app_version_id": {
           "type": "string",
-          "pattern": "^asdk_app_v_[a-z0-9]{32}$",
-          "not": {"const": "asdk_app_v_6a873f85363081918f25a5aeaee98159"}
+          "pattern": "^asdk_app_v_[a-z0-9]{32}$"
         },
         "displayed_model": {
           "type": "string", "minLength": 1, "maxLength": 128,

--- a/schemas/qual-206-chatgpt-tunnel-exact-five-private-run-v1.schema.json
+++ b/schemas/qual-206-chatgpt-tunnel-exact-five-private-run-v1.schema.json
@@ -93,8 +93,7 @@
         "app_id": {"const": "asdk_app_6a873f853628819184bccb4a9b961576"},
         "app_version_id": {
           "type": "string",
-          "pattern": "^asdk_app_v_[a-z0-9]{32}$",
-          "not": {"const": "asdk_app_v_6a873f85363081918f25a5aeaee98159"}
+          "pattern": "^asdk_app_v_[a-z0-9]{32}$"
         },
         "displayed_model": {
           "type": "string", "minLength": 1, "maxLength": 128,

--- a/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -992,8 +992,9 @@ export function startChatGptTunnelObserver(options) {
     }
     const meta = protocolMeta(message);
     const id = requestId(message.id);
-    const duplicate = id.digest !== null &&
-      (pending.has(id.digest) || completed.has(id.digest));
+    // MCP 2026-07-28 permits an identifier to be reused after its response has
+    // completed. Only an identifier that is still in flight is ambiguous.
+    const duplicate = id.digest !== null && pending.has(id.digest);
     const method = message.method;
     const operation = operationLabel(message);
     const parameters = Buffer.from(canonicalJson(message.params), "utf8");

--- a/scripts/verify_qual_206_chatgpt_tunnel_exact_five.py
+++ b/scripts/verify_qual_206_chatgpt_tunnel_exact_five.py
@@ -149,6 +149,30 @@ def fail(message: str) -> NoReturn:
     raise TunnelExactFiveVerificationError(message)
 
 
+def correlate_request_response_events(
+    events: list[dict[str, Any]], slot: str
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """Correlate responses while allowing an ID to be reused after completion."""
+
+    pending: dict[str, dict[str, Any]] = {}
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for event in events:
+        if event["event"] == "request":
+            digest = event["request_id_sha256"]
+            if digest in pending:
+                fail(f"{slot} reuses an in-flight request identity")
+            pending[digest] = event
+        elif event["event"] == "response":
+            digest = event["request_id_sha256"]
+            request = pending.pop(digest, None)
+            if request is None:
+                fail(f"{slot} contains an orphan or duplicate response")
+            pairs.append((request, event))
+    if pending:
+        fail(f"{slot} contains an unanswered request")
+    return pairs
+
+
 def _host_call(function: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     try:
         return function(*args, **kwargs)
@@ -641,9 +665,9 @@ def verify_event_log(
         or end["response_count"] != len(responses)
     ):
         fail(f"{slot} request and response counts differ")
-    by_id = {request["request_id_sha256"]: request for request in requests}
-    if len(by_id) != len(requests):
-        fail(f"{slot} contains duplicate request identities")
+    correlated = correlate_request_response_events(events, slot)
+    if len(correlated) != len(requests):
+        fail(f"{slot} request and response correlation is incomplete")
     methods: Counter[str] = Counter()
     operations: Counter[str] = Counter()
     for request in requests:
@@ -671,11 +695,9 @@ def verify_event_log(
             )
         ):
             fail(f"{slot} contains an invalid request")
-    for response in responses:
-        request = by_id.get(response["request_id_sha256"])
+    for request, response in correlated:
         if (
-            request is None
-            or response["request_id_kind"] != request["request_id_kind"]
+            response["request_id_kind"] != request["request_id_kind"]
             or response["request_method"] != request["method"]
             or response["operation"] != request["operation"]
             or response["correlation"] != "matched"

--- a/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
+++ b/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
@@ -206,6 +206,43 @@ class ChatGptTunnelPortableContractTests(unittest.TestCase):
             hashlib.sha256(private_raw).hexdigest(),
         )
 
+    def test_request_ids_may_be_reused_only_after_the_response(self) -> None:
+        digest = "a" * 64
+        serial = [
+            {"event": "request", "request_id_sha256": digest},
+            {"event": "response", "request_id_sha256": digest},
+            {"event": "request", "request_id_sha256": digest},
+            {"event": "response", "request_id_sha256": digest},
+        ]
+        self.assertEqual(
+            len(verifier.correlate_request_response_events(serial, "session-1")),
+            2,
+        )
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "in-flight request identity",
+        ):
+            verifier.correlate_request_response_events(
+                [serial[0], serial[2]], "session-1"
+            )
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "orphan or duplicate response",
+        ):
+            verifier.correlate_request_response_events(
+                [serial[0], serial[1], serial[3]], "session-1"
+            )
+
+    def test_developer_version_id_is_not_used_as_tool_surface_evidence(self) -> None:
+        for schema_path, source in (
+            (verifier.PRIVATE_SCHEMA, self.fixture["private_run"]),
+            (verifier.PUBLIC_SCHEMA, self.fixture["public_evidence"]),
+        ):
+            observed = copy.deepcopy(source)
+            observed["host"]["app_version_id"] = HISTORICAL_APP_VERSION
+            with self.subTest(schema=schema_path.name):
+                self.assertEqual(list(validator(schema_path).iter_errors(observed)), [])
+
     def test_request_arguments_bind_events_summaries_and_frozen_profile(self) -> None:
         session = self.fixture["sessions"][1]
         requests = [
@@ -494,7 +531,7 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
     def _request(
         cls,
         process: subprocess.Popen[str],
-        request_id: str,
+        request_id: str | int,
         method: str,
         parameters: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -553,13 +590,13 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
         cls._finish(discovery)
 
         exact_five = cls._start_observer()
-        listing = cls._request(exact_five, "list-1", "tools/list")
+        listing = cls._request(exact_five, 0, "tools/list")
         if sorted(tool["name"] for tool in listing["tools"]) != sorted(
             verifier.OPERATIONS
         ):
             raise AssertionError("the fake canonical tool listing changed")
         search_receipt: str | None = None
-        for index, operation in enumerate(cls.profile["operations"]):
+        for operation in cls.profile["operations"]:
             arguments = (
                 {"receipt_id": search_receipt}
                 if operation["name"] == "evidence.inspect"
@@ -567,7 +604,7 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
             )
             result = cls._request(
                 exact_five,
-                f"call-{index + 1}",
+                0,
                 "tools/call",
                 {"name": operation["name"], "arguments": arguments},
             )
@@ -1140,9 +1177,9 @@ process.stdout.write(`${JSON.stringify([ready, stopped])}\n`);
             (self.case / "run-manifest.json").read_text(encoding="utf-8")
         )
         mutations: list[tuple[str, dict[str, Any]]] = []
-        historical = copy.deepcopy(manifest)
-        historical["host"]["app_version_id"] = HISTORICAL_APP_VERSION
-        mutations.append(("historical app version", historical))
+        malformed_version = copy.deepcopy(manifest)
+        malformed_version["host"]["app_version_id"] = "asdk_app_v_invalid"
+        mutations.append(("malformed app version", malformed_version))
         direct_http = copy.deepcopy(manifest)
         direct_http["claims"]["direct_public_streamable_http_tls"] = True
         mutations.append(("direct public HTTP", direct_http))
@@ -1168,9 +1205,9 @@ process.stdout.write(`${JSON.stringify([ready, stopped])}\n`);
         endpoint = copy.deepcopy(projection)
         endpoint["tunnel"]["endpoint"] = "https://example.invalid/mcp"
         mutations.append(("endpoint", endpoint))
-        historical = copy.deepcopy(projection)
-        historical["host"]["app_version_id"] = HISTORICAL_APP_VERSION
-        mutations.append(("historical app version", historical))
+        malformed_version = copy.deepcopy(projection)
+        malformed_version["host"]["app_version_id"] = "asdk_app_v_invalid"
+        mutations.append(("malformed app version", malformed_version))
         direct_http = copy.deepcopy(projection)
         direct_http["claims"]["direct_public_streamable_http_tls"] = True
         mutations.append(("direct public HTTP", direct_http))

--- a/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -559,7 +559,10 @@ macRuntimeTest(
   assert.deepEqual(await finish(discovery), { code: 0, signal: null, stderr: "" });
 
   const exactFive = startObserver(t, captureRoot, runId);
-  const listing = await request(exactFive, "list-1", "tools/list");
+  // ChatGPT's current MCP 2026-07-28 client reuses integer 0 after each
+  // completed response. This is valid because no request with that ID remains
+  // in flight.
+  const listing = await request(exactFive, 0, "tools/list");
   assert.equal(advertisedToolSchemasExact(listing.tools), true);
   assert.deepEqual(
     listing.tools.map(({ name }) => name).sort(),
@@ -576,7 +579,7 @@ macRuntimeTest(
     const argumentsValue = operation.name === "evidence.inspect"
       ? { receipt_id: searchReceiptId }
       : operation.arguments;
-    const result = await request(exactFive, `call-${String(index + 1)}`, "tools/call", {
+    const result = await request(exactFive, 0, "tools/call", {
       name: operation.name,
       arguments: argumentsValue,
     });


### PR DESCRIPTION
## Summary

- accept MCP 2026-07-28 request identifier reuse after the earlier response completes
- keep simultaneous reuse and duplicate, orphan or invalid responses fail-closed
- verify the complete observer-to-public-projection path with ChatGPT's current sequential integer `0` behaviour
- use the captured, hashed canonical `tools/list` result as tool-surface evidence while retaining the displayed developer version ID as operator provenance

## Evidence

The bounded ChatGPT observation from exact protected `main` completed `tools/list`, then issued a valid `catalogue.search` request with the same integer request ID. The observer rejected it before any provider call because it incorrectly treated a completed request ID as permanently unavailable.

The MCP 2026-07-28 rule requires uniqueness only while a request remains outstanding.

## Checks

- 25 focused Python contract tests pass, including the complete finaliser and independent public-projection verifier with sequential ID reuse
- 8 focused macOS observer tests pass
- 93 schemas and 153 records validate
- 474 local Markdown links, 183 research hashes and 2 ledger snapshots validate
- 913 text files pass secret and machine-path scanning
- independent read-only review found no P0 or P1 defect

## Scope

This is a narrow evidence-harness correction. It does not activate a provider, make a live provider call, publish evidence, deploy or release.
