### PR TITLE
fix(qual-206): tolerate tunnel teardown EOF race

### DIFF
--- a/changelog.d/QUAL-206-chatgpt-tunnel-teardown.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-tunnel-teardown.fixed.md
@@ -1,5 +1,8 @@
 - Preserve fail-closed ChatGPT exact-five evidence when the pinned tunnel client
-  closes observer stdin and immediately sends `SIGTERM`. The observer now gives the
-  already-requested EOF a bounded 250-millisecond delivery grace, still rejects a
-  signal without EOF and leaves every call, receipt, runtime and publication gate
-  unchanged.
+  `v0.0.13` managed stop delivers `SIGTERM` a few milliseconds before or after
+  observer stdin closes. The observer records `stdin-eof-and-sigterm` and
+  `sigterm-then-stdin-eof` distinctly, allows at most 250 milliseconds for EOF
+  after the signal, and still rejects a signal without EOF. Operating-system and
+  application updates remain unsafe until the live observation has stopped and its
+  private records have been persisted. Every call, receipt, runtime and publication
+  gate remains unchanged.

--- a/changelog.d/QUAL-206-chatgpt-tunnel-teardown.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-tunnel-teardown.fixed.md
@@ -1,8 +1,8 @@
 - Preserve fail-closed ChatGPT exact-five evidence when the pinned tunnel client
-  `v0.0.13` managed stop delivers `SIGTERM` a few milliseconds before or after
-  observer stdin closes. The observer records `stdin-eof-and-sigterm` and
-  `sigterm-then-stdin-eof` distinctly, allows at most 250 milliseconds for EOF
-  after the signal, and still rejects a signal without EOF. Operating-system and
-  application updates remain unsafe until the live observation has stopped and its
-  private records have been persisted. Every call, receipt, runtime and publication
-  gate remains unchanged.
+  `v0.0.13` first forwards `SIGTERM`, then its STDIO OnStop hook closes observer
+  stdin and sends a duplicate `SIGTERM`. The observer records the first signal's
+  causal ordering, absorbs the duplicate idempotently, allows at most 250
+  milliseconds for EOF, and still rejects a signal without EOF. It also records
+  the valid EOF-first ordering separately. Operating-system and application updates
+  remain unsafe until the live observation has stopped and its private records have
+  been persisted. Every call, receipt, runtime and publication gate remains unchanged.

--- a/changelog.d/QUAL-206-chatgpt-tunnel-teardown.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-tunnel-teardown.fixed.md
@@ -1,0 +1,5 @@
+- Preserve fail-closed ChatGPT exact-five evidence when the pinned tunnel client
+  closes observer stdin and immediately sends `SIGTERM`. The observer now gives the
+  already-requested EOF a bounded 250-millisecond delivery grace, still rejects a
+  signal without EOF and leaves every call, receipt, runtime and publication gate
+  unchanged.

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -361,19 +361,26 @@ Run this immediately after the second ready-status attestation. Do not wait for 
 persistent ChatGPT transport to close itself: it remains open after the fifth
 response and would reach the fail-closed inter-frame deadline.
 
-The pinned tunnel client closes the managed child stdin and requests `SIGTERM`
-without an intervening delay. The observer therefore allows 250 milliseconds for
-the already-requested EOF to reach Node after the signal callback. It still requires
-that EOF before accepting teardown. A standalone or earlier `SIGTERM`, a missing
-EOF, a partial frame, an incomplete call or any request still in flight remains a
-fatal anomaly. This bounded delivery grace changes no call, result, receipt or
-publication predicate.
+During a managed stop, the pinned tunnel client `v0.0.13` can deliver `SIGTERM` to
+the observer a few milliseconds before its STDIO stop hook closes stdin. EOF can
+also arrive before the signal. The observer distinguishes and records both valid
+orderings: `stdin-eof-and-sigterm` when EOF arrives first, and
+`sigterm-then-stdin-eof` when EOF arrives within the bounded 250-millisecond grace
+after the signal. It still requires EOF before accepting teardown. A signal without
+EOF before that grace expires, a partial frame, an incomplete call or any request
+still in flight remains a fatal anomaly. This bounded delivery grace changes no
+call, result, receipt or publication predicate.
 
 The stop is local and credential-free. It re-verifies the pinned tunnel-client
 bytes, requires the exact profile and command digest, and writes
 `tunnel-status-stopped.json`. That envelope must show the process stopped, health
 and readiness false, no remote lookup, and no claim that the remote tunnel was
 removed. Do not finalise or publish evidence without it.
+
+Do not install a pending operating-system or application update, restart the Mac or
+otherwise change the reviewed toolchain while the live observation is running. An
+update is safe only after the managed observation has stopped and its private
+capture and operator records have been persisted.
 
 ## Finalise and independently verify
 

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -357,6 +357,18 @@ Stop the exact managed alias before finalisation:
   --operator-root "$QUAL206_OPERATOR_ROOT"
 ```
 
+Run this immediately after the second ready-status attestation. Do not wait for the
+persistent ChatGPT transport to close itself: it remains open after the fifth
+response and would reach the fail-closed inter-frame deadline.
+
+The pinned tunnel client closes the managed child stdin and requests `SIGTERM`
+without an intervening delay. The observer therefore allows 250 milliseconds for
+the already-requested EOF to reach Node after the signal callback. It still requires
+that EOF before accepting teardown. A standalone or earlier `SIGTERM`, a missing
+EOF, a partial frame, an incomplete call or any request still in flight remains a
+fatal anomaly. This bounded delivery grace changes no call, result, receipt or
+publication predicate.
+
 The stop is local and credential-free. It re-verifies the pinned tunnel-client
 bytes, requires the exact profile and command digest, and writes
 `tunnel-status-stopped.json`. That envelope must show the process stopped, health

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -361,15 +361,17 @@ Run this immediately after the second ready-status attestation. Do not wait for 
 persistent ChatGPT transport to close itself: it remains open after the fifth
 response and would reach the fail-closed inter-frame deadline.
 
-During a managed stop, the pinned tunnel client `v0.0.13` can deliver `SIGTERM` to
-the observer a few milliseconds before its STDIO stop hook closes stdin. EOF can
-also arrive before the signal. The observer distinguishes and records both valid
-orderings: `stdin-eof-and-sigterm` when EOF arrives first, and
+During a managed stop, the pinned tunnel client `v0.0.13` can first forward a host
+`SIGTERM`, then have its STDIO OnStop hook close observer stdin and send a second
+`SIGTERM`. The observer treats the first signal as the causal teardown stimulus and
+absorbs the duplicate idempotently; it does not emit a second lifecycle event. EOF
+can also arrive before the first signal. The observer distinguishes and records both
+valid causal orderings: `stdin-eof-and-sigterm` when EOF arrives first, and
 `sigterm-then-stdin-eof` when EOF arrives within the bounded 250-millisecond grace
-after the signal. It still requires EOF before accepting teardown. A signal without
-EOF before that grace expires, a partial frame, an incomplete call or any request
-still in flight remains a fatal anomaly. This bounded delivery grace changes no
-call, result, receipt or publication predicate.
+after the first signal. It still requires EOF before accepting teardown. A signal
+without EOF before that grace expires, a partial frame, an incomplete call or any
+request still in flight remains a fatal anomaly. This bounded delivery grace changes
+no call, result, receipt or publication predicate.
 
 The stop is local and credential-free. It re-verifies the pinned tunnel-client
 bytes, requires the exact profile and command digest, and writes

--- a/schemas/qual-206-chatgpt-tunnel-exact-five-event-v1.schema.json
+++ b/schemas/qual-206-chatgpt-tunnel-exact-five-event-v1.schema.json
@@ -243,7 +243,8 @@
       "required": [
         "schema", "run_id", "session_id", "slot", "sequence", "observed_at",
         "event", "previous_event_sha256", "event_sha256", "phase", "signal",
-        "stdin_closed_before_signal", "immediate_parent_verified"
+        "stdin_closed_before_signal", "stdin_eof_observed_within_grace",
+        "immediate_parent_verified"
       ],
       "properties": {
         "schema": {"const": "gis-ai-go.qual-206-chatgpt-tunnel-exact-five-event.v1"},
@@ -257,9 +258,24 @@
         "event_sha256": {"$ref": "#/$defs/sha256"},
         "phase": {"const": "parent-teardown-signal"},
         "signal": {"const": "SIGTERM"},
-        "stdin_closed_before_signal": {"const": true},
+        "stdin_closed_before_signal": {"type": "boolean"},
+        "stdin_eof_observed_within_grace": {"type": "boolean"},
         "immediate_parent_verified": {"const": true}
-      }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "stdin_closed_before_signal": {"const": true},
+            "stdin_eof_observed_within_grace": {"const": false}
+          }
+        },
+        {
+          "properties": {
+            "stdin_closed_before_signal": {"const": false},
+            "stdin_eof_observed_within_grace": {"const": true}
+          }
+        }
+      ]
     },
     "childExit": {
       "type": "object", "additionalProperties": false,
@@ -313,7 +329,10 @@
         "runtime_materials_stable": {"type": "boolean"},
         "runtime_closures_stable": {"const": true},
         "closure_stimulus": {
-          "enum": ["stdin-eof", "sigint", "sigterm", "stdin-eof-and-sigint", "stdin-eof-and-sigterm", "none"]
+          "enum": [
+            "stdin-eof", "sigint", "sigterm", "stdin-eof-and-sigint",
+            "stdin-eof-and-sigterm", "sigterm-then-stdin-eof", "none"
+          ]
         },
         "exit_code": {"oneOf": [
           {"type": "integer", "minimum": 0, "maximum": 255}, {"type": "null"}

--- a/schemas/qual-206-chatgpt-tunnel-exact-five-event-v1.schema.json
+++ b/schemas/qual-206-chatgpt-tunnel-exact-five-event-v1.schema.json
@@ -257,7 +257,10 @@
         "previous_event_sha256": {"$ref": "#/$defs/nullableSha256"},
         "event_sha256": {"$ref": "#/$defs/sha256"},
         "phase": {"const": "parent-teardown-signal"},
-        "signal": {"const": "SIGTERM"},
+        "signal": {
+          "const": "SIGTERM",
+          "description": "The first causal parent teardown signal; a later duplicate v0.0.13 managed-stop SIGTERM is absorbed rather than emitted as another lifecycle event."
+        },
         "stdin_closed_before_signal": {"type": "boolean"},
         "stdin_eof_observed_within_grace": {"type": "boolean"},
         "immediate_parent_verified": {"const": true}
@@ -329,6 +332,7 @@
         "runtime_materials_stable": {"type": "boolean"},
         "runtime_closures_stable": {"const": true},
         "closure_stimulus": {
+          "description": "The canonical causal teardown relationship, not a count of duplicate transport signals.",
           "enum": [
             "stdin-eof", "sigint", "sigterm", "stdin-eof-and-sigint",
             "stdin-eof-and-sigterm", "sigterm-then-stdin-eof", "none"

--- a/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -122,6 +122,8 @@ const MAX_STDERR_BYTES = 65_536;
 const MAX_PRE_FIRST_FRAME_MILLISECONDS = 10 * 60_000;
 const MAX_INTER_FRAME_IDLE_MILLISECONDS = 3 * 60_000;
 const MAX_OBSERVATION_MILLISECONDS = 15 * 60_000;
+// v0.0.13 closes stdin immediately before signalling its managed process group.
+const PARENT_TEARDOWN_EOF_GRACE_MILLISECONDS = 250;
 export const CHATGPT_TUNNEL_OBSERVATION_WINDOWS = Object.freeze({
   pre_first_frame_milliseconds: MAX_PRE_FIRST_FRAME_MILLISECONDS,
   inter_frame_idle_milliseconds: MAX_INTER_FRAME_IDLE_MILLISECONDS,
@@ -903,6 +905,9 @@ export function startChatGptTunnelObserver(options) {
   let terminationTimer = null;
   let deadlines = null;
   let parentTeardownSignal = null;
+  let pendingParentTeardownSignal = null;
+  let parentTeardownEofTimer = null;
+  let deferredChildClose = null;
   const streamEnds = new Map();
   let stderrEventCount = 0;
   let stderrBytes = 0;
@@ -1335,6 +1340,22 @@ export function startChatGptTunnelObserver(options) {
     });
   }
 
+  function recordParentTeardownAfterEof() {
+    if (pendingParentTeardownSignal !== "SIGTERM" || !hostInputEnded) return;
+    if (parentTeardownEofTimer !== null) {
+      clearTimeout(parentTeardownEofTimer);
+      parentTeardownEofTimer = null;
+    }
+    parentTeardownSignal = pendingParentTeardownSignal;
+    pendingParentTeardownSignal = null;
+    emit("lifecycle", {
+      phase: "parent-teardown-signal",
+      signal: parentTeardownSignal,
+      stdin_closed_before_signal: true,
+      immediate_parent_verified: true,
+    });
+  }
+
   deadlines = createChatGptTunnelObservationDeadlines({
     onTimeout: (classification) => captureFatal(classification),
   });
@@ -1344,7 +1365,13 @@ export function startChatGptTunnelObserver(options) {
   process.stdin.once("end", guarded("host-stdin-end-failure", () => {
     hostInputEnded = true;
     endStream("host-stdin", inputTap, true);
+    recordParentTeardownAfterEof();
     child.stdin.end();
+    if (deferredChildClose !== null) {
+      const { code, signal } = deferredChildClose;
+      deferredChildClose = null;
+      finaliseSession(code, signal);
+    }
   }));
   process.stdin.once("error", () => captureFatal("host-stdin-stream-error"));
   child.stdin.once("error", () => {
@@ -1383,9 +1410,13 @@ export function startChatGptTunnelObserver(options) {
   child.once("exit", guarded("child-exit-observation-failure", (code, signal) => {
     emit("lifecycle", { phase: "child-exit", exit_code: code, signal });
   }));
-  child.once("close", (code, signal) => {
+  function finaliseSession(code, signal) {
     finalising = true;
     deadlines.stop();
+    if (parentTeardownEofTimer !== null) {
+      clearTimeout(parentTeardownEofTimer);
+      parentTeardownEofTimer = null;
+    }
     if (terminationTimer !== null) clearTimeout(terminationTimer);
     try {
       endStream("host-stdin", inputTap, false);
@@ -1582,19 +1613,37 @@ export function startChatGptTunnelObserver(options) {
       process.stderr.write("QUAL-206 ChatGPT tunnel observer finalisation failed\n");
       process.exitCode = 2;
     }
+  }
+
+  child.once("close", (code, signal) => {
+    if (pendingParentTeardownSignal === "SIGTERM" && !hostInputEnded) {
+      deferredChildClose = { code, signal };
+      return;
+    }
+    finaliseSession(code, signal);
   });
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.once(signal, () => {
       if (finalising) return;
-      if (signal === "SIGTERM" && hostInputEnded && fatalError === null) {
-        parentTeardownSignal = signal;
-        emit("lifecycle", {
-          phase: "parent-teardown-signal",
-          signal,
-          stdin_closed_before_signal: true,
-          immediate_parent_verified: true,
-        });
-        if (!child.stdin.writableEnded) child.stdin.end();
+      if (signal === "SIGTERM" && fatalError === null) {
+        if (pendingParentTeardownSignal !== null) return;
+        pendingParentTeardownSignal = signal;
+        if (hostInputEnded) {
+          recordParentTeardownAfterEof();
+          if (!child.stdin.writableEnded) child.stdin.end();
+          return;
+        }
+        parentTeardownEofTimer = setTimeout(() => {
+          parentTeardownEofTimer = null;
+          if (hostInputEnded) return;
+          pendingParentTeardownSignal = null;
+          captureFatal("premature-parent-sigterm");
+          if (deferredChildClose !== null) {
+            const { code, signal: childSignal } = deferredChildClose;
+            deferredChildClose = null;
+            finaliseSession(code, childSignal);
+          }
+        }, PARENT_TEARDOWN_EOF_GRACE_MILLISECONDS);
         return;
       }
       captureFatal(

--- a/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -122,8 +122,9 @@ const MAX_STDERR_BYTES = 65_536;
 const MAX_PRE_FIRST_FRAME_MILLISECONDS = 10 * 60_000;
 const MAX_INTER_FRAME_IDLE_MILLISECONDS = 3 * 60_000;
 const MAX_OBSERVATION_MILLISECONDS = 15 * 60_000;
-// v0.0.13 may deliver SIGTERM just before the managed STDIO OnStop hook closes
-// stdin. Keep that transport race bounded without accepting signal-only closure.
+// v0.0.13 can forward SIGTERM before the managed STDIO OnStop hook closes
+// stdin and sends a duplicate SIGTERM. Keep that race bounded and idempotent
+// without accepting signal-only closure.
 const PARENT_TEARDOWN_EOF_GRACE_MILLISECONDS = 250;
 export const CHATGPT_TUNNEL_OBSERVATION_WINDOWS = Object.freeze({
   pre_first_frame_milliseconds: MAX_PRE_FIRST_FRAME_MILLISECONDS,
@@ -1655,7 +1656,11 @@ export function startChatGptTunnelObserver(options) {
     finaliseSession(code, signal);
   });
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-    process.once(signal, () => {
+    // v0.0.13 can forward a host SIGTERM before its managed STDIO OnStop hook,
+    // then close stdin and signal this command a second time. Keep the handler
+    // installed through finalisation so that the duplicate cannot restore
+    // Node's default signal termination during the bounded EOF grace.
+    process.on(signal, () => {
       if (finalising) return;
       if (signal === "SIGTERM" && fatalError === null) {
         if (pendingParentTeardownSignal !== null || parentTeardownSignal !== null) return;

--- a/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/scripts/qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -122,7 +122,8 @@ const MAX_STDERR_BYTES = 65_536;
 const MAX_PRE_FIRST_FRAME_MILLISECONDS = 10 * 60_000;
 const MAX_INTER_FRAME_IDLE_MILLISECONDS = 3 * 60_000;
 const MAX_OBSERVATION_MILLISECONDS = 15 * 60_000;
-// v0.0.13 closes stdin immediately before signalling its managed process group.
+// v0.0.13 may deliver SIGTERM just before the managed STDIO OnStop hook closes
+// stdin. Keep that transport race bounded without accepting signal-only closure.
 const PARENT_TEARDOWN_EOF_GRACE_MILLISECONDS = 250;
 export const CHATGPT_TUNNEL_OBSERVATION_WINDOWS = Object.freeze({
   pre_first_frame_milliseconds: MAX_PRE_FIRST_FRAME_MILLISECONDS,
@@ -905,6 +906,7 @@ export function startChatGptTunnelObserver(options) {
   let terminationTimer = null;
   let deadlines = null;
   let parentTeardownSignal = null;
+  let parentTeardownSignalBeforeEof = false;
   let pendingParentTeardownSignal = null;
   let parentTeardownEofTimer = null;
   let deferredChildClose = null;
@@ -1340,18 +1342,36 @@ export function startChatGptTunnelObserver(options) {
     });
   }
 
-  function recordParentTeardownAfterEof() {
-    if (pendingParentTeardownSignal !== "SIGTERM" || !hostInputEnded) return;
+  function clearParentTeardownEofTimer() {
     if (parentTeardownEofTimer !== null) {
       clearTimeout(parentTeardownEofTimer);
       parentTeardownEofTimer = null;
     }
+  }
+
+  function recordParentTeardownAfterEof() {
+    if (pendingParentTeardownSignal !== "SIGTERM" || !hostInputEnded) return;
+    clearParentTeardownEofTimer();
     parentTeardownSignal = pendingParentTeardownSignal;
+    parentTeardownSignalBeforeEof = true;
     pendingParentTeardownSignal = null;
     emit("lifecycle", {
       phase: "parent-teardown-signal",
       signal: parentTeardownSignal,
+      stdin_closed_before_signal: false,
+      stdin_eof_observed_within_grace: true,
+      immediate_parent_verified: true,
+    });
+  }
+
+  function recordParentTeardownAfterPriorEof() {
+    parentTeardownSignal = "SIGTERM";
+    parentTeardownSignalBeforeEof = false;
+    emit("lifecycle", {
+      phase: "parent-teardown-signal",
+      signal: parentTeardownSignal,
       stdin_closed_before_signal: true,
+      stdin_eof_observed_within_grace: false,
       immediate_parent_verified: true,
     });
   }
@@ -1360,13 +1380,21 @@ export function startChatGptTunnelObserver(options) {
     onTimeout: (classification) => captureFatal(classification),
   });
   process.stdin.on("data", guarded("host-stdin-failure", (chunk) => {
+    if (pendingParentTeardownSignal === "SIGTERM") {
+      captureFatal("host-bytes-after-parent-teardown-signal", {
+        direction: "host-to-fixture",
+        frame_bytes: chunk.length,
+        frame_sha256: sha256Bytes(chunk),
+      });
+      return;
+    }
     inputTap.push(chunk);
   }));
   process.stdin.once("end", guarded("host-stdin-end-failure", () => {
     hostInputEnded = true;
     endStream("host-stdin", inputTap, true);
     recordParentTeardownAfterEof();
-    child.stdin.end();
+    if (!child.stdin.writableEnded && !child.stdin.destroyed) child.stdin.end();
     if (deferredChildClose !== null) {
       const { code, signal } = deferredChildClose;
       deferredChildClose = null;
@@ -1411,12 +1439,10 @@ export function startChatGptTunnelObserver(options) {
     emit("lifecycle", { phase: "child-exit", exit_code: code, signal });
   }));
   function finaliseSession(code, signal) {
+    if (finalising) return;
     finalising = true;
     deadlines.stop();
-    if (parentTeardownEofTimer !== null) {
-      clearTimeout(parentTeardownEofTimer);
-      parentTeardownEofTimer = null;
-    }
+    clearParentTeardownEofTimer();
     if (terminationTimer !== null) clearTimeout(terminationTimer);
     try {
       endStream("host-stdin", inputTap, false);
@@ -1488,7 +1514,9 @@ export function startChatGptTunnelObserver(options) {
         runtime_materials_stable: runtimeStable,
         runtime_closures_stable: runtimeClosuresStable,
         closure_stimulus: parentTeardownSignal === "SIGTERM"
-          ? "stdin-eof-and-sigterm"
+          ? parentTeardownSignalBeforeEof
+            ? "sigterm-then-stdin-eof"
+            : "stdin-eof-and-sigterm"
           : hostInputEnded ? "stdin-eof" : "none",
         exit_code: code,
         signal,
@@ -1618,6 +1646,10 @@ export function startChatGptTunnelObserver(options) {
   child.once("close", (code, signal) => {
     if (pendingParentTeardownSignal === "SIGTERM" && !hostInputEnded) {
       deferredChildClose = { code, signal };
+      captureFatal("fixture-close-before-parent-stdin-eof");
+      // captureFatal pauses the host stream. This exceptional invalid path must
+      // still observe a later EOF or the bounded grace expiry before persisting.
+      process.stdin.resume();
       return;
     }
     finaliseSession(code, signal);
@@ -1626,13 +1658,14 @@ export function startChatGptTunnelObserver(options) {
     process.once(signal, () => {
       if (finalising) return;
       if (signal === "SIGTERM" && fatalError === null) {
-        if (pendingParentTeardownSignal !== null) return;
-        pendingParentTeardownSignal = signal;
+        if (pendingParentTeardownSignal !== null || parentTeardownSignal !== null) return;
+        deadlines.stop();
         if (hostInputEnded) {
-          recordParentTeardownAfterEof();
+          recordParentTeardownAfterPriorEof();
           if (!child.stdin.writableEnded) child.stdin.end();
           return;
         }
+        pendingParentTeardownSignal = signal;
         parentTeardownEofTimer = setTimeout(() => {
           parentTeardownEofTimer = null;
           if (hostInputEnded) return;

--- a/scripts/verify_qual_206_chatgpt_tunnel_exact_five.py
+++ b/scripts/verify_qual_206_chatgpt_tunnel_exact_five.py
@@ -601,9 +601,30 @@ def verify_event_log(
     if phases not in accepted_phases:
         fail(f"{slot} lifecycle is not the exact closed sequence")
     start = lifecycle[0]
-    child_exit = lifecycle[-2]
+    child_exit = next(event for event in lifecycle if event["phase"] == "child-exit")
     end = lifecycle[-1]
-    teardown = lifecycle[2] if len(lifecycle) == 5 else None
+    teardown = next(
+        (event for event in lifecycle if event["phase"] == "parent-teardown-signal"),
+        None,
+    )
+    expected_closure_stimulus = "stdin-eof"
+    if teardown is not None:
+        teardown_pair = (
+            teardown["stdin_closed_before_signal"],
+            teardown["stdin_eof_observed_within_grace"],
+        )
+        expected_closure_stimulus = {
+            (True, False): "stdin-eof-and-sigterm",
+            (False, True): "sigterm-then-stdin-eof",
+        }.get(teardown_pair, "")
+        if (
+            not expected_closure_stimulus
+            or teardown["signal"] != "SIGTERM"
+            or teardown["immediate_parent_verified"] is not True
+        ):
+            fail(f"{slot} parent teardown evidence is inconsistent")
+    if end["closure_stimulus"] != expected_closure_stimulus:
+        fail(f"{slot} parent teardown closure is inconsistent")
     if (
         events[0] is not start
         or events[-1] is not end
@@ -632,13 +653,6 @@ def verify_event_log(
         or start["mcp_child_network_access_allowed"] is not False
         or child_exit["exit_code"] != 0
         or child_exit["signal"] is not None
-        or (
-            teardown is None and end["closure_stimulus"] != "stdin-eof"
-        )
-        or (
-            teardown is not None
-            and end["closure_stimulus"] != "stdin-eof-and-sigterm"
-        )
     ):
         fail(f"{slot} runtime or source binding changed")
     prior_raw = b"".join(encoded_lines[:-1])

--- a/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
+++ b/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
@@ -233,6 +233,65 @@ class ChatGptTunnelPortableContractTests(unittest.TestCase):
                 [serial[0], serial[1], serial[3]], "session-1"
             )
 
+    def test_teardown_event_contract_distinguishes_the_two_truthful_orders(self) -> None:
+        event_validator = validator(verifier.EVENT_SCHEMA)
+        session = self.fixture["sessions"][0]
+        common = {
+            "schema": "gis-ai-go.qual-206-chatgpt-tunnel-exact-five-event.v1",
+            "run_id": self.fixture["private_run"]["run_id"],
+            "session_id": session["session_id"],
+            "slot": session["slot"],
+            "sequence": 2,
+            "observed_at": self.fixture["private_run"]["execution"]["started_at"],
+            "event": "lifecycle",
+            "previous_event_sha256": "a" * 64,
+            "event_sha256": "b" * 64,
+            "phase": "parent-teardown-signal",
+            "signal": "SIGTERM",
+            "immediate_parent_verified": True,
+        }
+        eof_before_signal = {
+            **common,
+            "stdin_closed_before_signal": True,
+            "stdin_eof_observed_within_grace": False,
+        }
+        signal_before_eof = {
+            **common,
+            "stdin_closed_before_signal": False,
+            "stdin_eof_observed_within_grace": True,
+        }
+        for label, event in (
+            ("EOF before SIGTERM", eof_before_signal),
+            ("SIGTERM before EOF", signal_before_eof),
+        ):
+            with self.subTest(order=label):
+                self.assertEqual(list(event_validator.iter_errors(event)), [])
+
+        for label, pair in (
+            ("both true", (True, True)),
+            ("both false", (False, False)),
+        ):
+            changed = {
+                **common,
+                "stdin_closed_before_signal": pair[0],
+                "stdin_eof_observed_within_grace": pair[1],
+            }
+            with self.subTest(order=label):
+                self.assertTrue(list(event_validator.iter_errors(changed)))
+
+        missing_grace_fact = dict(eof_before_signal)
+        del missing_grace_fact["stdin_eof_observed_within_grace"]
+        self.assertTrue(list(event_validator.iter_errors(missing_grace_fact)))
+
+        session_end = next(
+            event
+            for event in self.fixture["events"]
+            if event["session_id"] == session["session_id"]
+            and event.get("phase") == "session-end"
+        )
+        signal_first_end = {**session_end, "closure_stimulus": "sigterm-then-stdin-eof"}
+        self.assertEqual(list(event_validator.iter_errors(signal_first_end)), [])
+
     def test_developer_version_id_is_not_used_as_tool_surface_evidence(self) -> None:
         for schema_path, source in (
             (verifier.PRIVATE_SCHEMA, self.fixture["private_run"]),
@@ -949,6 +1008,53 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
         }
         write_private_json(capture_path, capture)
 
+    def add_parent_teardown(
+        self,
+        slot: str,
+        *,
+        after_child_exit: bool,
+        stdin_closed_before_signal: bool,
+        stdin_eof_observed_within_grace: bool,
+        closure_stimulus: str,
+    ) -> None:
+        event_path = self.case / slot / "events.jsonl"
+        events = [
+            json.loads(line)
+            for line in event_path.read_text(encoding="utf-8").splitlines()
+        ]
+        child_index = next(
+            index
+            for index, event in enumerate(events)
+            if event.get("event") == "lifecycle"
+            and event.get("phase") == "child-exit"
+        )
+        child_exit = events[child_index]
+        teardown = {
+            "schema": child_exit["schema"],
+            "run_id": child_exit["run_id"],
+            "session_id": child_exit["session_id"],
+            "slot": child_exit["slot"],
+            "sequence": 0,
+            "observed_at": child_exit["observed_at"],
+            "event": "lifecycle",
+            "previous_event_sha256": None,
+            "event_sha256": "0" * 64,
+            "phase": "parent-teardown-signal",
+            "signal": "SIGTERM",
+            "stdin_closed_before_signal": stdin_closed_before_signal,
+            "stdin_eof_observed_within_grace": stdin_eof_observed_within_grace,
+            "immediate_parent_verified": True,
+        }
+        events.insert(child_index + int(after_child_exit), teardown)
+        end = next(
+            event
+            for event in events
+            if event.get("event") == "lifecycle"
+            and event.get("phase") == "session-end"
+        )
+        end["closure_stimulus"] = closure_stimulus
+        self.rebind_session_events(slot, events)
+
     def rebind_session_summary(self, slot: str, summary: dict[str, Any]) -> None:
         summary_raw = write_private_json(
             self.case / slot / "exact-five-session.json",
@@ -991,6 +1097,54 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
         self.assertFalse(
             verifier.nested_field_names(projection) & verifier.FORBIDDEN_PUBLIC_FIELDS
         )
+
+    def test_verifier_accepts_eof_before_sigterm_teardown(self) -> None:
+        self.add_parent_teardown(
+            "session-2",
+            after_child_exit=False,
+            stdin_closed_before_signal=True,
+            stdin_eof_observed_within_grace=False,
+            closure_stimulus="stdin-eof-and-sigterm",
+        )
+        self.assertEqual(self.verify()["status"], "capability_pass")
+
+    def test_verifier_accepts_sigterm_then_eof_teardown_before_child_exit(self) -> None:
+        self.add_parent_teardown(
+            "session-2",
+            after_child_exit=False,
+            stdin_closed_before_signal=False,
+            stdin_eof_observed_within_grace=True,
+            closure_stimulus="sigterm-then-stdin-eof",
+        )
+        self.assertEqual(self.verify()["status"], "capability_pass")
+
+    def test_verifier_rejects_mismatched_teardown_closure(self) -> None:
+        self.add_parent_teardown(
+            "session-2",
+            after_child_exit=False,
+            stdin_closed_before_signal=False,
+            stdin_eof_observed_within_grace=True,
+            closure_stimulus="stdin-eof-and-sigterm",
+        )
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "parent teardown closure is inconsistent",
+        ):
+            self.verify()
+
+    def test_verifier_rejects_child_exit_before_any_parent_teardown(self) -> None:
+        self.add_parent_teardown(
+            "session-2",
+            after_child_exit=True,
+            stdin_closed_before_signal=False,
+            stdin_eof_observed_within_grace=True,
+            closure_stimulus="sigterm-then-stdin-eof",
+        )
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "lifecycle is not the exact closed sequence",
+        ):
+            self.verify()
 
     def test_status_contract_rejects_leakage_and_false_teardown(self) -> None:
         status_validator = validator(verifier.STATUS_SCHEMA)

--- a/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -320,6 +320,14 @@ async function finishWithSignalBeforeEof(observer) {
   return await withTimeout(observer.completion, "signal-first observer completion");
 }
 
+async function finishWithForwardedThenManagedTunnelStop(observer) {
+  assert.equal(observer.child.kill("SIGTERM"), true);
+  await waitMilliseconds(25);
+  if (!observer.child.stdin.writableEnded) observer.child.stdin.end();
+  assert.equal(observer.child.kill("SIGTERM"), true);
+  return await withTimeout(observer.completion, "two-signal observer completion");
+}
+
 function sessionEvents(captureRoot, slot) {
   return readFileSync(join(captureRoot, slot, "events.jsonl"), "utf8")
     .trim()
@@ -569,12 +577,58 @@ macRuntimeTest("SIGTERM followed by EOF within grace is a clean truthful teardow
   );
 });
 
+macRuntimeTest(
+  "forwarded SIGTERM then managed EOF and duplicate SIGTERM closes cleanly",
+  async (t) => {
+    const captureRoot = privateRoot(t);
+    const observer = startObserver(t, captureRoot, randomUUID());
+    await request(observer, "discover-1", "server/discover");
+    const completion = await finishWithForwardedThenManagedTunnelStop(observer);
+    assert.deepEqual(completion, { code: 0, signal: null, stderr: "" });
+    const events = sessionEvents(captureRoot, "session-1");
+    const teardown = events.find(({ phase }) => phase === "parent-teardown-signal");
+    assert.deepEqual({
+      signal: teardown?.signal,
+      stdin_closed_before_signal: teardown?.stdin_closed_before_signal,
+      stdin_eof_observed_within_grace: teardown?.stdin_eof_observed_within_grace,
+      closure_stimulus: events.find(({ phase }) => phase === "session-end")
+        ?.closure_stimulus,
+    }, {
+      signal: "SIGTERM",
+      stdin_closed_before_signal: false,
+      stdin_eof_observed_within_grace: true,
+      closure_stimulus: "sigterm-then-stdin-eof",
+    });
+  },
+);
+
 macRuntimeTest("SIGTERM without stdin EOF fails closed after the bounded grace", async (t) => {
   const captureRoot = privateRoot(t);
   const observer = startObserver(t, captureRoot, randomUUID());
   await request(observer, "discover-1", "server/discover");
   observer.child.kill("SIGTERM");
   const completion = await withTimeout(observer.completion, "premature SIGTERM rejection");
+  assert.equal(completion.code, 2, completion.stderr);
+  assert.deepEqual(
+    anomalyClassifications(captureRoot, "session-1"),
+    ["premature-parent-sigterm"],
+  );
+  const events = sessionEvents(captureRoot, "session-1");
+  assert.equal(events.some(({ phase }) => phase === "parent-teardown-signal"), false);
+  assert.equal(
+    events.find(({ phase }) => phase === "session-end")?.protocol_session_status,
+    "failed",
+  );
+});
+
+macRuntimeTest("duplicate SIGTERM without stdin EOF still fails closed", async (t) => {
+  const captureRoot = privateRoot(t);
+  const observer = startObserver(t, captureRoot, randomUUID());
+  await request(observer, "discover-1", "server/discover");
+  assert.equal(observer.child.kill("SIGTERM"), true);
+  await waitMilliseconds(25);
+  assert.equal(observer.child.kill("SIGTERM"), true);
+  const completion = await withTimeout(observer.completion, "duplicate SIGTERM rejection");
   assert.equal(completion.code, 2, completion.stderr);
   assert.deepEqual(
     anomalyClassifications(captureRoot, "session-1"),
@@ -705,7 +759,7 @@ macRuntimeTest(
     /^gis-ai-go:evidence-receipt:sha256:[0-9a-f]{64}$/u,
   );
   assert.deepEqual(
-    await finishWithSignalBeforeEof(exactFive),
+    await finishWithForwardedThenManagedTunnelStop(exactFive),
     { code: 0, signal: null, stderr: "" },
   );
 

--- a/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -305,7 +305,7 @@ async function finish(observer) {
 
 async function finishAsTunnelClient(observer) {
   if (!observer.child.stdin.writableEnded) observer.child.stdin.end();
-  setImmediate(() => observer.child.kill("SIGTERM"));
+  observer.child.kill("SIGTERM");
   return await withTimeout(observer.completion, "tunnel-client observer completion");
 }
 
@@ -493,7 +493,7 @@ macRuntimeTest("the reviewed macOS sandbox denies a node:net loopback connection
   });
 });
 
-macRuntimeTest("v0.0.13 close-stdin then SIGTERM is a clean tunnel teardown", async (t) => {
+macRuntimeTest("v0.0.13 immediate close-stdin then SIGTERM is a clean teardown", async (t) => {
   const captureRoot = privateRoot(t);
   const observer = startObserver(t, captureRoot, randomUUID());
   await request(observer, "discover-1", "server/discover");

--- a/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
+++ b/tests/interoperability/test_qual_206_chatgpt_tunnel_exact_five_observer.mjs
@@ -303,10 +303,39 @@ async function finish(observer) {
   return await withTimeout(observer.completion, "observer completion");
 }
 
-async function finishAsTunnelClient(observer) {
+function waitMilliseconds(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function finishWithImmediateTunnelStop(observer) {
   if (!observer.child.stdin.writableEnded) observer.child.stdin.end();
   observer.child.kill("SIGTERM");
   return await withTimeout(observer.completion, "tunnel-client observer completion");
+}
+
+async function finishWithSignalBeforeEof(observer) {
+  observer.child.kill("SIGTERM");
+  await waitMilliseconds(25);
+  if (!observer.child.stdin.writableEnded) observer.child.stdin.end();
+  return await withTimeout(observer.completion, "signal-first observer completion");
+}
+
+function sessionEvents(captureRoot, slot) {
+  return readFileSync(join(captureRoot, slot, "events.jsonl"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+}
+
+function directChildProcessId(parentPid) {
+  const values = execFileSync(
+    "/usr/bin/pgrep",
+    ["-P", String(parentPid)],
+    { encoding: "utf8" },
+  ).trim().split(/\s+/u).filter(Boolean).map(Number);
+  assert.equal(values.length, 1, `expected one direct fixture child, received ${values}`);
+  assert.equal(Number.isSafeInteger(values[0]) && values[0] > 1, true);
+  return values[0];
 }
 
 function readJson(path) {
@@ -314,10 +343,7 @@ function readJson(path) {
 }
 
 function anomalyClassifications(captureRoot, slot) {
-  return readFileSync(join(captureRoot, slot, "events.jsonl"), "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line))
+  return sessionEvents(captureRoot, slot)
     .filter(({ event }) => event === "anomaly")
     .map(({ classification }) => classification);
 }
@@ -493,33 +519,57 @@ macRuntimeTest("the reviewed macOS sandbox denies a node:net loopback connection
   });
 });
 
-macRuntimeTest("v0.0.13 immediate close-stdin then SIGTERM is a clean teardown", async (t) => {
+macRuntimeTest("v0.0.13 immediate managed stop records its observed teardown order", async (t) => {
   const captureRoot = privateRoot(t);
   const observer = startObserver(t, captureRoot, randomUUID());
   await request(observer, "discover-1", "server/discover");
-  const completion = await finishAsTunnelClient(observer);
+  const completion = await finishWithImmediateTunnelStop(observer);
   assert.deepEqual(completion, { code: 0, signal: null, stderr: "" });
-  const events = readFileSync(join(captureRoot, "session-1", "events.jsonl"), "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line));
+  const events = sessionEvents(captureRoot, "session-1");
+  const teardown = events.find(({ phase }) => phase === "parent-teardown-signal");
+  assert.equal(teardown?.signal, "SIGTERM");
+  assert.equal(teardown?.immediate_parent_verified, true);
+  const pair = [
+    teardown?.stdin_closed_before_signal,
+    teardown?.stdin_eof_observed_within_grace,
+  ];
+  assert.equal(
+    JSON.stringify(pair) === JSON.stringify([true, false]) ||
+      JSON.stringify(pair) === JSON.stringify([false, true]),
+    true,
+  );
+  assert.equal(
+    events.find(({ phase }) => phase === "session-end").closure_stimulus,
+    pair[0] ? "stdin-eof-and-sigterm" : "sigterm-then-stdin-eof",
+  );
+});
+
+macRuntimeTest("SIGTERM followed by EOF within grace is a clean truthful teardown", async (t) => {
+  const captureRoot = privateRoot(t);
+  const observer = startObserver(t, captureRoot, randomUUID());
+  await request(observer, "discover-1", "server/discover");
+  const completion = await finishWithSignalBeforeEof(observer);
+  assert.deepEqual(completion, { code: 0, signal: null, stderr: "" });
+  const events = sessionEvents(captureRoot, "session-1");
   const teardown = events.find(({ phase }) => phase === "parent-teardown-signal");
   assert.deepEqual({
     signal: teardown?.signal,
     stdin_closed_before_signal: teardown?.stdin_closed_before_signal,
+    stdin_eof_observed_within_grace: teardown?.stdin_eof_observed_within_grace,
     immediate_parent_verified: teardown?.immediate_parent_verified,
   }, {
     signal: "SIGTERM",
-    stdin_closed_before_signal: true,
+    stdin_closed_before_signal: false,
+    stdin_eof_observed_within_grace: true,
     immediate_parent_verified: true,
   });
   assert.equal(
     events.find(({ phase }) => phase === "session-end").closure_stimulus,
-    "stdin-eof-and-sigterm",
+    "sigterm-then-stdin-eof",
   );
 });
 
-macRuntimeTest("SIGTERM before stdin closure fails closed", async (t) => {
+macRuntimeTest("SIGTERM without stdin EOF fails closed after the bounded grace", async (t) => {
   const captureRoot = privateRoot(t);
   const observer = startObserver(t, captureRoot, randomUUID());
   await request(observer, "discover-1", "server/discover");
@@ -529,6 +579,69 @@ macRuntimeTest("SIGTERM before stdin closure fails closed", async (t) => {
   assert.deepEqual(
     anomalyClassifications(captureRoot, "session-1"),
     ["premature-parent-sigterm"],
+  );
+  const events = sessionEvents(captureRoot, "session-1");
+  assert.equal(events.some(({ phase }) => phase === "parent-teardown-signal"), false);
+  assert.equal(
+    events.find(({ phase }) => phase === "session-end")?.protocol_session_status,
+    "failed",
+  );
+});
+
+macRuntimeTest("a partial host frame remains fatal during signal-first teardown", async (t) => {
+  const captureRoot = privateRoot(t);
+  const observer = startObserver(t, captureRoot, randomUUID());
+  await request(observer, "discover-1", "server/discover");
+  await new Promise((resolve, reject) => {
+    observer.child.stdin.write('{"jsonrpc":"2.0"', (error) => {
+      if (error === null || error === undefined) resolve();
+      else reject(error);
+    });
+  });
+  const completion = await finishWithSignalBeforeEof(observer);
+  assert.equal(completion.code, 2, completion.stderr);
+  assert.deepEqual(
+    anomalyClassifications(captureRoot, "session-1"),
+    ["truncated-frame"],
+  );
+});
+
+macRuntimeTest("host bytes after SIGTERM cannot widen the accepted observation", async (t) => {
+  const captureRoot = privateRoot(t);
+  const observer = startObserver(t, captureRoot, randomUUID());
+  await request(observer, "discover-1", "server/discover");
+  observer.child.kill("SIGTERM");
+  await waitMilliseconds(25);
+  await writeFrame(observer.child.stdin, {
+    jsonrpc: "2.0",
+    id: "late-list",
+    method: "tools/list",
+    params: { _meta: modernMeta() },
+  });
+  if (!observer.child.stdin.writableEnded) observer.child.stdin.end();
+  const completion = await withTimeout(observer.completion, "late host bytes rejection");
+  assert.equal(completion.code, 2, completion.stderr);
+  assert.deepEqual(
+    anomalyClassifications(captureRoot, "session-1"),
+    ["host-bytes-after-parent-teardown-signal"],
+  );
+});
+
+macRuntimeTest("fixture close before parent stdin EOF poisons teardown", async (t) => {
+  const captureRoot = privateRoot(t);
+  const observer = startObserver(t, captureRoot, randomUUID());
+  await request(observer, "discover-1", "server/discover");
+  const fixturePid = directChildProcessId(observer.child.pid);
+  observer.child.kill("SIGTERM");
+  await waitMilliseconds(25);
+  process.kill(-fixturePid, "SIGTERM");
+  await waitMilliseconds(25);
+  if (!observer.child.stdin.writableEnded) observer.child.stdin.end();
+  const completion = await withTimeout(observer.completion, "fixture close rejection");
+  assert.equal(completion.code, 2, completion.stderr);
+  assert.deepEqual(
+    anomalyClassifications(captureRoot, "session-1"),
+    ["fixture-close-before-parent-stdin-eof"],
   );
 });
 
@@ -591,7 +704,10 @@ macRuntimeTest(
     searchReceiptId,
     /^gis-ai-go:evidence-receipt:sha256:[0-9a-f]{64}$/u,
   );
-  assert.deepEqual(await finish(exactFive), { code: 0, signal: null, stderr: "" });
+  assert.deepEqual(
+    await finishWithSignalBeforeEof(exactFive),
+    { code: 0, signal: null, stderr: "" },
+  );
 
   assert.deepEqual(readdirSync(captureRoot).sort(), [
     "exact-five-v1.claim.json",
@@ -629,6 +745,22 @@ macRuntimeTest(
   assert.equal(summary.audit.guarded_api_invocations, 0);
   assert.equal(summary.audit.ledger_event_count, 4);
   assert.equal(summary.result_material.name, "exact-five-results.json");
+  const exactFiveEvents = sessionEvents(captureRoot, "session-2");
+  const exactFiveTeardown = exactFiveEvents.find(
+    ({ phase }) => phase === "parent-teardown-signal",
+  );
+  assert.deepEqual({
+    stdin_closed_before_signal: exactFiveTeardown?.stdin_closed_before_signal,
+    stdin_eof_observed_within_grace:
+      exactFiveTeardown?.stdin_eof_observed_within_grace,
+    closure_stimulus: exactFiveEvents.find(
+      ({ phase }) => phase === "session-end",
+    )?.closure_stimulus,
+  }, {
+    stdin_closed_before_signal: false,
+    stdin_eof_observed_within_grace: true,
+    closure_stimulus: "sigterm-then-stdin-eof",
+  });
 
   const resultMaterial = readJson(join(
     captureRoot,


### PR DESCRIPTION
## Summary

- preserve the pinned tunnel client's managed stop when a forwarded `SIGTERM`
  precedes OnStop's stdin EOF and duplicate `SIGTERM`;
- record the two delivery orders truthfully as `stdin-eof-and-sigterm` or
  `sigterm-then-stdin-eof`, with a bounded 250-millisecond EOF grace for the latter;
- absorb duplicate managed-stop `SIGTERM`s idempotently without emitting a second
  causal lifecycle event;
- continue to reject signal-only stop, late or partial input, incomplete exchanges
  and fixture closure before parent EOF; and
- verify both the exact-five production path and adversarial shutdown paths in the
  macOS observer and independent Python verifier.

## Evidence boundary

This changes only the private QUAL-206 ChatGPT observation shutdown seam. It does
not relax the five-call order, schema, result, receipt, inspection, provider,
runtime, tunnel or publication predicates. No new ChatGPT result is included and
no capability, activation, deployment, registry or release claim is made.

Part of #24.

## Verification

- focused macOS observer suite — 14 passed
- `pnpm run test:interoperability` — 90 passed
- `python -m unittest tests.contract.test_qual_206_chatgpt_tunnel_exact_five` — 30 passed
- `pnpm run typecheck`
- `python scripts/validate_contracts.py`
- `python scripts/check_links.py`
- `python scripts/scan_secrets.py`
- `git diff --check`
