### PR TITLE
fix(explorer): preserve tools across bfcache

### DIFF
--- a/apps/webmcp-explorer/src/webmcp-adapter.ts
+++ b/apps/webmcp-explorer/src/webmcp-adapter.ts
@@ -193,15 +193,22 @@ export async function registerWebMcpTools(
     return { status: "unsupported", toolNames: [], dispose: () => undefined };
   }
 
+  const activeView = view;
   const controller = new AbortController();
   let disposed = false;
-  const dispose = (): void => {
+  function handlePageHide(event: PageTransitionEvent): void {
+    // A persisted pagehide moves this document into the back/forward cache. Its
+    // registration remains valid when the same document is restored, whereas a
+    // final navigation or close must remove the page-scoped tools.
+    if (!event.persisted) dispose();
+  }
+  function dispose(): void {
     if (disposed) return;
     disposed = true;
-    view.removeEventListener("pagehide", dispose);
+    activeView.removeEventListener("pagehide", handlePageHide);
     controller.abort("The WebMCP page was closed or navigated away from.");
-  };
-  view.addEventListener("pagehide", dispose, { once: true });
+  }
+  activeView.addEventListener("pagehide", handlePageHide);
   try {
     for (const tool of createTools(options.bundle, options.onResult)) {
       await context.registerTool(tool, { signal: controller.signal });

--- a/apps/webmcp-explorer/test/unit/webmcp-adapter.test.ts
+++ b/apps/webmcp-explorer/test/unit/webmcp-adapter.test.ts
@@ -74,7 +74,7 @@ describe("imperative WebMCP adapter", () => {
     expect(() => registration.dispose()).not.toThrow();
   });
 
-  it("aborts registration when the page is hidden", async () => {
+  it("preserves registration through BFCache and aborts on final pagehide", async () => {
     const signals: AbortSignal[] = [];
     Object.defineProperty(document, "modelContext", {
       configurable: true,
@@ -85,7 +85,11 @@ describe("imperative WebMCP adapter", () => {
       },
     });
     await registerWebMcpTools({ document, bundle: catalogueFixture() });
-    window.dispatchEvent(new Event("pagehide"));
+    window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true }));
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
+
+    window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: false }));
     expect(signals.every((signal) => signal.aborted)).toBe(true);
     delete (document as Document & { modelContext?: unknown }).modelContext;
   });

--- a/changelog.d/WEB-210-bfcache.fixed.md
+++ b/changelog.d/WEB-210-bfcache.fixed.md
@@ -1,0 +1,3 @@
+Keep WebMCP page-tool registrations active when Chrome restores the same document
+from its back/forward cache, while still cancelling them on final navigation or
+closure.

--- a/docs/implementation/WEBMCP_EXPLORER_CANDIDATE.md
+++ b/docs/implementation/WEBMCP_EXPLORER_CANDIDATE.md
@@ -329,6 +329,12 @@ browser test does not replace this observation.
   complexity, invalid facets, duplicates, control characters and missing records.
 - Both handlers honour a supplied cancellation signal and remain compatible with
   current Site-tools hosts that invoke the callback with input arguments only.
+- Registration remains bound to the same document across a back/forward-cache
+  restoration and is cancelled when the page is finally closed or navigated away
+  from.
+- `readOnlyHint` describes the absence of resource, session or persistent-state
+  changes. Each call deliberately renders its returned read result in the transient
+  page presentation so the person can verify what the browser-hosted AI received.
 - A call makes no external request and writes no cookie, `localStorage` or
   `sessionStorage` value.
 - Result fields always preserve the explicit page boundary.


### PR DESCRIPTION
## Outcome

Preserve the two page-tool registrations when Chrome stores and restores the same document through the back/forward cache, while still cancelling them on a final navigation or page closure.

The previous unconditional `pagehide` cancellation could leave a restored page claiming that two tools were available after their registration signal had been aborted. A persisted `pagehide` now keeps the document-bound registration alive; a non-persisted event still disposes it.

The implementation note also makes the `readOnlyHint` boundary explicit: calls do not alter a resource, session or persistent state, but deliberately render the returned read result in the transient page presentation for human verification.

## Verification

- `pnpm --filter @gis-ai-go/webmcp-explorer run test:unit`
- `pnpm --filter @gis-ai-go/webmcp-explorer run typecheck`
- `pnpm run build:webmcp-explorer`
- `pnpm --filter @gis-ai-go/webmcp-explorer run test:browser`
- `pnpm run validate:links`
- `pnpm run validate:secrets`
- `git diff --check`

All passed. The unit regression exercises both persisted and final `pagehide` events; the complete focused browser suite remains green.

## Boundary

This is a page lifecycle correction only. It adds no tool, provider call, persistence, public access, gateway change, activation or release claim. The owner-only Site will be rebuilt from the exact protected-main merge before live Chrome and ChatGPT Site-tools validation.
