### PR TITLE
fix(explorer): support current Site-tools callbacks

### DIFF
--- a/apps/webmcp-explorer/index.html
+++ b/apps/webmcp-explorer/index.html
@@ -117,7 +117,7 @@
         <aside class="prompt-card" aria-labelledby="prompt-heading">
           <h3 id="prompt-heading">Try this with your AI</h3>
           <blockquote>
-            Find the ONS provider capability for population data. Describe the most
+            Find the ONS Data API provider capability for statistics. Describe the most
             relevant record, its sources and its limitations.
           </blockquote>
           <p class="small-text">
@@ -146,7 +146,7 @@
             <input
               id="catalogue-query"
               type="search"
-              value="ONS population data"
+              value="ONS statistics"
               maxlength="256"
               required
               autocomplete="off"

--- a/apps/webmcp-explorer/src/webmcp-adapter.ts
+++ b/apps/webmcp-explorer/src/webmcp-adapter.ts
@@ -7,7 +7,7 @@ import {
 } from "./catalogue-tools";
 
 interface ToolExecuteOptions {
-  readonly signal: AbortSignal;
+  readonly signal?: AbortSignal;
 }
 
 export interface WebMcpTool {
@@ -19,7 +19,7 @@ export interface WebMcpTool {
     readonly readOnlyHint: true;
     readonly untrustedContentHint: true;
   };
-  readonly execute: (input: unknown, options: ToolExecuteOptions) => Promise<PageToolResult>;
+  readonly execute: (input: unknown, options?: ToolExecuteOptions) => Promise<PageToolResult>;
 }
 
 interface WebMcpModelContext {
@@ -149,11 +149,14 @@ function createTools(
 ): readonly WebMcpTool[] {
   const run = async (
     execute: () => PageToolResult,
-    options: ToolExecuteOptions,
+    options?: ToolExecuteOptions,
   ): Promise<PageToolResult> => {
-    options.signal.throwIfAborted();
+    // The Community Group draft supplies an execution AbortSignal. OpenAI Site
+    // tools has also shipped a one-argument callback shape, so tolerate that host
+    // while continuing to honour cancellation whenever a signal is supplied.
+    options?.signal?.throwIfAborted();
     const result = execute();
-    options.signal.throwIfAborted();
+    options?.signal?.throwIfAborted();
     onResult?.(result);
     return result;
   };

--- a/apps/webmcp-explorer/test/browser/journeys.spec.ts
+++ b/apps/webmcp-explorer/test/browser/journeys.spec.ts
@@ -11,7 +11,7 @@ interface CapturedTool {
   };
   execute(
     input: unknown,
-    options: { readonly signal: AbortSignal },
+    options?: { readonly signal?: AbortSignal },
   ): Promise<Record<string, unknown>>;
 }
 
@@ -93,6 +93,25 @@ test("manually searches and describes a governed catalogue record", async ({ pag
   expect(describeResult.record.source_records.length).toBeGreaterThan(0);
 });
 
+test("the default demonstration query finds the production ONS provider record", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const search = page.getByRole("searchbox", { name: "Search the governed catalogue" });
+  await expect(search).toHaveValue("ONS statistics");
+  await page.getByRole("button", { name: "Run search tool" }).click();
+
+  await expect(page.locator("#demo-status")).toContainText("Manual search call:");
+  await expect(page.getByRole("heading", { name: "ONS Data API", exact: true })).toBeVisible();
+  const result = JSON.parse((await page.locator("#result-json").textContent()) ?? "") as {
+    matches: { records: Array<{ id: string }>; returned: number };
+  };
+  expect(result.matches.returned).toBeGreaterThan(0);
+  expect(result.matches.returned).toBeLessThanOrEqual(5);
+  expect(result.matches.records.map(({ id }) => id)).toContain("PV-ONS-DATA");
+});
+
 test("registers exactly two bounded page tools and renders both AI calls", async ({ page }) => {
   await installWebMcpCapture(page);
   await page.goto("/");
@@ -158,11 +177,10 @@ test("registers exactly two bounded page tools and renders both AI calls", async
     }
     const options = { signal: new AbortController().signal };
     const input = { query: "Price Paid", limit: 2 };
-    const firstSearch = await searchTool.execute(input, options);
+    const firstSearch = await searchTool.execute(input);
     const secondSearch = await searchTool.execute(input, options);
     const described = await describeTool.execute(
       { record_id: "hmlr:dataset:price-paid-data" },
-      { signal: new AbortController().signal },
     );
     return {
       firstSearch,

--- a/apps/webmcp-explorer/test/browser/security.spec.ts
+++ b/apps/webmcp-explorer/test/browser/security.spec.ts
@@ -4,7 +4,7 @@ interface CapturedTool {
   readonly name: string;
   execute(
     input: unknown,
-    options: { readonly signal: AbortSignal },
+    options?: { readonly signal?: AbortSignal },
   ): Promise<Record<string, unknown>>;
 }
 

--- a/apps/webmcp-explorer/test/unit/webmcp-adapter.test.ts
+++ b/apps/webmcp-explorer/test/unit/webmcp-adapter.test.ts
@@ -38,13 +38,25 @@ describe("imperative WebMCP adapter", () => {
     );
     expect(registered[0]?.description).not.toContain("Ignore previous instructions");
 
-    const invocation = new AbortController();
-    const result = await registered[0]!.execute(
-      { query: "ONS population", limit: 2 },
-      { signal: invocation.signal },
-    );
+    const result = await registered[0]!.execute({ query: "ONS population", limit: 2 });
     expect(result.page_tool).toBe("explorer_search_catalogue");
     expect(onResult).toHaveBeenCalledOnce();
+
+    const described = await registered[1]!.execute(
+      { record_id: "provider:ons-data-api" },
+      {},
+    );
+    expect(described.page_tool).toBe("explorer_describe_record");
+    expect(onResult).toHaveBeenCalledTimes(2);
+
+    const invocation = new AbortController();
+    invocation.abort("The host cancelled this page-tool call.");
+    await expect(
+      registered[0]!.execute(
+        { query: "ONS population", limit: 2 },
+        { signal: invocation.signal },
+      ),
+    ).rejects.toThrow();
 
     registration.dispose();
     expect(registrationSignals).toHaveLength(2);

--- a/changelog.d/WEB-210.fixed.md
+++ b/changelog.d/WEB-210.fixed.md
@@ -1,0 +1,3 @@
+- Make both WebMCP callbacks tolerate the one-argument OpenAI Site-tools host shape
+  while still honouring supplied cancellation signals, and bind the documented ONS
+  demonstration query to a record in the generated production catalogue.

--- a/docs/implementation/WEBMCP_EXPLORER_CANDIDATE.md
+++ b/docs/implementation/WEBMCP_EXPLORER_CANDIDATE.md
@@ -277,7 +277,7 @@ compatible AI host only for the page-tool part of the demonstration.
    revision.
 2. Confirm the Site tools status either reports two read-only tools or clearly
    reports that the browser does not support them.
-3. Search for `ONS population data`.
+3. Search for `ONS statistics`.
 4. Inspect the bounded record cards and compact JSON.
 5. Choose **Describe record and sources** for the most relevant record.
 6. Inspect authority, access, rights, freshness, limitations and linked source
@@ -292,7 +292,7 @@ compatible AI host only for the page-tool part of the demonstration.
    `explorer_search_catalogue` and `explorer_describe_record` are registered.
 3. Ask:
 
-   > Find the ONS provider capability for population data. Describe the most
+   > Find the ONS Data API provider capability for statistics. Describe the most
    > relevant record, its sources and its limitations.
 
 4. Review each proposed call and its structured arguments before it runs.
@@ -327,7 +327,8 @@ browser test does not replace this observation.
 - Tool metadata, schemas and annotations are static and tested.
 - Executable validation rejects wrong types, extra fields, excessive length or
   complexity, invalid facets, duplicates, control characters and missing records.
-- Both handlers honour the supplied cancellation signal.
+- Both handlers honour a supplied cancellation signal and remain compatible with
+  current Site-tools hosts that invoke the callback with input arguments only.
 - A call makes no external request and writes no cookie, `localStorage` or
   `sessionStorage` value.
 - Result fields always preserve the explicit page boundary.


### PR DESCRIPTION
## Outcome

Make both WebMCP Explorer callbacks work with the currently deployed ChatGPT Site-tools host while retaining cancellation support when a standards-conforming host supplies a signal.

The live built-in-browser check discovered both read-only tools correctly, but invocation stopped before catalogue logic because the host called the page callback with one argument and the adapter unconditionally dereferenced `options.signal`. This change makes that execution context optional and continues to honour a supplied abort signal before and after each bounded synchronous operation.

The change also replaces the demonstration's zero-result `ONS population data` query with `ONS statistics`, which is bound to the generated production catalogue and includes `PV-ONS-DATA`.

## Verification

- `pnpm --filter @gis-ai-go/webmcp-explorer run test:unit`
- `pnpm --filter @gis-ai-go/webmcp-explorer run typecheck`
- `pnpm run build:webmcp-explorer`
- `pnpm --filter @gis-ai-go/webmcp-explorer run test:browser`
- `pnpm run validate:links`
- `pnpm run validate:secrets`
- `git diff --check`

All passed. The browser suite now covers both one-argument calls and supplied cancellation signals, and verifies that the documented ONS query finds `PV-ONS-DATA` in the production catalogue.

## Boundary

This is a compatibility and demonstration-content correction only. It does not add a write tool, a provider call, persistent storage, a persistent MCP runtime, activation, registry publication or a release claim. The owner-only Site will be rebuilt from the exact protected-main revision after merge and revalidated before the illustrated guide is added.
