### PR TITLE
fix(qual-206): retain protected-main provenance

### DIFF
--- a/changelog.d/QUAL-206-protected-main-provenance.fixed.md
+++ b/changelog.d/QUAL-206-protected-main-provenance.fixed.md
@@ -1,0 +1,3 @@
+- Keep the QUAL-206 local protocol matrix verifiable after squash merge by binding
+  its runtime materials to a protected-main commit and rejecting feature-branch-only
+  provenance during repository assurance.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -34,13 +34,20 @@ host session, activation, deployment, registration or release.
 ## QUAL-206 local protocol matrix
 
 [`qual-206-local-protocol-evidence-matrix.v1.json`][protocol-matrix] is a
-separate, compact source-coverage record for runtime base commit
-`a33876b16ac7c198e75773fc79097d2f2836cf13`. Repository assurance reads the exact
+separate, compact source-coverage record for protected-main runtime base commit
+`f253605ab26628e821d4ebc3809cf13c883d57ed`. Repository assurance reads the exact
 gateway, transport-test, gateway-manifest and lockfile blobs from that Git commit
 and compares their SHA-256 values with the matrix. Its four semantically fixed rows
 distinguish the pinned official MCP client 2.0.0 from independent raw JSON-RPC
 source coverage over HTTP and STDIO, including the 2026-07-28 protocol,
 cancellation and unsupported traffic.
+
+Keep the runtime base commit reachable from protected `main`. Do not bind this
+matrix to a feature-branch commit: a squash merge does not retain that branch
+ancestry, so a fresh protected-main checkout could not verify the named blobs.
+Merge or squash the implementation first, fetch protected `main`, then rebind the
+matrix to that protected-main commit in a follow-up change. Do not bind it to the
+rebind commit itself.
 
 The JSON matrix binds source declarations; it deliberately records no test-runner
 outcome. Current execution is established separately by the focused commands below

--- a/evaluation/qual-206-local-protocol-evidence-matrix.v1.json
+++ b/evaluation/qual-206-local-protocol-evidence-matrix.v1.json
@@ -3,11 +3,11 @@
   "classification": "repository-only-non-live-unscored",
   "schema_contract": {
     "path": "schemas/qual-206-local-protocol-evidence-matrix.schema.json",
-    "sha256": "e0955da7969213e1d54efed53c3e22ac796dd2ef426f3f1ca56c30a99625aa73"
+    "sha256": "950ac34cb36a216eecb2863d659c7a9bd37f269296a4e36563b5bfe21f38e7f6"
   },
   "repository_binding": {
     "kind": "repository-material-bound",
-    "runtime_base_commit": "a33876b16ac7c198e75773fc79097d2f2836cf13",
+    "runtime_base_commit": "f253605ab26628e821d4ebc3809cf13c883d57ed",
     "material_integrity": "sha256",
     "runtime_materials": [
       {
@@ -254,5 +254,5 @@
     "release_acceptance": false
   },
   "boundary": "Repository-material-bound deterministic source matrix. It is repository-only, non-live and unscored; coverage rows and subprocess sections bind source declarations but do not record a test-runner outcome. The exact-five and suspension regressions use test-only real-process STDIO with operating-system pipes and an injected zero-network fixture; the matrix does not complete host interoperability or authorise activation, deployment, registration or release.",
-  "matrix_id": "gis-ai-go:qual-206-local-protocol-evidence-matrix:sha256:3e596d1cb277809c6382604c1c004bc205223984778fcfcb4ba7c897799602a5"
+  "matrix_id": "gis-ai-go:qual-206-local-protocol-evidence-matrix:sha256:76500f8d2dfd3980dc0f6e7243b84474802012e2088d7b48a33e84e6750908f2"
 }

--- a/schemas/qual-206-local-protocol-evidence-matrix.schema.json
+++ b/schemas/qual-206-local-protocol-evidence-matrix.schema.json
@@ -220,7 +220,7 @@
           "const": "repository-material-bound"
         },
         "runtime_base_commit": {
-          "const": "a33876b16ac7c198e75773fc79097d2f2836cf13"
+          "const": "f253605ab26628e821d4ebc3809cf13c883d57ed"
         },
         "material_integrity": {
           "const": "sha256"

--- a/tests/contract/test_qual_206_local_protocol_evidence_matrix.py
+++ b/tests/contract/test_qual_206_local_protocol_evidence_matrix.py
@@ -21,7 +21,7 @@ MATRIX_PATH = (
 )
 GATEWAY_MANIFEST_PATH = ROOT / "apps" / "mcp-gateway" / "package.json"
 LOCKFILE_PATH = ROOT / "pnpm-lock.yaml"
-RUNTIME_BASE_COMMIT = "a33876b16ac7c198e75773fc79097d2f2836cf13"
+RUNTIME_BASE_COMMIT = "f253605ab26628e821d4ebc3809cf13c883d57ed"
 BOUNDARY = (
     "Repository-material-bound deterministic source matrix. It is repository-only, "
     "non-live and unscored; coverage rows and subprocess sections bind source "
@@ -274,6 +274,27 @@ class Qual206LocalProtocolEvidenceMatrixTests(unittest.TestCase):
         )
         binding = self.document["repository_binding"]
         self.assertEqual(binding["runtime_base_commit"], RUNTIME_BASE_COMMIT)
+        protected_main = "refs/remotes/origin/main"
+        ancestor = subprocess.run(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                RUNTIME_BASE_COMMIT,
+                protected_main,
+            ],
+            cwd=ROOT,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(
+            ancestor.returncode,
+            0,
+            "runtime base commit must remain reachable from the local protected-main "
+            f"reference {protected_main}: "
+            f"{ancestor.stderr.decode('utf-8', errors='replace').strip()}",
+        )
         self.assertEqual(
             [material["path"] for material in binding["runtime_materials"]],
             EXPECTED_RUNTIME_PATHS,

--- a/tests/contract/test_qual_206_strict_modern_evidence.py
+++ b/tests/contract/test_qual_206_strict_modern_evidence.py
@@ -40,7 +40,7 @@ HISTORICAL_V1_SHA256 = {
         "f8859d81eeff3efc3072698e14f20399a89ac429ce8b8848922f570603590b0a"
     ),
     "evaluation/qual-206-local-protocol-evidence-matrix.v1.json": (
-        "182ec2221167e4c3b117b9f8aaf3707e571ceeb3b34059a7ecc793fbf62d2088"
+        "91dc5a38125b5fd686d3028621f8452c0a3d77fe177dd67b110da6316bfc6039"
     ),
     "tests/interoperability/qual_206_cases.json": (
         "23ac9bc1a76d524bd0e250b11b9ba321b09e66bd5921f1463f50c150001cd389"
@@ -72,7 +72,7 @@ HISTORICAL_V1_SHA256 = {
         "9584de9fe7531457b7b83eb7f9102ee897e2cae61a5fe1f5f68b0f6b775232d9"
     ),
     "schemas/qual-206-local-protocol-evidence-matrix.schema.json": (
-        "e0955da7969213e1d54efed53c3e22ac796dd2ef426f3f1ca56c30a99625aa73"
+        "950ac34cb36a216eecb2863d659c7a9bd37f269296a4e36563b5bfe21f38e7f6"
     ),
     "schemas/qual-206-evaluation-expansion.schema.json": (
         "1843351626b6f96cb118e575388606daa0d6f60b22b28b92d9655a14873caf8b"


### PR DESCRIPTION
## Outcome

Restore protected-main repository assurance after PR #98's squash merge without
changing the activated runtime.

## Root cause

The QUAL-206 protocol matrix named the implementation branch commit `a33876b`.
That commit was reachable during PR assurance, but squash merge did not retain its
ancestry, so a fresh protected-main checkout could not read the bound Git blobs.

## Change

- rebind the matrix to protected-main implementation commit `f253605`;
- regenerate the schema hash, matrix identity and strict byte-integrity pins;
- require the runtime base to be an ancestor of local `origin/main`;
- document the two-change workflow so a feature-branch or self-referential commit
  cannot be used again;
- add the release-note fragment.

The runtime material hashes are unchanged. There is no provider call, activation,
deployment, registration or release change.

## Verification

- 30 focused QUAL-206 matrix and strict-evidence tests pass;
- 93 schemas and 153 records validate;
- 480 local links, 183 research hashes and 2 ledger snapshots pass;
- 921 text files pass the secret and machine-path scan;
- independent review approved the protected-main rebind and ancestry guard.
