### PR TITLE
fix(qual-206): verify live tunnel chronology

### DIFF
--- a/changelog.d/QUAL-206-chatgpt-live-verifier.fixed.md
+++ b/changelog.d/QUAL-206-chatgpt-live-verifier.fixed.md
@@ -1,0 +1,2 @@
+- Fixed the QUAL-206 ChatGPT tunnel verifier to distinguish outer and inner command
+  digests and to model real preflight and teardown chronology.

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -388,7 +388,11 @@ capture and operator records have been persisted.
 
 Hash the private conversation identifier locally; pass only the SHA-256 digest to
 the finaliser. Use UTC timestamps from the private operator record for the bounded
-observation window. Then create the immutable private run manifest:
+host observation window. The ready `before` and `after` status observations must
+bracket those timestamps and every host protocol request and response. Observer
+startup and readiness audit events may precede the host window; managed teardown,
+stream closure and summary events may follow it. Then create the immutable private
+run manifest:
 
 ```bash
 .venv/bin/python \

--- a/scripts/verify_qual_206_chatgpt_tunnel_exact_five.py
+++ b/scripts/verify_qual_206_chatgpt_tunnel_exact_five.py
@@ -62,6 +62,7 @@ NETWORK_SANDBOX = "macos-seatbelt-deny-network"
 NETWORK_SANDBOX_PROFILE_SHA256 = (
     "0a5222386587bf836d30a070bd759c0194f999bf5503ba76c6c0f8cb84b19db2"
 )
+FIXTURE_SERVER_AUTHORITY = "--exact-five-stdio-conformance-only"
 OPERATIONS = (
     "catalogue.search",
     "catalogue.describe",
@@ -190,6 +191,21 @@ def canonical_bytes(value: Any) -> bytes:
 
 def canonical_line(value: dict[str, Any]) -> bytes:
     return canonical_bytes(value) + b"\n"
+
+
+def expected_fixture_command_sha256(runtime_digests: dict[str, str]) -> str:
+    """Bind the observer's inner network-denied fixture command independently."""
+    return sha256_bytes(canonical_bytes([
+        host002.EXPECTED_SANDBOX_EXEC_SHA256,
+        "-p",
+        host002.NETWORK_SANDBOX_PROFILE,
+        EXPECTED_NODE_SHA256,
+        "--import",
+        runtime_digests["provider_egress_guard_source_sha256"],
+        runtime_digests["fixture_source_sha256"],
+        FIXTURE_SERVER_AUTHORITY,
+        f"--scenario={SCENARIO}",
+    ]))
 
 
 def event_digest(value: dict[str, Any]) -> str:
@@ -562,7 +578,7 @@ def verify_event_log(
     parent_identity: dict[str, Any],
     runtime_digests: dict[str, str],
     runtime_closure: dict[str, Any],
-    mcp_command_sha256: str,
+    fixture_command_sha256: str,
     event_validator: Draft202012Validator,
 ) -> tuple[list[dict[str, Any]], Counter[str], Counter[str], dict[str, int]]:
     if not raw or not raw.endswith(b"\n") or raw.endswith(b"\r\n"):
@@ -647,7 +663,7 @@ def verify_event_log(
             for field, digest in runtime_digests.items()
         )
         or start["runtime_closure"] != runtime_closure
-        or start["observer_runtime"]["command_sha256"] != mcp_command_sha256
+        or start["observer_runtime"]["command_sha256"] != fixture_command_sha256
         or start["credential_environment_observed"] is not False
         or start["credential_environment_forwarded"] is not False
         or start["mcp_child_network_access_allowed"] is not False
@@ -792,11 +808,17 @@ def verify_event_observation_window(
     if not events:
         fail("the session event window is empty")
     observed = [parse_time(event["observed_at"]) for event in events]
-    if (
-        any(value < started or value > finished for value in observed)
-        or any(left > right for left, right in zip(observed, observed[1:]))
+    if any(left > right for left, right in zip(observed, observed[1:])):
+        fail("session events are not monotonic")
+    protocol_events = [
+        event for event in events
+        if event["event"] in {"request", "response", "notification"}
+    ]
+    if not protocol_events or any(
+        not started <= parse_time(event["observed_at"]) <= finished
+        for event in protocol_events
     ):
-        fail("session events are not monotonic within the declared observation window")
+        fail("session protocol events are outside the declared observation window")
 
 
 def verify_request_argument_bindings(
@@ -837,7 +859,7 @@ def verify_sessions(
     node_path: str,
     parent_identity: dict[str, Any],
     runtime_closure: dict[str, Any],
-    mcp_command_sha256: str,
+    fixture_command_sha256: str,
     event_validator: Draft202012Validator | None = None,
 ) -> tuple[dict[str, Any], Counter[str], Counter[str], Counter[str], int]:
     session_names = sorted(
@@ -929,7 +951,7 @@ def verify_sessions(
             parent_identity=parent_identity,
             runtime_digests=runtime_digests,
             runtime_closure=runtime_closure,
-            mcp_command_sha256=mcp_command_sha256,
+            fixture_command_sha256=fixture_command_sha256,
             event_validator=event_check,
         )
         verify_event_observation_window(
@@ -1142,6 +1164,7 @@ def verify_and_project(
     (source_verifier or verify_source)(manifest)
     _profile, profile_arguments, profile_sha256 = load_profile()
     runtime_digests = source_runtime_digests(profile_sha256)
+    fixture_command_sha256 = expected_fixture_command_sha256(runtime_digests)
     runtime_closure = (
         runtime_reproducer(
             manifest["source"]["commit"],
@@ -1169,7 +1192,7 @@ def verify_and_project(
             "sha256": manifest["tunnel_client"]["binary_sha256"],
         },
         runtime_closure,
-        mcp_command_sha256,
+        fixture_command_sha256,
         event_validator,
     )
     if (

--- a/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
+++ b/tests/contract/test_qual_206_chatgpt_tunnel_exact_five.py
@@ -360,23 +360,44 @@ class ChatGptTunnelPortableContractTests(unittest.TestCase):
                 finished=finished,
             )
 
+        lifecycle_outside = copy.deepcopy(sessions[1])
+        lifecycle_outside[0]["observed_at"] = iso_milliseconds(
+            started - timedelta(seconds=1)
+        )
+        verifier.verify_event_observation_window(
+            lifecycle_outside,
+            started=started,
+            finished=finished,
+        )
         outside = copy.deepcopy(sessions[1])
-        outside[0]["observed_at"] = iso_milliseconds(finished + timedelta(seconds=1))
+        last_protocol = max(
+            verifier.parse_time(event["observed_at"])
+            for event in outside
+            if event["event"] in {"request", "response", "notification"}
+        )
         non_monotonic = copy.deepcopy(sessions[1])
         non_monotonic[1]["observed_at"] = iso_milliseconds(
             verifier.parse_time(non_monotonic[0]["observed_at"])
             - timedelta(milliseconds=1)
         )
-        for label, events in (("outside", outside), ("non-monotonic", non_monotonic)):
-            with self.subTest(mutation=label), self.assertRaisesRegex(
-                verifier.TunnelExactFiveVerificationError,
-                "not monotonic within the declared observation window",
-            ):
-                verifier.verify_event_observation_window(
-                    events,
-                    started=started,
-                    finished=finished,
-                )
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "protocol events are outside the declared observation window",
+        ):
+            verifier.verify_event_observation_window(
+                outside,
+                started=started,
+                finished=last_protocol - timedelta(milliseconds=1),
+            )
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "session events are not monotonic",
+        ):
+            verifier.verify_event_observation_window(
+                non_monotonic,
+                started=started,
+                finished=finished,
+            )
 
     def test_cli_requires_explicit_node_and_pnpm_paths(self) -> None:
         verifier_arguments = [
@@ -480,14 +501,19 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
         )
         cls.profile = json.loads(verifier.PROFILE.read_text(encoding="utf-8"))
         cls._create_observer_capture()
-        cls.command_sha256 = cls._session_start("session-1")["observer_runtime"][
+        cls.fixture_command_sha256 = cls._session_start("session-1")["observer_runtime"][
             "command_sha256"
         ]
         if (
             cls._session_start("session-2")["observer_runtime"]["command_sha256"]
-            != cls.command_sha256
+            != cls.fixture_command_sha256
         ):
-            raise AssertionError("the fake sessions did not retain one MCP command")
+            raise AssertionError("the fake sessions did not retain one fixture command")
+        cls.outer_mcp_command_sha256 = hashlib.sha256(
+            b"synthetic outer tunnel MCP command"
+        ).hexdigest()
+        if cls.outer_mcp_command_sha256 == cls.fixture_command_sha256:
+            raise AssertionError("the fake inner and outer command digests are not distinct")
         cls._create_statuses_and_manifest()
         cls.private_validator = validator(
             verifier.PRIVATE_SCHEMA,
@@ -692,7 +718,7 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
             "alias": PROFILE_NAME,
             "profile_name": PROFILE_NAME,
             "target_kind": "command",
-            "mcp_command_sha256": cls.command_sha256,
+            "mcp_command_sha256": cls.outer_mcp_command_sha256,
             "tunnel_id": TUNNEL_ID,
             "remote": {**REMOTE_IDENTITY, "found": not stopped},
             "stale": False,
@@ -715,15 +741,24 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
 
     @classmethod
     def _create_statuses_and_manifest(cls) -> None:
-        first = datetime.fromisoformat(
-            cls._session_start("session-1")["observed_at"].replace("Z", "+00:00")
-        )
-        last_event = json.loads(
-            (cls.capture / "session-2" / "events.jsonl")
+        events = [
+            json.loads(line)
+            for slot in ("session-1", "session-2")
+            for line in (cls.capture / slot / "events.jsonl")
             .read_text(encoding="utf-8")
-            .splitlines()[-1]
+            .splitlines()
+        ]
+        protocol_times = [
+            datetime.fromisoformat(event["observed_at"].replace("Z", "+00:00"))
+            for event in events
+            if event["event"] in {"request", "response", "notification"}
+        ]
+        first = min(protocol_times)
+        last = max(protocol_times)
+        final_lifecycle = max(
+            datetime.fromisoformat(event["observed_at"].replace("Z", "+00:00"))
+            for event in events
         )
-        last = datetime.fromisoformat(last_event["observed_at"].replace("Z", "+00:00"))
         before_raw = write_private_json(
             cls.capture / verifier.STATUS_BEFORE_NAME,
             cls._status("before", iso_milliseconds(first - timedelta(milliseconds=1))),
@@ -734,7 +769,10 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
         )
         stopped_raw = write_private_json(
             cls.capture / verifier.STATUS_STOPPED_NAME,
-            cls._status("stopped", iso_milliseconds(last + timedelta(milliseconds=2))),
+            cls._status(
+                "stopped",
+                iso_milliseconds(final_lifecycle + timedelta(milliseconds=1)),
+            ),
         )
         claim_raw = (cls.capture / verifier.CLAIM_NAME).read_bytes()
         claim = json.loads(claim_raw)
@@ -1085,7 +1123,7 @@ class ChatGptTunnelExactFiveContractTests(unittest.TestCase):
         self.assertEqual(projection["transport"]["provider_transport_calls"], 1)
         self.assertTrue(projection["tunnel"]["teardown_verified"])
         self.assertEqual(
-            projection["tunnel"]["mcp_command_sha256"], self.command_sha256
+            projection["tunnel"]["mcp_command_sha256"], self.outer_mcp_command_sha256
         )
         receipts = projection["result"]["operation_receipts"]
         self.assertEqual(len(receipts), 5)
@@ -1442,7 +1480,22 @@ process.stdout.write(`${JSON.stringify([ready, stopped])}\n`);
         self.rebind_session_events(slot, events)
         with self.assertRaisesRegex(
             verifier.TunnelExactFiveVerificationError,
-            "not monotonic within the declared observation window",
+            "protocol events are outside the declared observation window",
+        ):
+            self.verify()
+
+    def test_inner_fixture_command_digest_is_independently_bound(self) -> None:
+        slot = "session-2"
+        event_path = self.case / slot / "events.jsonl"
+        events = [
+            json.loads(line)
+            for line in event_path.read_text(encoding="utf-8").splitlines()
+        ]
+        events[0]["observer_runtime"]["command_sha256"] = "d" * 64
+        self.rebind_session_events(slot, events)
+        with self.assertRaisesRegex(
+            verifier.TunnelExactFiveVerificationError,
+            "runtime or source binding changed",
         ):
             self.verify()
 


### PR DESCRIPTION
## Summary

- distinguish the outer tunnel command digest from the independently derived,
  network-denied fixture command digest
- treat the declared execution interval as the host protocol observation window,
  while retaining monotonic observer setup and teardown events outside it
- add adversarial regression coverage and clarify the operator runbook

## Why

A completed private ChatGPT exact-five observation exposed two pre-existing
verifier assumptions that the synthetic fixtures had masked:

1. the tunnel status binds the outer tunnel observer command, while the observer
   event log binds its downstream sandboxed fixture command;
2. observer setup necessarily precedes the ready `before` status and managed
   teardown necessarily follows the `after` status.

The correction keeps both command identities independently source-bound and keeps
all events monotonic. Only host protocol requests, responses and notifications
must fall within the declared observation interval. The private diagnostic capture
now verifies as one session with seven protocol requests and exactly five ordered
tool calls, but it remains local and is not proposed as public evidence because it
is bound to the pre-fix source commit.

## Verification

- 31 focused QUAL-206 ChatGPT tunnel verifier contract tests
- 485 repository Python tests
- 22 geo-execution service tests with real loopback sockets
- 222 TypeScript gateway and package tests
- 90 interoperability tests and seven deterministic local receipt checks
- 93 schemas and 153 contract records
- 474 documentation links, 183 research hashes and two research ledgers
- type checking
- secret and machine-path scan
- `git diff --check`

An independent review found no correctness, security, closed-contract, coverage or
British-English defect. Its single changelog-format finding is resolved in this
commit.

## Boundary

This PR changes the verifier and its documentation only. It does not publish the
private ChatGPT capture, alter the five-operation runtime, activate a provider,
register the assembly, deploy a service or release `v0.2.0`.
