### PR TITLE
docs(qual-206): reconcile ChatGPT exact-five evidence

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Delivery progress
 
-Last updated: 27 August 2026
+Last updated: 28 August 2026
 
 ## Current outcome
 
@@ -85,22 +85,25 @@ The supported target active set is exactly `catalogue.search`,
   valid. This closes local STDIO exact-five model capability only. Raw capture
   remains local and owner-only; remote HTTP, live-provider use, registry publication,
   activation, deployment and release remain false and open;
-- prepare one separate fail-closed ChatGPT exact-five remote-host observation through
-  the OpenAI secure tunnel to a local STDIO child. The pack pins reviewed
-  tunnel-client `v0.0.13`, isolates the observer and deterministic fixture from
-  recognised credentials, denies the fixture network access, permits up to eight
-  contiguous discovery/session
-  slots while requiring every call in one claimed session, attests remote and local
-  tunnel health before and after the host run, binds the generated and dependency
-  closures, requires credential-free stopped-state evidence, and can publish only a
-  verifier-built path-free pass. Merge and verify the pack before making the bounded
-  observation from a fresh clean detached protected-main checkout. These
-  implementation bytes contain no new ChatGPT result and do not close direct public
-  Streamable HTTP/TLS, live-provider, registry, activation, deployment or release;
+- accept the verifier-produced
+  [ChatGPT exact-five projection](tests/interoperability/evidence/chatgpt-tunnel-exact-five-2026-08-28.json)
+  from exact protected-main source commit
+  `d8fb8728b0d02afc79b28cf72625ee899d3eb325`, tree
+  `fa3a2bc2f9e7be576510f76a7a989c80cd54df42`. The verifier-produced projection
+  records the observation at `2026-08-28T22:17:50.190Z`; it merged through
+  [pull request 95](https://github.com/chris-page-gov/gis-ai-go/pull/95) as
+  protected-main evidence commit `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`.
+  It records `capability_pass` for one ChatGPT remote-host observation through the
+  reviewed OpenAI secure tunnel to a network-denied deterministic local STDIO child,
+  with all five ordered MCP `2026-07-28` calls and receipts independently valid.
+  The private capture remains local and owner-only. This closes only that narrow
+  remote-host-through-secure-tunnel capability; direct public Streamable HTTP/TLS,
+  live-provider use, registry publication, activation, deployment and release remain
+  false and open;
 - retain the accepted fail-closed real-socket loopback HTTP exact-five preflight,
   whose owner-only raw capture remains local and whose independent path-free
   projection keeps remote-host acceptance false and capability unscored;
-- complete the remaining remote-HTTP host evidence;
+- complete the remaining direct public Streamable HTTP/TLS host evidence;
   and
 - continue provider-neutral preparation, but stop before public provisioning or
   spend until a provider account, numeric monthly ceiling and operational hosting
@@ -378,7 +381,8 @@ or release is claimed.
   [run 32819344472](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32819344472)
   passed CodeQL for Actions, JavaScript/TypeScript and Python. The path-free public
   summary records transport readiness only; capability, the exact-five operation
-  journey, remote HTTP evidence, registration, activation, deployment and release
+  journey, direct public Streamable HTTP/TLS evidence, registration, activation,
+  deployment and release
   remain incomplete; and
 - the exact-five local HTTP harness merged through
   [pull request 66](https://github.com/chris-page-gov/gis-ai-go/pull/66) as
@@ -408,8 +412,9 @@ or release is claimed.
 1. Preserve the verified Claude Code `2.1.241` and `2.1.245` strict-modern transport
    summaries, the separate historical default-negotiation record, the accepted
    one-case `HOST-002` capability projection, the exact-five local STDIO capability
-   projection and the protected-main loopback HTTP projection. Complete the remaining
-   remote-HTTP host evidence without widening any narrow result.
+   projection, the accepted ChatGPT secure-tunnel exact-five projection and the
+   protected-main loopback HTTP projection. Complete the remaining direct public
+   Streamable HTTP/TLS host evidence without widening any narrow result.
 2. Retain the exact protected-main UBI, independent-derivation and provenance
    evidence from runs `32760872035` and `32760871684`; rebuild and repeat it after
    every later source-changing activation or release commit.
@@ -433,26 +438,28 @@ or release is claimed.
 - The gateway assertion is a typed private hand-off, not workload authentication or
   a signed policy decision. Any non-loopback deployment remains blocked on explicit
   service identity and network-policy evidence.
-- Activating or publishing a catalogue service remains hard-blocked. Raw protocol
-  transcripts, deterministic local host fixtures and the pinned SDK clients do not
-  establish independent live major-host capability. The retained 24 August Claude
+- Activating or publishing a catalogue service remains hard-blocked. The accepted
+  ChatGPT exact-five projection establishes one remote host through the OpenAI secure
+  tunnel, but not a direct public Streamable HTTP/TLS service or live-provider use.
+  The retained 24 August Claude
   Code `2.1.241` default-negotiation observation remains an explained historical
   `2025-11-25` result. The separate 25 August v2 automatic-negotiation observations
   for exact Claude Code `2.1.241` and `2.1.245` establish strict MCP `2026-07-28`
   desktop-STDIO transport readiness, but neither involved a model task or tool
   call. The later accepted `HOST-002` projection scores one bounded
-  `catalogue.search` case only. A separate fresh protected-main observation now
-  passes all five ordered local STDIO calls; remote-HTTP host evidence remains
-  incomplete.
+  `catalogue.search` case only. A separate fresh protected-main observation passes
+  all five ordered local STDIO calls. Direct public Streamable HTTP/TLS host evidence
+  remains incomplete.
   Security, accessibility, governed ingress/storage admission, retention/disposal
   and host-specific lifecycle evidence remain activation gates.
 - Direct routes and MCP transports now exist on protected `main`, but the
   exact-five assembly is `candidate-unregistered`, production registration is
   false, the production/default capability arrays are empty, shipped readiness is
   `503`, and there is no public service deployment or activation override. The
-  repository-local matrix and accepted loopback HTTP projection are non-live and
-  cannot close issue #23 or issue #24; independent hosts, a live provider,
-  authorised deployment and release evidence remain outstanding.
+  repository-local matrix and accepted loopback HTTP projection are non-live. The
+  accepted ChatGPT secure-tunnel result is not a public service endpoint and cannot
+  establish live-provider, deployment or release readiness; those evidence gates
+  remain outstanding.
 - The historical Debian image findings are superseded for the accepted repository
   candidate by exact protected-main UBI commit `dda0eb9`, whose producer and
   independent archives were byte-identical and whose image, SBOM and evidence
@@ -470,6 +477,24 @@ or release is claimed.
   the open product.
 
 ## Latest evidence
+
+- ChatGPT exact-five remote-host capability through the OpenAI secure tunnel: the
+  verifier-produced
+  [path-free projection](tests/interoperability/evidence/chatgpt-tunnel-exact-five-2026-08-28.json)
+  binds exact protected-main source commit
+  `d8fb8728b0d02afc79b28cf72625ee899d3eb325`, tree
+  `fa3a2bc2f9e7be576510f76a7a989c80cd54df42`, and records the observation at
+  `2026-08-28T22:17:50.190Z`. The evidence file has
+  SHA-256 `e394466801e78f1eaa024cd01c1109ec21d0accbe517e546e18bc45e6eb5a1c9`
+  and merged through
+  [pull request 95](https://github.com/chris-page-gov/gis-ai-go/pull/95) as
+  protected-main evidence commit `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`.
+  It records one call-bearing session, five ordered MCP `2026-07-28` calls, five
+  independently valid receipts, structured/plain-text parity and a valid
+  search-to-inspection relationship. The deterministic fixture made one synthetic
+  provider transport call and zero guarded live-provider API invocations. The result
+  is `capability_pass`; direct public Streamable HTTP/TLS, live-provider use,
+  registry publication, activation, deployment and release remain false;
 
 - Claude Code `2.1.245` bounded exact-five capability: the fresh verifier-produced
   [path-free projection](tests/interoperability/evidence/claude-code-2.1.245-exact-five-capability-2026-08-27.json)
@@ -621,8 +646,8 @@ or release is claimed.
   session. Independent offline replay accepted both sessions with zero provider
   calls, pending requests, anomalies or stderr, and read-only process checks found
   no retained observer or fixture. That 2.1.241 observation itself establishes
-  transport readiness only, not capability or exact-five; remote-HTTP evidence
-  remains incomplete. Raw captures remain owner-only and local;
+  transport readiness only, not capability or exact-five; direct public Streamable
+  HTTP/TLS evidence remains incomplete. Raw captures remain owner-only and local;
 
 - Claude Code `2.1.241` historical default-negotiation observation: the
   [additive source-bound summary](tests/interoperability/evidence/claude-code-2.1.241-stdio-observation-2026-08-24.json)

--- a/changelog.d/QUAL-206-chatgpt-tunnel-exact-five.added.md
+++ b/changelog.d/QUAL-206-chatgpt-tunnel-exact-five.added.md
@@ -1,8 +1,10 @@
-- Add a fail-closed, evidence-only pack for one future ChatGPT exact-five remote-host
-  observation through the reviewed OpenAI secure tunnel to a local MCP STDIO child.
-  It pins tunnel-client `v0.0.13`, isolates credentials, permits up to eight
-  discovery/session slots while requiring all five calls in one claimed session,
-  binds the built runtime and dependency closure, proves credential-free local
-  teardown, independently verifies receipts and provenance, and can publish only a
-  minimised pass projection. These bytes include no live observation, provider
-  call, activation, deployment or release.
+- Add a fail-closed ChatGPT exact-five remote-host evidence lane through reviewed
+  `openai/tunnel-client` `v0.0.13` to a network-denied deterministic local MCP STDIO
+  child, then record the verifier-produced
+  `tests/interoperability/evidence/chatgpt-tunnel-exact-five-2026-08-28.json`
+  `capability_pass` from exact source commit
+  `d8fb8728b0d02afc79b28cf72625ee899d3eb325`. The public projection merged through
+  pull request 95 as protected-main evidence commit
+  `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`. It proves only the bounded
+  remote-host-through-secure-tunnel lane; direct public Streamable HTTP/TLS, a live
+  provider, registry publication, activation, deployment and release remain false.

--- a/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
+++ b/docs/operations/QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md
@@ -1,7 +1,8 @@
 # QUAL-206 ChatGPT secure-tunnel exact-five observation
 
-- status: evidence pack only; no exact-five ChatGPT observation or public pass
-  is included in these bytes
+- status: `capability_pass` projection accepted on protected `main` through
+  [pull request 95](https://github.com/chris-page-gov/gis-ai-go/pull/95) at evidence
+  commit `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`
 - host lane: ChatGPT remote host through the OpenAI secure tunnel
 - local child transport: operating-system STDIO pipes
 - direct public Streamable HTTP over TLS: not exercised
@@ -11,9 +12,9 @@
 
 ## Purpose
 
-This runbook prepares one bounded ChatGPT observation of the unchanged
-`exact-five-v1` capability profile. It is additive to the accepted Claude Code
-local STDIO result. It does not change, repeat or relabel that result.
+This runbook records and supports a repeat of one bounded ChatGPT observation of the
+unchanged `exact-five-v1` capability profile. It is additive to the accepted Claude
+Code local STDIO result. It does not change, repeat or relabel that result.
 
 The observation can establish only this narrow claim:
 
@@ -23,22 +24,48 @@ The observation can establish only this narrow claim:
 
 It cannot establish a direct public MCP endpoint, public hostname, product TLS
 ingress, live geospatial-provider operation, registry publication, activation,
-deployment or release. The public projection keeps each of those claims false.
+deployment or release. The accepted public projection keeps each of those claims
+false.
 
-## Why the pack is merged before the observation
+## Accepted result
+
+The verifier-produced
+[public projection](../../tests/interoperability/evidence/chatgpt-tunnel-exact-five-2026-08-28.json)
+records `capability_pass` from exact protected-main source commit
+`d8fb8728b0d02afc79b28cf72625ee899d3eb325`, tree
+`fa3a2bc2f9e7be576510f76a7a989c80cd54df42`. The verifier-produced projection
+records the observation at `2026-08-28T22:17:50.190Z`. That projection, with
+SHA-256 `e394466801e78f1eaa024cd01c1109ec21d0accbe517e546e18bc45e6eb5a1c9`,
+merged through pull request 95 as protected-main evidence commit
+`060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`.
+
+ChatGPT made the five ordered MCP `2026-07-28` calls in one call-bearing session
+through reviewed `openai/tunnel-client` `v0.0.13` to the network-denied deterministic
+local STDIO child. Independent verification accepted every result contract, all five
+distinct receipts, structured/plain-text parity and the search-to-inspection
+relationship. The fixture made one synthetic provider transport call and zero
+guarded live-provider API invocations. Raw capture remains owner-only and local.
+
+This accepted result proves only the remote-host-through-secure-tunnel lane. It does
+not prove direct public Streamable HTTP/TLS, a live geospatial provider, registry
+publication, activation, deployment or release.
+
+## Why the pack was merged before the observation
 
 The observer, schemas, result checker, independent verifier and mutation tests must
 first pass review on protected `main`. The live step must then use a new clean,
 detached worktree at that exact protected-main commit. This avoids using unreviewed
 capture code and prevents a later commit from being attributed to an earlier run.
 
-Use two pull requests:
+The accepted sequence used two pull requests:
 
-1. merge this evidence-preparation pack with no live result;
-2. make one bounded observation from exact protected `main`, independently verify
-   the private capture, then submit only the minimised public projection.
+1. the evidence-preparation pack merged with no live result;
+2. one bounded observation ran from exact protected `main`, the private capture
+   passed independent verification, and only the minimised public projection was
+   submitted.
 
-Do not make the live observation from the pack branch.
+Any repeat must preserve this sequence; do not make a live observation from an
+unmerged pack branch.
 
 ## Frozen profile
 

--- a/docs/operations/QUAL-206_INTEROPERABILITY.md
+++ b/docs/operations/QUAL-206_INTEROPERABILITY.md
@@ -1,7 +1,7 @@
 # QUAL-206 host interoperability and secure-tunnel runbook
 
-- status: local conformance and four ChatGPT secure-tunnel probes passed, including
-  the current final telemetry wrapper;
+- status: local conformance and four historical ChatGPT secure-tunnel probes passed,
+  including the current final telemetry wrapper;
   a test-only real-process exact-five STDIO transcript, cancellation, unsupported
   traffic and all seven suspension scenarios pass locally with zero live-provider
   calls; the additive test-only real-socket loopback HTTP journey now has an
@@ -16,10 +16,12 @@
   canonical `catalogue.search` call and independent receipt verification;
   a fresh bounded exact-five observation from later exact protected-main bytes
   passed all five ordered local STDIO calls and independent verification;
-  a separate ChatGPT secure-tunnel exact-five evidence pack now pins the current
-  reviewed tunnel client and closed verifier but contains no live observation;
+  a separate ChatGPT secure-tunnel exact-five observation from exact protected-main
+  source passed all five ordered calls and independent verification, producing an
+  accepted path-free `capability_pass` projection;
   deterministic `HOST-015` application recovery passes locally but remains non-live
-  and unscored; remote HTTP evidence and activation remain pending
+  and unscored; direct public Streamable HTTP/TLS evidence and activation remain
+  pending
 - reviewed source base: `66507f9a6e6c0da23a8af4682268f9362d93bc06`
 - local HTTP transport evidence source: protected `main` commit
   `066a9cb22f719d22e29c95cd99857ddf694c878e`
@@ -29,6 +31,10 @@
   `5837bd65a482e90238c466673318f007e305c744`
 - accepted Claude exact-five capability source: protected `main` commit
   `029a9d5c7efcafcd45941194394384ee6c578fe9`
+- accepted ChatGPT exact-five capability source: protected `main` commit
+  `d8fb8728b0d02afc79b28cf72625ee899d3eb325`
+- accepted ChatGPT exact-five evidence publication: protected `main` commit
+  `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`
 - historical Claude legacy transport-readiness source: protected `main` commit
   `30b575beb27ff805745a2864c1acf44392774046`
 - legacy fallback integration base: protected `main` commit
@@ -100,8 +106,26 @@ MCP `2026-07-28` calls over local STDIO at reported turn 7. Every result contrac
 distinct receipt, structured/plain-text parity check and the inspection relationship
 passed independent verification. The deterministic fixture made one synthetic
 provider transport call and zero guarded live-provider API invocations. This closes
-local STDIO exact-five model capability only; remote HTTP and every production gate
-remain open.
+local STDIO exact-five model capability only; direct public Streamable HTTP/TLS and
+every production gate remain open.
+
+The independently verified
+[ChatGPT secure-tunnel exact-five projection](../../tests/interoperability/evidence/chatgpt-tunnel-exact-five-2026-08-28.json)
+records `capability_pass` from exact protected-main source commit
+`d8fb8728b0d02afc79b28cf72625ee899d3eb325`, tree
+`fa3a2bc2f9e7be576510f76a7a989c80cd54df42`. The verifier-produced projection
+records the observation at `2026-08-28T22:17:50.190Z` and has SHA-256
+`e394466801e78f1eaa024cd01c1109ec21d0accbe517e546e18bc45e6eb5a1c9`
+and merged through
+[pull request 95](https://github.com/chris-page-gov/gis-ai-go/pull/95) as
+protected-main evidence commit `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f`.
+ChatGPT made all five ordered MCP `2026-07-28` calls in one call-bearing session
+through the reviewed OpenAI secure tunnel to a network-denied deterministic local
+STDIO child. Every result contract, distinct receipt, structured/plain-text parity
+check and the inspection relationship passed independent verification. This closes
+only that secure-tunnel remote-host capability: direct public Streamable HTTP/TLS,
+live-provider use, registry publication, activation, deployment and release remain
+false.
 
 ## Build the exact local candidate
 
@@ -158,12 +182,11 @@ path-free summary and checksums; retain the detailed JSONL locally.
 
 ## OpenAI secure tunnel and ChatGPT
 
-The new
+The
 [ChatGPT secure-tunnel exact-five runbook](QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md)
-defines the post-merge, one-observation procedure. Its implementation bytes are an
-evidence pack only: they do not establish a new ChatGPT capability result. The lane
-is a remote ChatGPT host through the OpenAI secure tunnel to a local STDIO child; it
-is not a direct public Streamable HTTP/TLS endpoint.
+records the accepted result and defines the repeat procedure. The lane is a remote
+ChatGPT host through the OpenAI secure tunnel to a local STDIO child; it is not a
+direct public Streamable HTTP/TLS endpoint.
 
 ### Historical verified client
 
@@ -178,10 +201,10 @@ The live probe used official `openai/tunnel-client` `v0.0.12`:
 
 Verify downloaded bytes against the release's `SHA256SUMS.txt` before use.
 
-### Current reviewed client for the exact-five pack
+### Current reviewed client for the exact-five observation
 
-The future exact-five observation must use official `openai/tunnel-client`
-`v0.0.13`, released after the historical probes. The pack pins:
+The accepted exact-five observation used official `openai/tunnel-client` `v0.0.13`,
+released after the historical probes. The evidence pack pins:
 
 - release archive SHA-256:
   `15abf165f06050af642c948ba6bd6c905191dc5420a9422dadde2b49d892e2c6`;
@@ -206,7 +229,12 @@ configuration, enable raw HTTP logging or commit it. Creating or changing a tunn
 requires an authorised Platform session or organisation admin key; the runtime
 project key alone cannot do administrative tunnel CRUD.
 
-### Create and connect
+### Historical create-and-connect context
+
+The steps below record the connection context used for the accepted observation.
+For any repeat, follow
+[the exact-five runbook](QUAL-206_CHATGPT_TUNNEL_EXACT_FIVE.md) as the normative
+procedure and re-verify the current OpenAI interface before changing the app.
 
 1. In the OpenAI Platform, open **Settings → Organisation → Tunnels**.
 2. Create a tunnel with a descriptive, non-secret name, select the intended
@@ -230,8 +258,9 @@ tunnel-client runtimes connect \
 7. Choose **Plugins → Create app → Tunnel**, select the exact tunnel, select
    **No Auth** for this anonymous-open local catalogue, acknowledge the unreviewed
    connector warning, create the app and connect it.
-8. Inspect the app before use. It must advertise only the two expected read actions
-   with the exact closed input schemas.
+8. Inspect the app before use. It must advertise exactly the five canonical actions
+   `catalogue.search`, `catalogue.describe`, `selection.resolve`, `data.query` and
+   `evidence.inspect`, each with its exact closed input schema.
 
 The current authorised proof used:
 
@@ -286,7 +315,7 @@ MCP registry for a conformance run.
 
 | Host | Required test | Current evidence state |
 | --- | --- | --- |
-| ChatGPT | Secure tunnel, discovery, search, receipt and text fallback | Four probes passed; latest run binds the final wrapper and current receipt |
+| ChatGPT | Secure tunnel and five ordered MCP `2026-07-28` calls with receipt and relationship verification | `capability_pass` from exact protected main `d8fb872`; the path-free projection merged as `060e019`; direct public Streamable HTTP/TLS remains open |
 | Codex CLI 0.146.1 | Isolated non-interactive STDIO search and inline evidence | `not_ready`: legacy `2025-06-18` initialisation rejected `-32022`; capability unscored |
 | Antigravity IDE 1.107.0 | Temporary profile, STDIO discovery, search, resource and fallback | `not_ready`: isolated profile signed out and server directory unavailable; zero MCP traffic |
 | Claude Code 2.1.204, modern-only seam, 20 August | Strict temporary MCP configuration and non-persistent session | `not_ready`: legacy `initialize` rejected `-32022`; capability unscored |
@@ -295,7 +324,7 @@ MCP registry for a conformance run.
 | Claude Code 2.1.241, v2 automatic negotiation, 25 August | Two-session credential-free `mcp list` observation against exact protected main `c679b6f` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
 | Claude Code 2.1.245, v2 automatic negotiation, 25 August | Fresh two-session credential-free `mcp list` observation after the parent-identity repair reached exact protected main `e905c63` | `ready`: `server/discover` and `tools/list` passed at `2026-07-28`; capability unscored |
 | Claude Code 2.1.245, bounded `HOST-002`, 26 August | One model-mediated `catalogue.search` call from exact protected main `5837bd6`, with independent receipt verification | `capability_pass` for the one bounded MCP `2026-07-28` case; exact-five and remote HTTP remain open |
-| Claude Code 2.1.245, bounded exact-five, 27 August | Five ordered model-mediated calls from exact protected main `029a9d5`, with independent contract, receipt, parity and relationship verification | `capability_pass` for local MCP `2026-07-28` STDIO exact-five; remote HTTP remains open |
+| Claude Code 2.1.245, bounded exact-five, 27 August | Five ordered model-mediated calls from exact protected main `029a9d5`, with independent contract, receipt, parity and relationship verification | `capability_pass` for local MCP `2026-07-28` STDIO exact-five; direct public Streamable HTTP/TLS remains open |
 | VS Code 1.134.0 | Temporary workspace and MCP registry; prove correct window attachment | `not_ready`: no GitHub token and no proved chat attachment; zero MCP traffic |
 | Official SDK client | HTTP and STDIO discovery, calls, resources and shutdown | Accepted on protected `main` |
 
@@ -730,7 +759,8 @@ modern-only attempt remains `not_ready` because it received `-32022`, and the
 uncommitted fallback observation remains exploratory. The later accepted
 `HOST-002` projection scores only its separately authorised bounded
 `catalogue.search` case. The later exact-five projection separately closes local
-desktop STDIO model capability. Complete the remaining remote HTTP evidence before
+desktop STDIO model capability. Complete the remaining direct public Streamable
+HTTP/TLS evidence before
 claiming the full independent-host gate.
 
 This fallback is local-only. Do not attach it to the existing ChatGPT tunnel,
@@ -906,8 +936,8 @@ remains local and owner-only. The deterministic fixture made one synthetic provi
 transport call and zero guarded live-provider API invocations.
 
 This closes local STDIO exact-five model capability only. It does not establish
-remote HTTP interoperability, live-provider readiness, registry publication, activation,
-deployment or release. See the
+direct public Streamable HTTP/TLS interoperability, live-provider readiness,
+registry publication, activation, deployment or release. See the
 [exact-five capability runbook](QUAL-206_CLAUDE_EXACT_FIVE_CAPABILITY.md) for the
 closed profile, terminal predicate and publication boundary.
 

--- a/tests/interoperability/evidence/README.md
+++ b/tests/interoperability/evidence/README.md
@@ -75,7 +75,7 @@ and all CodeQL analyses passed in
 [run 32868252219](https://github.com/chris-page-gov/gis-ai-go/actions/runs/32868252219).
 The public projection is path-free and preserves the 2.1.241 schema and evidence
 digests as historical lineage. It proves transport readiness only: capability,
-the exact-five journey, remote HTTP evidence, provider use, registration,
+the exact-five journey, direct public Streamable HTTP/TLS evidence, provider use,
 activation, deployment and release remain incomplete or unexercised. Raw capture,
 client output, profile data and local identities remain owner-only and unpublished.
 
@@ -119,13 +119,24 @@ exact-five model capability only. Remote HTTP interoperability, a live geospatia
 provider, registry publication, activation, deployment and release remain false.
 Raw capture remains owner-only and local.
 
-The repository also contains a separately gated ChatGPT secure-tunnel exact-five
-evidence pack. The pack itself is not an observation and adds no evidence file to
-this directory. A later result may be added only after the pack is merged, one fresh
-run is made from exact protected `main`, the private capture passes independent
-verification and the path-free projection passes deliberate publication review.
-That projection must describe the remote-host-through-secure-tunnel lane without
-claiming a direct public Streamable HTTP endpoint.
+The separately gated
+[`ChatGPT secure-tunnel exact-five capability projection`](chatgpt-tunnel-exact-five-2026-08-28.json)
+is a verifier-produced, path-free `capability_pass` from exact protected-main source
+commit `d8fb8728b0d02afc79b28cf72625ee899d3eb325`, tree
+`fa3a2bc2f9e7be576510f76a7a989c80cd54df42`. The verifier-produced projection
+records the observation at `2026-08-28T22:17:50.190Z`; it merged through
+[pull request 95](https://github.com/chris-page-gov/gis-ai-go/pull/95) as
+protected-main evidence commit `060e0198f6c2663a5c9964d8bfb484eeed0d8e5f` and
+has SHA-256 `e394466801e78f1eaa024cd01c1109ec21d0accbe517e546e18bc45e6eb5a1c9`.
+ChatGPT made all five ordered MCP `2026-07-28` calls in one call-bearing session
+through the reviewed OpenAI secure tunnel to a network-denied deterministic local
+STDIO child. Independent verification accepted every result contract, five distinct
+receipts, structured/plain-text parity and the search-to-inspection relationship.
+The deterministic fixture made one synthetic provider transport call and zero
+guarded live-provider API invocations. This closes only remote-host capability
+through that secure-tunnel lane. Direct public Streamable HTTP/TLS, a live
+geospatial provider, registry publication, activation, deployment and release
+remain false. Raw host and operator material remains owner-only and local.
 
 The
 [`protected-main local HTTP transport preflight`](local-http-transport-preflight-2026-08-25.json)


### PR DESCRIPTION
## Summary

- reconcile the maintained QUAL-206 progress, runbooks and evidence index with the accepted ChatGPT exact-five projection from PR #95
- distinguish the observation source commit from the evidence-publication commit and bind the public claim to the verifier-produced timestamp and SHA-256
- retain the exact boundary: this is a `capability_pass` for the remote-host-through-secure-tunnel lane, not direct public Streamable HTTP/TLS, live-provider use, registry publication, activation, deployment or release
- make the historical create-and-connect context route repeat operators to the exact-five runbook and require exactly the five canonical actions

## Verification

- `pnpm run validate:contracts` — 93 schemas and 153 records
- `pnpm run validate:links` — 480 local Markdown links, 183 research hashes, 2 ledger snapshots and 71 source identifiers
- `pnpm run validate:secrets` — 869 text files, no baseline secret or machine-path match
- `git diff --check`
- independent claim-boundary review — no remaining actionable findings

## Change boundary

Documentation and ledger wording only. No runtime, evidence JSON, version surface, activation, provider, deployment or release behaviour changes.
